### PR TITLE
fixing issue of lagoon throwing error during deletion of not existing project

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -84,10 +84,10 @@ In this example we create the Service Account `lagoon` in the OpenShift Project 
 
 6. We are interested in the `token`, keep that for now somewhere safe.
 
-7. Add Service Account `lagoon` to cluster role self-provisioner \(this will allow lagoon to create new projects in OpenShift\)
+7. Create new ClusterRole `lagoon` and add Service Account `lagoon` to it \(this will allow lagoon to create new projects in OpenShift\)
 
-        oc -n default adm policy add-cluster-role-to-user self-provisioner -z lagoon
-        oc -n default adm policy add-cluster-role-to-user system:build-strategy-custom -z lagoon
+        oc -n default create -f openshift-setup/clusterrole-lagoon.yaml
+        oc -n default adm policy add-cluster-role-to-user lagoon -z lagoon
 
 8. Create docker-host which will be used by the builds for docker layer caching (if you run that with a local OpenShift started via `make openshift`, this step is already done for you)
 

--- a/openshift-setup/clusterrole-lagoon.yaml
+++ b/openshift-setup/clusterrole-lagoon.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  annotations:
+    authorization.openshift.io/system-only: "true"
+  name: lagoon
+  resourceVersion: "10"
+rules:
+- apiGroups:
+  - project.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups:
+  - project.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - projectrequests
+  verbs:
+  - create
+- apiGroups:
+  - build.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - builds/custom
+  verbs:
+  - create


### PR DESCRIPTION
- the lagoon serviceaccount did not have permissions to all projects so it could not figure out if a project is actually existing or not
- also actually first check if a project exists before deleting it

thanks @JohnAlbin @blazeyo for reporting :)