### PR TITLE
refactoring of docker-host

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,10 +32,9 @@ node {
                   sh "sleep 60"
                 }
               },
-              'start openshift': {
-                stage ('start openshift') {
-                  sh 'make openshift'
-                  sh "sleep 60"
+              'start minishift': {
+                stage ('start minishift') {
+                  sh 'make minishift'
                 }
               }
             )
@@ -49,7 +48,7 @@ node {
             '_tests': {
                 stage ('run tests') {
                   try {
-                    sh "make push-openshift"
+                    sh "make push-minishift"
                     sh "make tests -j4"
                   } catch (e) {
                     echo "Something went wrong, trying to cleanup"
@@ -102,7 +101,7 @@ node {
 def cleanup() {
   try {
     sh "make down"
-    sh "make openshift/clean"
+    sh "make minishift/clean"
     sh "make clean"
   } catch (error) {
     echo "cleanup failed, ignoring this."

--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ endif
 	@echo "$$(./local-dev/minishift/minishift --profile $(CI_BUILD_TAG) ip)" > $@
 	@echo "wait 60secs in order to give openshift time to setup it's registry"
 	sleep 60
-	$(MAKE) openshift-lagoon-setup push-docker-host-image
+	$(MAKE) minishift/configure-lagoon-local push-docker-host-image
 
 minishift/login-docker-registry:
 	eval $$(./local-dev/minishift/minishift --profile $(CI_BUILD_TAG) oc-env); \

--- a/Makefile
+++ b/Makefile
@@ -394,12 +394,12 @@ run-rest-tests = $(foreach image,$(rest-tests),tests/$(image))
 # List of Lagoon Services needed for REST endpoint testing
 deployment-test-services-rest = $(deployment-test-services-main) rest2tasks
 .PHONY: $(run-rest-tests)
-$(run-rest-tests): minishift build/node__6-builder build/node__8-builder build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-rest),build/$(image)) push-openshift
+$(run-rest-tests): minishift build/node__6-builder build/node__8-builder build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-rest),build/$(image)) push-minishift
 		$(eval testname = $(subst tests/,,$@))
 		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d $(deployment-test-services-rest)
 		IMAGE_REPO=$(CI_BUILD_TAG) docker exec -i $$(docker-compose -p $(CI_BUILD_TAG) ps -q tests) ansible-playbook /ansible/tests/$(testname).yaml $(testparameter)
 
-tests/drupal: minishift build/varnish-drupal build/solr__5.5-drupal build/centos7-mariadb10-drupal build/nginx-drupal build/redis build/php__5.6-cli-drupal build/php__7.0-cli-drupal build/php__7.1-cli-drupal build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-rest),build/$(image)) build/drush-alias push-openshift
+tests/drupal: minishift build/varnish-drupal build/solr__5.5-drupal build/centos7-mariadb10-drupal build/nginx-drupal build/redis build/php__5.6-cli-drupal build/php__7.0-cli-drupal build/php__7.1-cli-drupal build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-rest),build/$(image)) build/drush-alias push-minishift
 		$(eval testname = $(subst tests/,,$@))
 		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d $(deployment-test-services-rest) drush-alias
 		IMAGE_REPO=$(CI_BUILD_TAG) docker exec -i $$(docker-compose -p $(CI_BUILD_TAG) ps -q tests) ansible-playbook /ansible/tests/$(testname).yaml $(testparameter)
@@ -410,7 +410,7 @@ run-webhook-tests = $(foreach image,$(webhook-tests),tests/$(image))
 # List of Lagoon Services needed for webhook endpoint testing
 deployment-test-services-webhooks = $(deployment-test-services-main) webhook-handler webhooks2tasks
 .PHONY: $(run-webhook-tests)
-$(run-webhook-tests): openshift build/node__6-builder build/node__8-builder build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-webhooks),build/$(image)) push-openshift
+$(run-webhook-tests): openshift build/node__6-builder build/node__8-builder build/oc-build-deploy-dind $(foreach image,$(deployment-test-services-webhooks),build/$(image)) push-minishift
 		$(eval testname = $(subst tests/,,$@))
 		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d $(deployment-test-services-webhooks)
 		IMAGE_REPO=$(CI_BUILD_TAG) docker exec -i $$(docker-compose -p $(CI_BUILD_TAG) ps -q tests) ansible-playbook /ansible/tests/$(testname).yaml $(testparameter)
