### PR TITLE
Fix for JWT Issues

### DIFF
--- a/local-dev/api-data-watcher-pusher/Dockerfile
+++ b/local-dev/api-data-watcher-pusher/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine
 
-RUN apk add --no-cache mysql-client tini openssl bash wget curl \
-    && curl -sLo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-    && chmod +x /bin/jq
+RUN apk add --no-cache mysql-client tini openssl bash wget curl nodejs \
+    && npm -g install jwtgen
 
 ENV MYSQL_DATABASE=infrastructure \
     MYSQL_USER=api \

--- a/local-dev/api-data-watcher-pusher/create_jwt.sh
+++ b/local-dev/api-data-watcher-pusher/create_jwt.sh
@@ -1,50 +1,12 @@
 #!/usr/bin/env bash
 
-# THIS FILE IS COPIED AND ADAPTED FROM http://willhaley.com/blog/generate-jwt-with-bash/
-# Credits: Will Haley Dec 17, 2016
-
 set -euo pipefail
-IFS=$'\n\t'
-
-HEADER='{
-    "typ": "JWT",
-    "alg": "HS256"
-}'
 
 PAYLOAD='{
-    "role": "admin",
-    "iss": "api-data-wather-pusher Bash Generator",
-    "aud": "'$JWTAUDIENCE'",
-    "sub": "auth-server",
-    "iat": '$(date +%s)'
+  "role": "admin",
+  "iss": "api-data-watcher-pusher",
+  "aud": "'$JWTAUDIENCE'",
+  "sub": "api-data-watcher-pusher"
 }'
 
-function base64_encode()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-
-    # The `tr` part is equivalent to `node_modules/base64url` encode mechanism
-    echo -n "${INPUT}" | openssl enc -base64 -A | tr -- '+/' '-_' | tr -d '='
-}
-
-# For some reason, probably bash-related, JSON that terminates with an integer
-# must be compacted. So it must be something like `{"userId":1}` or else the
-# signing gets screwed up. Weird, but using `jq -c` works to fix that.
-function json() {
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | jq -c .
-}
-
-function hmacsha256_sign()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | openssl dgst -binary -sha256 -hmac "${JWTSECRET}"
-}
-
-HEADER_BASE64=$(echo "${HEADER}" | json | base64_encode)
-PAYLOAD_BASE64=$(echo "${PAYLOAD}" | json | base64_encode)
-
-HEADER_PAYLOAD=$(echo "${HEADER_BASE64}.${PAYLOAD_BASE64}")
-SIGNATURE=$(echo "${HEADER_PAYLOAD}" | hmacsha256_sign | base64_encode)
-
-echo "${HEADER_PAYLOAD}.${SIGNATURE}"
+jwtgen -a HS256 -s "${JWTSECRET}" --claims "${PAYLOAD}" $@

--- a/services/auth-ssh/Dockerfile
+++ b/services/auth-ssh/Dockerfile
@@ -16,11 +16,10 @@ RUN chmod g+w /etc/passwd \
 # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
 ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache openssh openssl curl bash wget
+RUN apk add --no-cache openssh openssl curl bash wget nodejs
 
-# Required for our create_jwt.sh
-RUN curl -sLo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-    && chmod +x /bin/jq
+# Needed for jwt generation
+RUN npm -g install jwtgen
 
 # Generate ssh server keys
 RUN mkdir .ssh && \

--- a/services/auth-ssh/create_jwt.sh
+++ b/services/auth-ssh/create_jwt.sh
@@ -1,50 +1,12 @@
 #!/usr/bin/env bash
 
-# THIS FILE IS COPIED AND ADAPTED FROM http://willhaley.com/blog/generate-jwt-with-bash/
-# Credits: Will Haley Dec 17, 2016
-
 set -euo pipefail
-IFS=$'\n\t'
-
-HEADER='{
-    "typ": "JWT",
-    "alg": "HS256"
-}'
 
 PAYLOAD='{
-    "role": "admin",
-    "iss": "auth-ssh Bash Generator",
-    "aud": "'$JWTAUDIENCE'",
-    "sub": "auth-server",
-    "iat": '$(date +%s)'
+  "role": "admin",
+  "iss": "auth-ssh Bash Generator",
+  "aud": "'$JWTAUDIENCE'",
+  "sub": "auth-server"
 }'
 
-function base64_encode()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-
-    # The `tr` part is equivalent to `node_modules/base64url` encode mechanism
-    echo -n "${INPUT}" | openssl enc -base64 -A | tr -- '+/' '-_' | tr -d '='
-}
-
-# For some reason, probably bash-related, JSON that terminates with an integer
-# must be compacted. So it must be something like `{"userId":1}` or else the
-# signing gets screwed up. Weird, but using `jq -c` works to fix that.
-function json() {
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | jq -c .
-}
-
-function hmacsha256_sign()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | openssl dgst -binary -sha256 -hmac "${JWTSECRET}"
-}
-
-HEADER_BASE64=$(echo "${HEADER}" | json | base64_encode)
-PAYLOAD_BASE64=$(echo "${PAYLOAD}" | json | base64_encode)
-
-HEADER_PAYLOAD=$(echo "${HEADER_BASE64}.${PAYLOAD_BASE64}")
-SIGNATURE=$(echo "${HEADER_PAYLOAD}" | hmacsha256_sign | base64_encode)
-
-echo "${HEADER_PAYLOAD}.${SIGNATURE}"
+jwtgen -a HS256 -s "${JWTSECRET}" --claims "${PAYLOAD}" $@

