### PR TITLE
#86 #77 switching to openresty:

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM nginx:alpine
+FROM openresty/openresty:alpine
 
 MAINTAINER amazee.io
 
@@ -17,18 +17,17 @@ RUN chmod g+w /etc/passwd \
 ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
 
-
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY fastcgi.conf /etc/nginx/fastcgi.conf
-COPY fastcgi.conf /etc/nginx/fastcgi_params
-COPY static-files.conf /etc/nginx/conf.d/app.conf
-
-RUN mkdir -p /app \
-    && rm -f /etc/nginx/conf.d/default.conf \
+RUN apk add --no-cache openssl \
+    && mkdir -p /app \
+    && rm -f /etc/nginx/conf.d/default.conf /usr/local/openresty/nginx/conf/fastcgi* \
     && fix-permissions /etc/nginx/ \
-    && fix-permissions /var/cache/nginx \
     && fix-permissions /var/run/
 
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY fastcgi.conf /etc/nginx/fastcgi.conf
+COPY fastcgi.conf /etc/nginx/fastcgi_params
+COPY lua/ /etc/nginx/lua/
+COPY static-files.conf /etc/nginx/conf.d/app.conf
 COPY docker-entrypoint /lagoon/entrypoints/70-nginx-entrypoint
 
 EXPOSE 8080

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -19,9 +19,7 @@ ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache openssl \
     && mkdir -p /app \
-    && rm -f /etc/nginx/conf.d/default.conf /usr/local/openresty/nginx/conf/fastcgi* \
-    && fix-permissions /etc/nginx/ \
-    && fix-permissions /var/run/
+    && rm -f /etc/nginx/conf.d/default.conf /usr/local/openresty/nginx/conf/fastcgi*
 
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY fastcgi.conf /etc/nginx/fastcgi.conf
@@ -29,6 +27,11 @@ COPY fastcgi.conf /etc/nginx/fastcgi_params
 COPY lua/ /etc/nginx/lua/
 COPY static-files.conf /etc/nginx/conf.d/app.conf
 COPY docker-entrypoint /lagoon/entrypoints/70-nginx-entrypoint
+
+RUN fix-permissions /etc/nginx/ \
+    && fix-permissions /usr/local/openresty/nginx/conf \
+    && fix-permissions  /usr/local/openresty/nginx/logs/ \
+    && fix-permissions /var/run/
 
 EXPOSE 8080
 

--- a/images/nginx/docker-entrypoint
+++ b/images/nginx/docker-entrypoint
@@ -1,6 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+if [ ! -z ${BASIC_AUTH_USERNAME+x} ] && [ ! -z ${BASIC_AUTH_PASSWORD+x} ]; then
+  printf "${BASIC_AUTH_USERNAME}:$(openssl passwd -crypt ${BASIC_AUTH_PASSWORD})\n" >> /etc/nginx/.htpasswd
+  export BASIC_AUTH="restricted"
+fi
 
 ep /etc/nginx/*
 ep /etc/nginx/conf.d/*
-
-exec "$@"
+ep /usr/local/openresty/nginx/conf/*

--- a/images/nginx/lua/x-robots-header.lua
+++ b/images/nginx/lua/x-robots-header.lua
@@ -1,0 +1,3 @@
+if os.getenv('LAGOON_ENVIRONMENT_TYPE') == 'development' then
+  ngx.header["X-Robots-Tag"] = 'noindex, nofollow'
+end

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -70,6 +70,7 @@ http {
     client_body_timeout      10s;
     client_header_timeout    10s;
     client_body_buffer_size  128k;
+    client_body_temp_path    /tmp/client_body_temp;
     proxy_redirect           off;
     proxy_max_temp_file_size 4096m;
     proxy_connect_timeout    90;
@@ -81,6 +82,11 @@ http {
     proxy_set_header         X-Real-IP $remote_addr;
     proxy_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_headers_hash_bucket_size 64;
+    proxy_temp_path          /tmp/proxy_temp;
+
+    fastcgi_temp_path        /tmp/fastcgi_temp;
+    uwsgi_temp_path          /tmp/uwsgi_temp;
+    scgi_temp_path           /tmp/scgi_temp;
 
     port_in_redirect         off;
 

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -1,6 +1,8 @@
 
 error_log /dev/stdout ${NGINX_ERROR_LOG_LEVEL:-warn};
 
+env LAGOON_ENVIRONMENT_TYPE;
+
 events {
     worker_connections  1024;
     multi_accept        on;
@@ -8,7 +10,7 @@ events {
 }
 
 http {
-    include         /etc/nginx/mime.types;
+    include         /usr/local/openresty/nginx/conf/mime.types;
     default_type    application/octet-stream;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -99,6 +101,12 @@ http {
         }
 
     }
+
+    # BASIC_AUTH is set during docker-entrypoint if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD are set
+    auth_basic "${BASIC_AUTH:-off}";
+    auth_basic_user_file "/etc/nginx/.htpasswd";
+
+    header_filter_by_lua_file /etc/nginx/lua/x-robots-header.lua;
 
     include /etc/nginx/conf.d/*.conf;
 


### PR DESCRIPTION
- this gives us lua in nginx
- dynamically adding X-Robots-Tag header if we are on development
- allowing basic auth via BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD