### PR TITLE
adding mysqli to the php-fpm image

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -52,7 +52,7 @@ RUN apk update \
     && yes '' | pecl install -f redis \
     && docker-php-ext-enable apcu redis xdebug \
     && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j4 bcmath gd gettext mcrypt pdo_mysql shmop soap sockets opcache xsl zip \
+    && docker-php-ext-install -j4 bcmath gd gettext mcrypt pdo_mysql mysqli shmop soap sockets opcache xsl zip \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && rm -rf /var/cache/apk/* /tmp/pear/ \
     && apk del .phpize-deps \


### PR DESCRIPTION
As some web applications need use mysql_* functions adding the `mysqli` extension it to the php-fpm image