--- a/services/rsh-console/Dockerfile
+++ b/services/rsh-console/Dockerfile
@@ -22,10 +22,8 @@ RUN chmod g+w /etc/passwd \
 # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
 ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache openssh openssl curl bash wget
-
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util && \
-		apk add --update curl && \
+RUN apk add --no-cache openssh openssl curl bash wget nodejs && \
+    apk apk add --update curl && \
 		curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
 		curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
 		curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
@@ -33,8 +31,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing au
 		/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
 		echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
 		rm -rf glibc.apk glibc-bin.apk /var/cache/apk/*  && \
-    apk add --no-cache bash git && \
-    git config --global user.email "lagoon@lagoon.io" && git config --global user.name lagoon && \
     mkdir -p /openshift-origin-client-tools && \
     curl -Lo /tmp/openshift-origin-client-tools.tar https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_HASH}-linux-64bit.tar.gz && \
     echo "$OC_SHA256  /tmp/openshift-origin-client-tools.tar" | sha256sum -c -  && \
@@ -42,9 +38,8 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing au
     tar -xzf /tmp/openshift-origin-client-tools.tar -C /tmp/openshift-origin-client-tools --strip-components=1 && \
     install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar
 
-# Required for our create_jwt.sh
-RUN curl -sLo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-    && chmod +x /bin/jq
+# Needed for jwt generation
+RUN npm -g install jwtgen
 
 # Generate ssh server keys
 RUN mkdir .ssh && \

--- a/services/rsh-console/Dockerfile
+++ b/services/rsh-console/Dockerfile
@@ -23,7 +23,6 @@ RUN chmod g+w /etc/passwd \
 ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache openssh openssl curl bash wget nodejs && \
-    apk apk add --update curl && \
 		curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
 		curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
 		curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \

--- a/services/rsh-console/create_jwt.sh
+++ b/services/rsh-console/create_jwt.sh
@@ -1,50 +1,12 @@
 #!/usr/bin/env bash
 
-# THIS FILE IS COPIED AND ADAPTED FROM http://willhaley.com/blog/generate-jwt-with-bash/
-# Credits: Will Haley Dec 17, 2016
-
 set -euo pipefail
-IFS=$'\n\t'
-
-HEADER='{
-    "typ": "JWT",
-    "alg": "HS256"
-}'
 
 PAYLOAD='{
-    "role": "admin",
-    "iss": "auth-ssh Bash Generator",
-    "aud": "'$JWTAUDIENCE'",
-    "sub": "auth-server",
-    "iat": '$(date +%s)'
+  "role": "admin",
+  "iss": "rsh-console Bash JWT Generator",
+  "aud": "'$JWTAUDIENCE'",
+  "sub": "remote-shell"
 }'
 
-function base64_encode()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-
-    # The `tr` part is equivalent to `node_modules/base64url` encode mechanism
-    echo -n "${INPUT}" | openssl enc -base64 -A | tr -- '+/' '-_' | tr -d '='
-}
-
-# For some reason, probably bash-related, JSON that terminates with an integer
-# must be compacted. So it must be something like `{"userId":1}` or else the
-# signing gets screwed up. Weird, but using `jq -c` works to fix that.
-function json() {
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | jq -c .
-}
-
-function hmacsha256_sign()
-{
-    declare INPUT=${1:-$(</dev/stdin)}
-    echo -n "${INPUT}" | openssl dgst -binary -sha256 -hmac "${JWTSECRET}"
-}
-
-HEADER_BASE64=$(echo "${HEADER}" | json | base64_encode)
-PAYLOAD_BASE64=$(echo "${PAYLOAD}" | json | base64_encode)
-
-HEADER_PAYLOAD=$(echo "${HEADER_BASE64}.${PAYLOAD_BASE64}")
-SIGNATURE=$(echo "${HEADER_PAYLOAD}" | hmacsha256_sign | base64_encode)
-
-echo "${HEADER_PAYLOAD}.${SIGNATURE}"
+jwtgen -a HS256 -s "${JWTSECRET}" --claims "${PAYLOAD}" $@


### PR DESCRIPTION
the create_jwt bash function shows to be very unreliable with generating valid tokens. Example:
generated tokens with `iat: 1513429801` are wrong, while tokens with `iat: 1513429800` work.

This moves to the nodejs jwtgen implementation