@@ -419,7 +419,7 @@ $(run-webhook-tests): openshift build/node__6-builder build/node__8-builder buil
 push-minishift-images = $(foreach image,$(base-images),[push-minishift]-$(image))
 # tag and push all images
 .PHONY: push-minishift
-push-minishift: minishift/login-docker-registry $(push-openshift-images)
+push-minishift: minishift/login-docker-registry $(push-minishift-images)
 # tag and push of each image
 .PHONY: $(push-minishift-images)
 $(push-minishift-images):

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -25,75 +25,11 @@ In this example we create the Service Account `lagoon` in the OpenShift Project 
 
         oc login <openshift console>
 
-2. Switch to the project default
+2. Run the openshift-lagoon-setup script
 
-        oc project default
+        make openshift-lagoon-setup
 
-3. Create Service Account `lagoon`.
-
-        oc create serviceaccount lagoon
-
-4. Describe lagoon \(we are interested in the first token\):
-
-        oc describe serviceaccount lagoon
-
-   example output:
-
-        $ oc describe serviceaccount lagoon
-
-        Name:		lagoon
-        Namespace:	default
-        Labels:		none;
-        Annotations:	none;
-        Image pull secrets:	lagoon-dockercfg-9q303
-
-        Mountable secrets: 	lagoon-token-kvlv0
-                              lagoon-dockercfg-9q303
-
-        Tokens:            	lagoon-token-dkgwz
-                              lagoon-token-kvlv0
-
-5. Describe first token \(token are random generated, so yours will probably have another name\)
-
-        oc describe secret lagoon-token-dkgwz
-
-  example:
-
-        Name:		lagoon-token-dkgwz
-
-        Namespace:	default
-
-        Labels:		&lt;none&gt;
-
-        Annotations:	kubernetes.io/created-by=openshift.io/create-dockercfg-secrets
-            kubernetes.io/service-account.name=lagoon
-            kubernetes.io/service-account.uid=190342fc-99db-11e7-8e14-005056a1ae62
-
-        Type:	kubernetes.io/service-account-token
-
-        Data
-        ====
-
-        service-ca.crt:	2186 bytes
-
-        token:		eyJhbGciOiJdfasdfNiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImxhZ29vbi10b2tlbi1kadasdfasdfasfV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJsYWdvb24iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiIxOTA3NDlmYy05OWRiLTExZTctOGUxNC0wMDUwNTZhMWFlNjIiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpsYWdvb24ifQ.TD6zFNtxgSzpQV3IpF5uXDm96XWUqseMqxabPA3cLh9V5qrqoolJ73ZW3a8lx2klzTY20XDV4HpiTIMuqayjrljkc46\_JaWpkPwsDLl61jQdldVrO7PtAXZ-UD4AgDqVfchLhObDn1azlkudohYPtPvYsh8Qv8F1RPWQTpMaFywSLEza8MmrJWrnTCZ6d9V48Duzsmu5Jn2luS8NgmAN2375l5vYYD2fA4CLOUuOqBFrGjQasdfasdffq3np5ZsBMlg0piOREJEwul7hKfPxxMEblHZw7VZUvMleod9jCQmnwrrr5h8rprRV5wfHmpTFiC5JPV6UZGhA\_2gjOVw
-
-        ca.crt:		1070 bytes
-
-        namespace:	7 bytes
-
-6. We are interested in the `token`, keep that for now somewhere safe.
-
-7. Create new ClusterRole `lagoon` and add Service Account `lagoon` to it \(this will allow lagoon to create new projects in OpenShift\)
-
-        oc -n default create -f openshift-setup/clusterrole-lagoon.yaml
-        oc -n default adm policy add-cluster-role-to-user lagoon -z lagoon
-
-8. Create docker-host which will be used by the builds for docker layer caching (if you run that with a local OpenShift started via `make openshift`, this step is already done for you)
-
-        oc -n default create serviceaccount docker-host
-        oc -n default adm policy add-scc-to-user privileged -z docker-host
-        oc -n default create -f openshift-setup/docker-host.yaml
+3. At the end of this script it will give you a serviceaccount token, keep that somewhere safe.
 
 ### Configure and connect local Lagoon with OpenShift
 
