### PR TITLE
refactoring cronjobs:

### DIFF
--- a/images/oc-build-deploy-dind/scripts/convert-crontab.sh
+++ b/images/oc-build-deploy-dind/scripts/convert-crontab.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# no globbing
+set -f
+
+function join { local IFS="$1"; shift; echo "$*"; }
+
+index=0
+
+while read piece
+do
+
+  # Minutes
+  if [ "$index" = "0" ]; then
+    if [[ $piece =~ ^H$ ]]; then
+      # If just an H is defined, we generate a random minute
+      MINUTES=$((0 + RANDOM % 59))
+
+    elif [[ $piece =~ ^H|\*\/([0-5]?[0-9])$ ]]; then
+      # A Minute like H/15 or (*/15 for backwards compatibility) is defined, create a list of minutes with a random start
+      # like 4,19,34,49 or 6,21,36,51
+      STEP=${BASH_REMATCH[1]}
+      if [ $STEP -lt 15 ]; then
+        echo "cronjobs with less than 15 minute steps are not supported"; exit 1
+      fi
+      # Generate a random start within the given step to prevent that all cronjobs start at the same time
+      # but still incorporate the wished step
+      COUNTER=$((0 + RANDOM % $STEP))
+      MINUTES_ARRAY=()
+      while [ $COUNTER -lt 60 ]; do
+          MINUTES_ARRAY+=($COUNTER)
+          let COUNTER=COUNTER+$STEP
+      done
+      MINUTES=$(join , ${MINUTES_ARRAY[@]})
+
+    elif [[ $piece =~ ^([0-5]?[0-9])(,[0-5]?[0-9])*$ ]]; then
+      MINUTES=$piece
+
+    elif [[ $piece =~ ^\*$ ]]; then
+      echo "cronjobs with less than 15 minute steps are not supported"; exit 1
+
+    else
+      echo "error parsing cronjob minute: '$piece'"; exit 1
+
+    fi
+
+  #Hours
+  elif [ "$index" = "1" ]; then
+    if [[ $piece =~ ^H$ ]]; then
+      # If just an H is defined, we generate a random hour
+      HOURS=$((0 + RANDOM % 23))
+    else
+      HOURS=$piece
+    fi
+
+  #Days
+  elif [ "$index" = "2" ]; then
+    DAYS=$piece
+
+  #Month
+  elif [ "$index" = "3" ]; then
+    MONTHS=$piece
+
+  #Day of Week
+  elif [ "$index" = "4" ]; then
+    DAY_WEEK="$piece"
+  fi
+  #increment index
+  index=$((index+1))
+
+done < <(echo $1 | tr " " "\n")
+
+echo "${MINUTES} ${HOURS} ${DAYS} ${MONTHS} ${DAY_WEEK}"

--- a/tests/files/drupal8/.lagoon.yml
+++ b/tests/files/drupal8/.lagoon.yml
@@ -35,8 +35,8 @@ environments:
                 insecure: Allow
             - www.domain.com
 
-cronjobs:
-  - name: drush cron
-    schedule: "1 * * * *"
-    command: drush cron
-    service: cli
+    cronjobs:
+        - name: drush cron
+          schedule: "1 * * * *"
+          command: drush cron
+          service: cli

--- a/tests/files/features/.lagoon.yml
+++ b/tests/files/features/.lagoon.yml
@@ -6,13 +6,13 @@ environments:
     - node:
       - customdomain-will-be-main-domain.com
       - customdomain-will-be-not-be-main-domain.com
-
-cronjobs:
-  - name: echo /files/cron.txt multi
-    schedule: "* * * * *"
-    command: echo "$(date)" >> /files/cron.txt && echo "CRONJOB_MULTI" >> /files/cron.txt
-    service: node
-  - name: echo /files/cron.txt single
-    schedule: "* * * * *"
-    command: echo "CRONJOB_SINGLE" >> /files/cron.txt
-    service: node
+  branch/cronjob:
+    cronjobs:
+    - name: echo /files/cron.txt multi
+      schedule: "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59 * * * *"
+      command: echo "$(date)" >> /files/cron.txt && echo "CRONJOB_MULTI" >> /files/cron.txt
+      service: node
+    - name: echo /files/cron.txt single
+      schedule: "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59 * * * *"
+      command: echo "CRONJOB_SINGLE" >> /files/cron.txt
+      service: node

