### PR TITLE
fix for "mariadb image cannot be run as root"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,6 @@ version: '3.2'
 services:
   api-db:
     image: ${IMAGE_REPO:-lagoon}/api-db
-    user: '111111111'
     volumes:
       - ./services/api-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - ./services/api-db/rerun_initdb.sh:/rerun_initdb.sh

--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -20,7 +20,7 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_USER=lagoon \
     MARIADB_PASSWORD=lagoon
 
-RUN apk add --no-cache bash mariadb-client mariadb mariadb-common pwgen && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash mariadb-client mariadb mariadb-common pwgen shadow && rm -rf /var/cache/apk/*
 
 RUN for i in /var/run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}"; \
 do mkdir -p $i; /bin/fix-permissions $i; done
@@ -33,6 +33,10 @@ COPY mysql-backup.sh /lagoon/
 COPY my.cnf /etc/mysql/my.cnf
 
 RUN ln -s /var/lib/mysql/.my.cnf /home/.my.cnf
+
+### we cannot start mysql as root, we add the user mysql to the group root and change the user of the Docker Image to this user
+RUN usermod -G 0 --append mysql
+USER mysql
 
 WORKDIR /var/lib/mysql
 VOLUME /var/lib/mysql

--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -25,8 +25,6 @@ RUN apk add --no-cache bash mariadb-client mariadb mariadb-common pwgen && rm -r
 RUN for i in /run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}"; \
 do mkdir -p $i; chown mysql $i;  /bin/fix-permissions $i; done
 
-# USER mysql
-
 COPY docker-entrypoint.sh /lagoon/entrypoints/90-mariadb-entrypoint
 COPY mysql-backup.sh /lagoon/
 

--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -20,10 +20,10 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_USER=lagoon \
     MARIADB_PASSWORD=lagoon
 
-RUN apk add --no-cache bash mariadb-client mariadb mariadb-common pwgen shadow && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash mariadb-client mariadb mariadb-common pwgen && rm -rf /var/cache/apk/*
 
-RUN for i in /var/run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}"; \
-do mkdir -p $i; /bin/fix-permissions $i; done
+RUN for i in /run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}"; \
+do mkdir -p $i; chown mysql $i;  /bin/fix-permissions $i; done
 
 # USER mysql
 
@@ -35,7 +35,6 @@ COPY my.cnf /etc/mysql/my.cnf
 RUN ln -s /var/lib/mysql/.my.cnf /home/.my.cnf
 
 ### we cannot start mysql as root, we add the user mysql to the group root and change the user of the Docker Image to this user
-RUN usermod -G 0 --append mysql
 USER mysql
 
 WORKDIR /var/lib/mysql


### PR DESCRIPTION
Do not specify a user in docker-compose.
Add shadow package to provide usermod.
usermod mysql user into group 0, run container as mysql.