@@ -101,7 +37,7 @@ In order to use a local Lagoon to deploy itself on an OpenShift, we need a subse
 
 1. Edit `lagoon` inside local-dev/api-data/api-data.sql, in the `INSERT INTO openshift` section:
    1. `[replace me with OpenShift console URL]` - The URL to the OpenShift Console, without `console` at the end.
-   2. `[replace me with OpenShift Token]` - The token of the lagoon service account that you created earlier
+   2. `[replace me with OpenShift Token]` - The token of the lagoon service account that was shown to you during `make openshift-lagoon-setup`
 
 2. Build required Images and start services:
 

--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -1,0 +1,30 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM docker:stable-dind
+
+MAINTAINER amazee.io
+ENV LAGOON=docker-host
+
+# Copying commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /home /home
+
+# When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+# When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
+
+RUN apk add --no-cache bash
+
+ENV DOCKER_HOST=docker-host \
+    OPENSHIFT_REGISTRY=docker-registry.default.svc:5000 \
+    REPOSITORY_TO_UPDATE=amazeeio
+
+RUN fix-permissions /home
+
+COPY update-push-images.sh /update-push-images.sh
+COPY prune-images.sh /prune-images.sh
+
+ENTRYPOINT ["/lagoon/entrypoints.sh"]
+
+CMD ["sh", "-c", "sh /usr/local/bin/dind /usr/local/bin/dockerd --host=tcp://0.0.0.0:2375 --host=unix:///var/run/docker.sock --insecure-registry=${OPENSHIFT_REGISTRY} --storage-driver=overlay2 --storage-opt=overlay2.override_kernel_check=1"]

--- a/images/docker-host/prune-images.sh
+++ b/images/docker-host/prune-images.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -x
+if ! docker -H ${DOCKER_HOST} info &> /dev/null; then
+    echo "could not connect to ${DOCKER_HOST}"; exit 1
+fi
+
+docker image prune -f

