### PR TITLE
ignore services marked persistent when jenkins checks deploys

### DIFF
--- a/images/oc-build-deploy/build-deploy.sh
+++ b/images/oc-build-deploy/build-deploy.sh
@@ -52,7 +52,7 @@ SERVICES=($(cat .amazeeio.yml | shyaml keys services))
 
 # export the services so Jenkins can load them afterwards to check the deployments
 for i in `cat .amazeeio.yml | shyaml keys services`; do
-cat .amazeeio.yml | shyaml get-value services.$i.amazeeio.persistant > /dev/null 2>/dev/null || echo $i
+cat .amazeeio.yml | shyaml get-value services.$i.amazeeio.persistent > /dev/null 2>/dev/null || echo $i
 done | tr '\n' ',' | sed 's/,$//'  > .amazeeio.services
 
 BUILD_ARGS=()

--- a/images/oc-build-deploy/build-deploy.sh
+++ b/images/oc-build-deploy/build-deploy.sh
@@ -51,7 +51,9 @@ oc process --insecure-skip-tls-verify \
 SERVICES=($(cat .amazeeio.yml | shyaml keys services))
 
 # export the services so Jenkins can load them afterwards to check the deployments
-cat .amazeeio.yml | shyaml keys services | tr '\n' ',' | sed 's/,$//' > .amazeeio.services
+for i in `cat .amazeeio.yml | shyaml keys services`; do
+cat .amazeeio.yml | shyaml get-value services.$i.amazeeio.persistant > /dev/null 2>/dev/null || echo $i
+done | tr '\n' ',' | sed 's/,$//'  > .amazeeio.services
 
 BUILD_ARGS=()
 

--- a/services/auth-ssh/Dockerfile
+++ b/services/auth-ssh/Dockerfile
@@ -19,9 +19,9 @@ FROM ${IMAGE_REPO:-amazeeiolagoon}/centos7:${AMAZEEIO_GIT_BRANCH:-latest}
 
 COPY --from=builder /home/rpmbuild/RPMS/x86_64 /home/openssh
 
-RUN rpm -Uvh --nodeps /home/openssh/*.rpm
+RUN yum install -y wget openssl-libs
 
-RUN yum install -y wget
+RUN rpm -Uvh --nodeps /home/openssh/*.rpm
 
 # Generate ssh server keys
 RUN mkdir .ssh && \

--- a/services/jenkins/Dockerfile
+++ b/services/jenkins/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkinsci/jenkins
 
 # Installing the Docker Client
 USER root
-RUN usermod -G root -a jenkins && \
+RUN /usr/sbin/usermod -G root -a jenkins && \
     wget -q https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz -O /tmp/docker.tgz && \
     tar xfvz /tmp/docker.tgz -C /tmp/ && \
     cp /tmp/docker/docker /usr/local/bin


### PR DESCRIPTION
issue #31 

This code would be used for any statefulset and will remove items from the "verify checklist" if set like
```    amazeeio:
      type: custom
      template: services/rabbitmq/.amazeeio.app.yml
      persistent: true```