### PR TITLE
Add attribute filter for openshift token

### DIFF
--- a/services/api/src/attrFilter.js
+++ b/services/api/src/attrFilter.js
@@ -1,0 +1,24 @@
+/*
+  This module exposes a filter mechanism for GraphQL entities
+  by user credentials.
+
+  It's extracted in its own module for readability... it's supposed
+  to be integrated in the dao module
+*/
+
+const R = require('ramda');
+
+const openshift = R.curry((cred, entity) => {
+  const role = cred.role;
+
+  // Only admin is allowed to see all attributes
+  if (role === 'admin') {
+    return entity;
+  }
+
+  return R.omit(['token'], entity);
+});
+
+module.exports = {
+  openshift,
+};

--- a/services/api/src/attrFilter.test.js
+++ b/services/api/src/attrFilter.test.js
@@ -1,0 +1,10 @@
+const attrFilter = require('./attrFilter');
+
+describe('openshift', () => {
+  it('should filter token if normal user', () => {
+    const entity = { token: 'openshift1', other: 'test' };
+
+    const ret = attrFilter.openshift({ role: 'user' }, entity);
+    expect(ret).not.toHaveProperty('token');
+  });
+});

--- a/services/api/src/dao.js
+++ b/services/api/src/dao.js
@@ -19,6 +19,7 @@
 //   apply those to the later exported daoFns
 // - Use a sql-string builder, additionally with our prepared statements
 
+const attrFilter = require('./attrFilter');
 const R = require('ramda');
 
 // Useful for creating extra if-conditions for non-admins
@@ -122,7 +123,7 @@ const getAllOpenshifts = sqlClient => async (cred, args) => {
   const prep = prepare(sqlClient, 'SELECT * FROM openshift');
   const rows = await query(sqlClient, prep(args));
 
-  return rows;
+  return rows.map(attrFilter.openshift(cred));
 };
 
 const getAllProjects = sqlClient => async (cred, args) => {
@@ -163,7 +164,7 @@ const getOpenshiftByProjectId = sqlClient => async (cred, pid) => {
 
   const rows = await query(sqlClient, prep({ pid }));
 
-  return rows ? rows[0] : null;
+  return rows ? (attrFilter.openshift(cred, rows[0])) : null;
 };
 
 const getNotificationsByProjectId = sqlClient => async (cred, pid, args) => {


### PR DESCRIPTION
This prevents non-admin roles to access the `Openshift.token` attribute.