### PR TITLE
Adding SERVICE_TYPE and SERVICE_ROLLOUT_TYPE

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -239,9 +239,12 @@ do
   OVERRIDE_TEMPLATE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$SERVICE.labels.lagoon\\.template false)
 
   if [ $OVERRIDE_TEMPLATE == "false" ]; then
-    OPENSHIFT_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/deployment.yml"
-    if [ ! -f $OPENSHIFT_TEMPLATE ]; then
-      echo "No Template for service type ${SERVICE_TYPE} found"; exit 1;
+    # Only if SERVICE_TYPE is custom we search for default deployment.yml
+    if [ ! $SERVICE_TYPE == "custom" ]; then
+      OPENSHIFT_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/deployment.yml"
+      if [ ! -f $OPENSHIFT_TEMPLATE ]; then
+        echo "No Template for service type ${SERVICE_TYPE} found"; exit 1;
+      fi
     fi
   else
     OPENSHIFT_TEMPLATE=$OVERRIDE_TEMPLATE
@@ -312,7 +315,7 @@ done
 
 
 ##############################################
-### WAIT FOR DEPLOYMENTS TO BE FINISHED
+### WAIT FOR POST-ROLLOUT TO BE FINISHED
 ##############################################
 
 for SERVICE_TYPES_ENTRY in "${SERVICE_TYPES[@]}"
@@ -323,7 +326,11 @@ do
   SERVICE_TYPE=${SERVICE_TYPES_ENTRY_SPLIT[0]}
   SERVICE_NAME=${SERVICE_TYPES_ENTRY_SPLIT[1]}
 
-  . /scripts/exec-monitor-deploy.sh
+  SERVICE_ROLLOUT_TYPE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$SERVICE.labels.lagoon\\.rollout deploymentconfigs)
+
+  if [ ! $SERVICE_ROLLOUT_TYPE == "false" ]; then
+    . /scripts/exec-monitor-deploy.sh
+  fi
 done
 
 

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -239,7 +239,7 @@ do
   OVERRIDE_TEMPLATE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$SERVICE.labels.lagoon\\.template false)
 
   if [ $OVERRIDE_TEMPLATE == "false" ]; then
-    # Only if SERVICE_TYPE is custom we search for default deployment.yml
+    # Only if SERVICE_TYPE is not custom we search for a default deployment.yml
     if [ ! $SERVICE_TYPE == "custom" ]; then
       OPENSHIFT_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/deployment.yml"
       if [ ! -f $OPENSHIFT_TEMPLATE ]; then

--- a/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-oc rollout --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} status dc/${SERVICE_NAME} --watch
+oc rollout --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} status ${SERVICE_ROLLOUT_TYPE} ${SERVICE_NAME} --watch


### PR DESCRIPTION
As we're deploying projects into openshift that don't require services to be started, we introduce 2 Flags:

SERVICE_TYPE - If the service Type is `custom` we don't look for a openshift template
SERVICE_ROLLOUT_TYPE - Disables the monitoring of the deployments