--- a/tests/tests/features.yaml
+++ b/tests/tests/features.yaml
@@ -7,64 +7,64 @@
     branch: branch/cronjob
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/multiproject.yaml
-#   vars:
-#     testname: "MULTIPROJECT - two projects with same git url"
-#     git_repo_name: multiproject.git
-#     project1: ci-multiproject1
-#     project2: ci-multiproject2
-#     branch: multiproject
-#     check_url1: "http://node.{{ project1 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
-#     check_url2: "http://node.{{ project2 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/multiproject.yaml
+  vars:
+    testname: "MULTIPROJECT - two projects with same git url"
+    git_repo_name: multiproject.git
+    project1: ci-multiproject1
+    project2: ci-multiproject2
+    branch: multiproject
+    check_url1: "http://node.{{ project1 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    check_url2: "http://node.{{ project2 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/production-environment-protection.yaml
-#   vars:
-#     testname: "PROTECTED PRODUCTION ENVIRONMENT"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: master
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/production-environment-protection.yaml
+  vars:
+    testname: "PROTECTED PRODUCTION ENVIRONMENT"
+    git_repo_name: features.git
+    project: ci-features
+    branch: master
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/environment-type.yaml
-#   vars:
-#     testname: "ENVIRONMENT TYPE DEVELOPMENT"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: develop
-#     environment_type: development
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/environment-type.yaml
+  vars:
+    testname: "ENVIRONMENT TYPE DEVELOPMENT"
+    git_repo_name: features.git
+    project: ci-features
+    branch: develop
+    environment_type: development
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/environment-type.yaml
-#   vars:
-#     testname: "ENVIRONMENT TYPE PRODUCTION"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: master
-#     environment_type: production
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/environment-type.yaml
+  vars:
+    testname: "ENVIRONMENT TYPE PRODUCTION"
+    git_repo_name: features.git
+    project: ci-features
+    branch: master
+    environment_type: production
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/route-env-variables.yaml
-#   vars:
-#     testname: "ROUTE ENV VARIABLES"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: branch/routes
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/route-env-variables.yaml
+  vars:
+    testname: "ROUTE ENV VARIABLES"
+    git_repo_name: features.git
+    project: ci-features
+    branch: branch/routes
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/dot-env.yaml
-#   vars:
-#     testname: "DOT-ENV VARIABLES"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: slash/branch1
-#     expected_dot_env: slash/branch1
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/dot-env.yaml
+  vars:
+    testname: "DOT-ENV VARIABLES"
+    git_repo_name: features.git
+    project: ci-features
+    branch: slash/branch1
+    expected_dot_env: slash/branch1
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-# - include: features/dot-env.yaml
-#   vars:
-#     testname: "DOT-ENV VARIABLES"
-#     git_repo_name: features.git
-#     project: ci-features
-#     branch: branch1
-#     expected_dot_env: branch1
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+- include: features/dot-env.yaml
+  vars:
+    testname: "DOT-ENV VARIABLES"
+    git_repo_name: features.git
+    project: ci-features
+    branch: branch1
+    expected_dot_env: branch1
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"

--- a/tests/tests/features.yaml
+++ b/tests/tests/features.yaml
@@ -4,67 +4,67 @@
     testname: "CRONJOBS"
     git_repo_name: features.git
     project: ci-features
-    branch: cronjobs
+    branch: branch/cronjob
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/multiproject.yaml
-  vars:
-    testname: "MULTIPROJECT - two projects with same git url"
-    git_repo_name: multiproject.git
-    project1: ci-multiproject1
-    project2: ci-multiproject2
-    branch: multiproject
-    check_url1: "http://node.{{ project1 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
-    check_url2: "http://node.{{ project2 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/multiproject.yaml
+#   vars:
+#     testname: "MULTIPROJECT - two projects with same git url"
+#     git_repo_name: multiproject.git
+#     project1: ci-multiproject1
+#     project2: ci-multiproject2
+#     branch: multiproject
+#     check_url1: "http://node.{{ project1 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+#     check_url2: "http://node.{{ project2 | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/production-environment-protection.yaml
-  vars:
-    testname: "PROTECTED PRODUCTION ENVIRONMENT"
-    git_repo_name: features.git
-    project: ci-features
-    branch: master
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/production-environment-protection.yaml
+#   vars:
+#     testname: "PROTECTED PRODUCTION ENVIRONMENT"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: master
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/environment-type.yaml
-  vars:
-    testname: "ENVIRONMENT TYPE DEVELOPMENT"
-    git_repo_name: features.git
-    project: ci-features
-    branch: develop
-    environment_type: development
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/environment-type.yaml
+#   vars:
+#     testname: "ENVIRONMENT TYPE DEVELOPMENT"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: develop
+#     environment_type: development
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/environment-type.yaml
-  vars:
-    testname: "ENVIRONMENT TYPE PRODUCTION"
-    git_repo_name: features.git
-    project: ci-features
-    branch: master
-    environment_type: production
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/environment-type.yaml
+#   vars:
+#     testname: "ENVIRONMENT TYPE PRODUCTION"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: master
+#     environment_type: production
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/route-env-variables.yaml
-  vars:
-    testname: "ROUTE ENV VARIABLES"
-    git_repo_name: features.git
-    project: ci-features
-    branch: branch/routes
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/route-env-variables.yaml
+#   vars:
+#     testname: "ROUTE ENV VARIABLES"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: branch/routes
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/dot-env.yaml
-  vars:
-    testname: "DOT-ENV VARIABLES"
-    git_repo_name: features.git
-    project: ci-features
-    branch: slash/branch1
-    expected_dot_env: slash/branch1
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/dot-env.yaml
+#   vars:
+#     testname: "DOT-ENV VARIABLES"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: slash/branch1
+#     expected_dot_env: slash/branch1
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: features/dot-env.yaml
-  vars:
-    testname: "DOT-ENV VARIABLES"
-    git_repo_name: features.git
-    project: ci-features
-    branch: branch1
-    expected_dot_env: branch1
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+# - include: features/dot-env.yaml
+#   vars:
+#     testname: "DOT-ENV VARIABLES"
+#     git_repo_name: features.git
+#     project: ci-features
+#     branch: branch1
+#     expected_dot_env: branch1
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"


### PR DESCRIPTION
- Using hash syntax like on Jenkins to allow the system to choose a random hour or minute
- allow max 15min steps for cronjobs
- auto generate a random start for step minutes (to prevent that all of the cronjobs are happening at the exact same time)
- cronjobs need to be defined per environment, not globally per project (prevents too many cronjobs overall)