### PR TITLE
Document purpose of file

### DIFF
--- a/local-dev/hiera/amazeeio/clients.yaml
+++ b/local-dev/hiera/amazeeio/clients.yaml
@@ -1,3 +1,4 @@
+# This file contains configuration used during automated testing. The keys are not used in production.
 ---
 amazeeio_clients:
   credentialtestclient:


### PR DESCRIPTION
Avoid any confusion about storing private keys in a public repo.