### PR TITLE
#70 xdebug enable/disable functionality

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod g+w /etc/passwd \
 ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
 COPY check_fcgi /usr/sbin/
-COPY entrypoints/70-php-config.sh /lagoon/entrypoints
+COPY entrypoints/70-php-config.sh entrypoints/60-php-xdebug.sh /lagoon/entrypoints/
 
 COPY php.ini /usr/local/etc/php/
 COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
@@ -44,8 +44,10 @@ RUN apk update \
         yes '' | pecl install -f apcu-4.0.11; \
        fi \
     && yes '' | pecl install -f redis \
-    && docker-php-ext-enable apcu redis  \
+    && yes '' | pecl install -f xdebug \
+    && docker-php-ext-enable apcu redis xdebug  \
     && docker-php-ext-install -j4 bcmath gd gettext mcrypt pdo_mysql shmop soap opcache xsl zip \
+    && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && rm -rf /var/cache/apk/* /tmp/pear/ \
     && apk del .phpize-deps \
     && mkdir -p /app \

--- a/images/php/fpm/README.md
+++ b/images/php/fpm/README.md
@@ -32,12 +32,12 @@ The included php config contains sane values that will make the creation of php 
 
 Hint: If you don't like any of these configs, you have three possibilities:
 1. If they are changeable via environment variables, use them (prefeered version, see list of environment variables below)
-2. Create your own fpm-pool config and set configs them via `php_admin_value` and `php_admin_flag` in there (learn more about them [here](http://php.net/manual/en/configuration.changes.php) - yes this refeers to Apache, but it is also the case for php-fpm). _Important:_ 
+2. Create your own fpm-pool config and set configs them via `php_admin_value` and `php_admin_flag` in there (learn more about them [here](http://php.net/manual/en/configuration.changes.php) - yes this refeers to Apache, but it is also the case for php-fpm). _Important:_
     1. If you like to provide your own php-fpm pool, overwrite the file `/etc/php-fpm.d/www.conf` with your own config or remove this file if you like another name. If you don't do that the provided pool will be started!
     2. PHP Values with the [`PHP_INI_SYSTEM` changeable mode](http://php.net/manual/en/configuration.changes.modes.php) cannot be changed via an fpm-pool config. They need to changed either via already provided Environment variables or:
 3. Provide your own `php.ini` or `php-fpm.conf` file (least prefeered version)
 
-## default fpm-pool 
+## default fpm-pool
 
 This image is shipped with an fpm-pool config ([`php-fpm.d/www.conf`](./php-fpm.d/www.conf)) that creates a fpm-pool and listens on port 9000. This is because we try to provide an image which covers already most needs for PHP and so you don't need to create your own. You are happy to do so if you like though :) Here a short description of what this file does:
 
@@ -52,7 +52,7 @@ This image is shipped with an fpm-pool config ([`php-fpm.d/www.conf`](./php-fpm.
 
 Environment variables are meant to do common behavior changes of php.
 
-| Environment Variable | Default | Description  | 
+| Environment Variable | Default | Description  |
 |--------|---------|---|
 | `PHP_MAX_EXECUTION_TIME` | `900` | Maximum execution time of each script, in seconds,  [see php.net](http://php.net/max-execution-time) |
 | `PHP_MEMORY_LIMIT` | `400M` | Maximum amount of memory a script may consume,   [see php.net](http://php.net/memory-limit) |
@@ -60,3 +60,4 @@ Environment variables are meant to do common behavior changes of php.
 | `PHP_DISPLAY_STARTUP_ERRORS` | `Off` | Even when display_errors is on, errors that occur during PHP's startup sequence are not displayed. It's strongly recommended to keep it off, except for debugging., [see php.net](http://php.net/display-startup-errors) |
 | `PHP_APC_SHM_SIZE` | `32m` | The size of each shared memory segment given, [see php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.shm-size) |
 | `PHP_APC_ENABLED` | `1` | Can be set to 0 to disable APC, [see php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.enabled) |
+| `XDEBUG_ENABLED` | (not set) | Used to enable xdebug module, [see php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.enabled) |

--- a/images/php/fpm/entrypoints/60-php-xdebug.sh
+++ b/images/php/fpm/entrypoints/60-php-xdebug.sh
@@ -1,9 +1,43 @@
 #!/bin/sh
 
+# Tries to find the Dockerhost
+get_dockerhost() {
+  # https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds
+  if timeout -t 1 ping -c1 docker.for.mac.localhost &> /dev/null; then
+    echo "docker.for.mac.localhost"
+    return
+  fi
+
+  # https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-17060-win13-release-notes-2017-06-01-17060-rc1-ce-win13-edge
+  if timeout -t 1 ping -c1 docker.for.win.localhost &> /dev/null; then
+    echo "docker.for.win.localhost"
+    return
+  fi
+
+  # https://github.com/amazeeio/pygmy/blob/267ba143158548628f190f05ecb5cb2c19212038/lib/pygmy/resolv_osx.rb#L26
+  if timeout -t 1 ping -c1 172.16.172.16 &> /dev/null; then
+    echo "172.16.172.16"
+    return
+  fi
+
+  # Fallback to localhost
+  echo "localhost"
+  return
+}
+
 # Only if XDEBUG_ENABLE is set
 if [ ${XDEBUG_ENABLE+x} ]; then
   # remove first line and all comments
   sed -i '1d; s/;//' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
   # add comment that explains how we have xdebug enabled
   sed -i '1s/^/;xdebug enabled as XDEBUG_ENABLE is set, see \/lagoon\/entrypoints\/60-php-xdebug.sh \n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+  # Only if DOCKERHOST is not already set, allows to set a DOCKERHOST via environment variables
+  if [[ -z ${DOCKERHOST+x} ]]; then
+    DOCKERHOST=$(get_dockerhost)
+  fi
+
+  # Add the found remote_host to xdebug.ini
+  echo -e "\n\nxdebug.remote_host=${DOCKERHOST}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
+

--- a/images/php/fpm/entrypoints/60-php-xdebug.sh
+++ b/images/php/fpm/entrypoints/60-php-xdebug.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Only if XDEBUG_ENABLE is set
+if [ ${XDEBUG_ENABLE+x} ]; then
+  # remove first line and all comments
+  sed -i '1d; s/;//' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  # add comment that explains how we have xdebug enabled
+  sed -i '1s/^/;xdebug enabled as XDEBUG_ENABLE is set, see \/lagoon\/entrypoints\/60-php-xdebug.sh \n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+fi

--- a/images/php/fpm/php.ini
+++ b/images/php/fpm/php.ini
@@ -1582,3 +1582,6 @@ opcache.huge_code_pages=1
 [APC]
 apc.shm_size = ${PHP_APC_SHM_SIZE:-32m}
 apc.enabled = ${PHP_APC_ENABLED:-1}
+
+[xdebug]
+xdebug.remote_enable = on


### PR DESCRIPTION
- install xdebug php module
- disable it by default
- enable it on docker entrypoint via XDEBUG_ENABLE