### PR TITLE
Add env variables to set PHP server name and port.

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -55,6 +55,8 @@ server {
       include /etc/nginx/fastcgi.conf;
       fastcgi_param  SCRIPT_NAME        /index.php;
       fastcgi_param  SCRIPT_FILENAME    $realpath_root/index.php;
+      fastcgi_param  SERVER_NAME        ${AMAZEEIO_PHP_SERVER_NAME:-lagoon};
+      fastcgi_param  SERVER_PORT        ${AMAZEEIO_PHP_SERVER_PORT:-NGINX_LISTEN};
       fastcgi_pass ${NGINX_FASTCGI_PASS:-php}:9000;
   }
 


### PR DESCRIPTION
PHPStorm Zero configuration debugging requires a valid server name and port.

`$_SERVER['SERVER_NAME']`
`$_SERVER['SERVER_PORT']`

https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html

This PR adds the ability to define a custom server name and port with environment variables for the `nginx-drupal` container --

`AMAZEEIO_PHP_SERVER_NAME`
`AMAZEEIO_PHP_SERVER_PORT`

Happy to update the defaults if required.