--- a/images/docker-host/update-push-images.sh
+++ b/images/docker-host/update-push-images.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+set -x
+OPENSHIFT_PROJECT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+if ! docker -H ${DOCKER_HOST} info &> /dev/null; then
+    echo "could not connect to ${DOCKER_HOST}"; exit 1
+fi
+
+docker login -u=serviceaccount --password-stdin ${OPENSHIFT_REGISTRY} < /var/run/secrets/kubernetes.io/serviceaccount/token
+
+# Iterates through all images that have the name of the repository we are interested in in it
+for FULL_IMAGE in $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep "${REPOSITORY_TO_UPDATE}/" | grep -v none); do
+  IMAGE=(${FULL_IMAGE//// })
+  if [ ${#IMAGE[@]} == "3" ]; then
+    IMAGE_NO_REPOSITORY=${IMAGE[2]}
+  else
+    IMAGE_NO_REPOSITORY=${IMAGE[1]}
+  fi
+
+  # pull newest version of found image
+  docker pull ${FULL_IMAGE} | cat
+  # Tag the image with the openshift registry name and the openshift project this container is running
+  docker tag ${FULL_IMAGE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NO_REPOSITORY}
+  # Push to the openshift registry
+  docker push ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NO_REPOSITORY}
+done

--- a/images/oc-build-deploy-dind/docker-entrypoint.sh
+++ b/images/oc-build-deploy-dind/docker-entrypoint.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
 
-if docker -H docker-host.default.svc info &> /dev/null; then
-    export DOCKER_HOST=docker-host.default.svc
+if docker -H docker-host.lagoon.svc info &> /dev/null; then
+    export DOCKER_HOST=docker-host.lagoon.svc
 else
-    echo "could not connect to docker-host.default.svc"; exit 1
+    echo "could not connect to docker-host.lagoon.svc, trying fallback of docker-host.default.svc";
+    if docker -H docker-host.default.svc info &> /dev/null; then
+        export DOCKER_HOST=docker-host.default.svc
+    else
+        echo "could not connect to docker-host.default.svc";
+    fi
 fi
 
 mkdir -p ~/.ssh

--- a/images/php/fpm/check_fcgi
+++ b/images/php/fpm/check_fcgi
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/sh -v
 # This script calls the /ping endpoing of the php-fpm, if the return code is 0, the php-fpm has correctly started
-SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET /usr/bin/cgi-fcgi -bind -connect 127.0.0.1:9000
+SCRIPT_NAME=/${1:-ping} SCRIPT_FILENAME=/${1:-ping} REQUEST_METHOD=GET /usr/bin/cgi-fcgi -bind -connect 127.0.0.1:9000

--- a/images/php/fpm/entrypoints/50-ssmtp.sh
+++ b/images/php/fpm/entrypoints/50-ssmtp.sh
@@ -25,6 +25,16 @@ else
     echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
     return
   fi
+  # check if mxout.lagoon.svc can do smtp TLS
+  if nc -z -w 1 mxout.lagoon.svc 465 &> /dev/null; then
+    echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
+    return
+  fi
+  # Fallback: check if mxout.lagoon.svc can do regular 25 smtp
+  if nc -z -w 1 mxout.lagoon.svc 25 &> /dev/null; then
+    echo -e "\nmailhub=mxout.lagoon.svc:25" >> /etc/ssmtp/ssmtp.conf
+    return
+  fi
   # check if mxout.default.svc can do smtp TLS
   if nc -z -w 1 mxout.default.svc 465 &> /dev/null; then
     echo -e "UseTLS=Yes\nmailhub=mxout.default.svc:465" >> /etc/ssmtp/ssmtp.conf

--- a/images/php/fpm/php-fpm.d/www.conf
+++ b/images/php/fpm/php-fpm.d/www.conf
@@ -95,6 +95,9 @@ ping.path = /ping
 ; Default Value: pong
 ping.response = pong
 
+; PHP FPM Status Page
+pm.status_path = /status
+
 ; The access log file
 ; Default: not set
 access.log = ${PHP_FPM_ACCESS_LOG:-/dev/null}

--- a/openshift-setup/clusterrole-openshiftbuilddeploy.yaml
+++ b/openshift-setup/clusterrole-openshiftbuilddeploy.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   annotations:
     authorization.openshift.io/system-only: "true"
-  name: lagoon
+  name: openshiftbuilddeploy
   resourceVersion: "10"
 rules:
 - apiGroups:

--- a/openshift-setup/docker-host-cronjobs.yaml
+++ b/openshift-setup/docker-host-cronjobs.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-image-updater-cronjob
+parameters:
+  - name: IMAGE
+    description: Image that should be used
+    value: amazeeiolagoon/docker-host:master
+  - name: REPOSITORY_TO_UPDATE
+    description: Repository that should be updated by the cronjob
+    value: amazeeio
+objects:
+- apiVersion: batch/v2alpha1
+  kind: CronJob
+  metadata:
+    name: cronjob-update-push-images
+  spec:
+    schedule: "* * * * *"
+    concurrencyPolicy: Forbid
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            annotations:
+              alpha.image.policy.openshift.io/resolve-names: "*"
+            labels:
+              cronjob: update-images
+              parent: cronjob-update-push-images
+          spec:
+            containers:
+            - name: update-push-images
+              image: ${IMAGE}
+              command:
+                - /lagoon/cronjob.sh
+                - "/update-push-images.sh"
+              env:
+                - name: REPOSITORY_TO_UPDATE
+                  value: ${REPOSITORY_TO_UPDATE}
+            serviceAccount: cronjob
+            serviceAccountName: cronjob
+            restartPolicy: OnFailure
+- apiVersion: batch/v2alpha1
+  kind: CronJob
+  metadata:
+    name: cronjob-prune-images
+  spec:
+    schedule: "22 1 * * *"
+    concurrencyPolicy: Forbid
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            annotations:
+              alpha.image.policy.openshift.io/resolve-names: "*"
+            labels:
+              cronjob: prune-images
+              parent: cronjob-prune-images
+          spec:
+            containers:
+            - name: prune-dangling
+              image: ${IMAGE}
+              command:
+                - /lagoon/cronjob.sh
+                - /prune-images.sh"
+              env:
+                - name: REPOSITORY_TO_UPDATE
+                  value: ${REPOSITORY_TO_UPDATE}
+            serviceAccount: cronjob
+            serviceAccountName: cronjob
+            restartPolicy: OnFailure

--- a/openshift-setup/docker-host-minishift.yaml
+++ b/openshift-setup/docker-host-minishift.yaml
@@ -6,7 +6,7 @@ metadata:
 parameters:
   - name: IMAGE
     description: Image that should be used
-    value: amazeeiolagoon/docker-host:master
+    value: docker.io/amazeeiolagoon/docker-host:master
   - name: REPOSITORY_TO_UPDATE
     description: Repository that should be updated by the cronjob
     value: amazeeio
@@ -71,6 +71,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - docker-host
+        from:
+          kind: ImageStreamTag
+          name: docker-host:latest
+      type: ImageChange
 - apiVersion: v1
   kind: Service
   metadata:

--- a/openshift-setup/docker-host.yaml
+++ b/openshift-setup/docker-host.yaml
@@ -1,5 +1,16 @@
 apiVersion: v1
-items:
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-docker-host
+parameters:
+  - name: IMAGE
+    description: Image that should be used
+    value: amazeeiolagoon/docker-host:master
+  - name: REPOSITORY_TO_UPDATE
+    description: Repository that should be updated by the cronjob
+    value: amazeeio
+objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -20,14 +31,7 @@ items:
           deploymentconfig: docker-host
       spec:
         containers:
-        - command:
-          - sh
-          - /usr/local/bin/dind
-          - /usr/local/bin/dockerd
-          - --host=tcp://0.0.0.0:2375
-          - --host=unix:///var/run/docker.sock
-          - --insecure-registry=docker-registry.default.svc:5000
-          image: docker:stable-dind
+        - image: ${IMAGE}
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -36,7 +40,12 @@ items:
             tcpSocket:
               port: 2375
             timeoutSeconds: 1
-          name: docker
+          name: docker-host
+          env:
+            - name: DOCKER_HOST
+              value: localhost
+            - name: REPOSITORY_TO_UPDATE
+              value: ${REPOSITORY_TO_UPDATE}
           ports:
           - containerPort: 2375
             protocol: TCP
@@ -53,7 +62,6 @@ items:
           volumeMounts:
           - mountPath: /var/lib/docker
             name: docker-lib
-        dnsPolicy: ClusterFirst
         restartPolicy: Always
         serviceAccount: docker-host
         serviceAccountName: docker-host
@@ -63,6 +71,14 @@ items:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - docker-host
+        from:
+          kind: ImageStreamTag
+          name: docker-host:latest
+      type: ImageChange
 - apiVersion: v1
   kind: Service
   metadata:
@@ -80,4 +96,3 @@ items:
       deploymentconfig: docker-host
   status:
     loadBalancer: {}
-kind: List

--- a/openshift-setup/policybinding.yaml
+++ b/openshift-setup/policybinding.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PolicyBinding
+metadata:
+  creationTimestamp: null
+  name: lagoon:default
+policyRef:
+  name: default
+  namespace: lagoon
+roleBindings:
+- name: shared-resource-viewer
+  roleBinding:
+    groupNames:
+    - system:authenticated
+    metadata:
+      name: shared-resource-viewer
+      namespace: lagoon
+    roleRef:
+      name: shared-resource-viewer
+      namespace: lagoon
+    subjects:
+    - kind: SystemGroup
+      name: system:authenticated
+    userNames: null

--- a/openshift-setup/shared-resource-viewer.yaml
+++ b/openshift-setup/shared-resource-viewer.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: shared-resource-viewer
+rules:
+- apiGroups:
+  - template.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - templates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - imagestreamimages
+  - imagestreams
+  - imagestreamtags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  - ""
+  attributeRestrictions: null
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get


### PR DESCRIPTION
- it's now inside the lagoon project
- it's built with a real docker image
- renaming all commands that have to do with minishift from `make openshift` to `make openshift`
- Lagoon now does not add anything to the `default` project anymore, but instead makes the `lagoon` project read available from all other openshift projects
- waiting 60 secs after minshifrt is started to situate itself
- use the same command during minishift setup as we also use during setup of an actual openshift for lagoon
- Update the installation documentation with the new `make openshift-lagoon-setup`
- all necessary yaml files for setting up an openshift fully automatically for lagoon
- two cronjobs: 
1. update the image from the upstream registry every minute
2. clean up dangling images once per day