### PR TITLE
Remove empty continuation line

### DIFF
--- a/images/oc-build-deploy-dind/Dockerfile
+++ b/images/oc-build-deploy-dind/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing au
 		/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
 		echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
 		rm -rf glibc.apk glibc-bin.apk /var/cache/apk/*  && \
-
 		apk add --no-cache bash git openssh py-pip && \
 		git config --global user.email "lagoon@lagoon.io" && git config --global user.name lagoon && \
     pip install shyaml && \


### PR DESCRIPTION
Found this error in the logs for `oc-build-deploy-dind`:

```
docker build  --build-arg IMAGE_REPO=lagoon -t lagoon/oc-build-deploy-dind -f images/oc-build-deploy-dind/Dockerfile images/oc-build-deploy-dind
Sending build context to Docker daemon    150kB
[WARNING]: Empty continuation line found in:
    RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util &&          apk add --update curl &&                curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub &&             curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" &&                 curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" &&              apk add glibc-bin.apk glibc.apk &&                 /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib &&           echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf &&             rm -rf glibc.apk glibc-bin.apk /var/cache/apk/*  &&             apk add --no-cache bash git openssh py-pip &&           git config --global user.email "lagoon@lagoon.io" && git config --global user.name lagoon &&     pip install shyaml &&             mkdir -p /openshift-origin-client-tools &&     curl -Lo /tmp/openshift-origin-client-tools.tar https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_HASH}-linux-64bit.tar.gz &&            echo "$OC_SHA256  /tmp/openshift-origin-client-tools.tar" | sha256sum -c -  &&             mkdir /tmp/openshift-origin-client-tools &&     tar -xzf /tmp/openshift-origin-client-tools.tar -C /tmp/openshift-origin-client-tools --strip-components=1 &&     install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar &&              mkdir -p /git
[WARNING]: Empty continuation lines will become errors in a future release.
```

Apparently this will become an error in future releases of Docker, so maybe we should fix it now?