### PR TITLE
removing the check for custom and introducing a custom template which…

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -239,21 +239,18 @@ do
   OVERRIDE_TEMPLATE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$SERVICE.labels.lagoon\\.template false)
 
   if [ $OVERRIDE_TEMPLATE == "false" ]; then
-    # Only if SERVICE_TYPE is not custom we search for a default deployment.yml
-    if [ ! $SERVICE_TYPE == "custom" ]; then
-      OPENSHIFT_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/deployment.yml"
-      if [ ! -f $OPENSHIFT_TEMPLATE ]; then
-        echo "No Template for service type ${SERVICE_TYPE} found"; exit 1;
-      fi
+    OPENSHIFT_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/deployment.yml"
+    if [ -f $OPENSHIFT_TEMPLATE ]; then
+      . /scripts/exec-openshift-resources.sh
     fi
   else
     OPENSHIFT_TEMPLATE=$OVERRIDE_TEMPLATE
     if [ ! -f $OPENSHIFT_TEMPLATE ]; then
       echo "defined template $OPENSHIFT_TEMPLATE for service $SERVICE_TYPE not found"; exit 1;
+    else
+      . /scripts/exec-openshift-resources.sh
     fi
   fi
-
-  . /scripts/exec-openshift-resources.sh
 
   # Generate cronjobs if service type defines them
   OPENSHIFT_SERVICES_TEMPLATE="/openshift-templates/${SERVICE_TYPE}/cronjobs.yml"

--- a/images/oc-build-deploy-dind/openshift-templates/custom/custom-cronjob.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/custom/custom-cronjob.yml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-openshift-template-custom-custom-cronjob
+parameters:
+  - name: SERVICE_NAME
+    description: Name of this service
+    required: true
+  - name: SAFE_BRANCH
+    description: Which branch this belongs to, special chars replaced with dashes
+    required: true
+  - name: SAFE_PROJECT
+    description: Which project this belongs to, special chars replaced with dashes
+    required: true
+  - name: BRANCH
+    description: Which branch this belongs to, original value
+    required: true
+  - name: PROJECT
+    description: Which project this belongs to, original value
+    required: true
+  - name: LAGOON_GIT_SHA
+    description: git hash sha of the current deployment
+    required: true
+  - name: SERVICE_ROUTER_URL
+    description: URL of the Router for this service
+    value: ""
+  - name: OPENSHIFT_PROJECT
+    description: Name of the Project that this service is in
+    required: true
+  - name: REGISTRY
+    description: Registry where Images are pushed to
+    required: true
+  - name: CRONJOB_NAME
+    description: Name of this cronjob
+    required: true
+  - name: CRONJOB_SCHEDULE
+    description: Schedule of this cronjob
+    required: true
+  - name: CRONJOB_COMMAND
+    description: Command of this cronjob
+    required: true
+objects:
+- apiVersion: batch/v2alpha1
+  kind: CronJob
+  metadata:
+    name: cronjob-${SERVICE_NAME}-${CRONJOB_NAME}
+  spec:
+    schedule: "${CRONJOB_SCHEDULE}"
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            annotations:
+              alpha.image.policy.openshift.io/resolve-names: "*"
+            labels:
+              cronjob: ${CRONJOB_NAME}
+              branch: ${SAFE_BRANCH}
+              project: ${SAFE_PROJECT}
+              parent: cronjob-${SERVICE_NAME}-${CRONJOB_NAME}
+          spec:
+            containers:
+            - name: cronjob-${SERVICE_NAME}-${CRONJOB_NAME}
+              image: ${REGISTRY}/${OPENSHIFT_PROJECT}/${SERVICE_NAME}:latest
+              command:
+                - /lagoon/cronjob.sh
+                - "${CRONJOB_COMMAND}"
+              envFrom:
+              - configMapRef:
+                  name: lagoon-env
+              env:
+                ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
+                ## This will cause the cli to redeploy on every deployment, even the files have not changed
+                - name: LAGOON_GIT_SHA
+                  value: ${LAGOON_GIT_SHA}
+            restartPolicy: OnFailure


### PR DESCRIPTION
… only does cronjobs

adapting the logic to run exec-openshift-resources only if there is a template available