### PR TITLE
Fix CLI SSH key path, pass arguments to inner script

### DIFF
--- a/runCli.sh
+++ b/runCli.sh
@@ -8,7 +8,7 @@ export API_URL="http://localhost:3000/graphql"
 # Set the identity option to the local private key for the `login` and `logout`
 # commands unless the option is already set.
 if [[ $@ =~ login|logout && ! $@ =~ ^.*(--identity\ |-i\ ).*$ ]]; then
-  ARGS="--identity $(dirname "${BASH_SOURCE[0]}")/local/cli_id_rsa"
+  ARGS="--identity $(dirname "${BASH_SOURCE[0]}")/local-dev/cli_id_rsa"
 fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")/cli" && yarn run execute "$@" $ARGS

--- a/runCli.sh
+++ b/runCli.sh
@@ -9,6 +9,9 @@ export API_URL="http://localhost:3000/graphql"
 # commands unless the option is already set.
 if [[ $@ =~ login|logout && ! $@ =~ ^.*(--identity\ |-i\ ).*$ ]]; then
   ARGS="--identity $(dirname "${BASH_SOURCE[0]}")/local-dev/cli_id_rsa"
+  if [[ $@ =~ ^[^-][^-] ]]; then
+    PREFIX="--"
+  fi
 fi
 
-cd "$(dirname "${BASH_SOURCE[0]}")/cli" && yarn run execute "$@" $ARGS
+cd "$(dirname "${BASH_SOURCE[0]}")/cli" && yarn run execute $PREFIX "$@" $ARGS


### PR DESCRIPTION
Since we updated the path to the CLI SSH key in #2, I've updated this path in `runCli.sh` and also fixed an issue with the arguments when `runCli.sh` is run without a double dash:

```sh
# This fails to provide the correct path before the changes in this PR
./runCli.sh login

# For contrast, this works before this PR:
./runCli.sh -- login
```

---

Note: #12 is based on these changes.