### PR TITLE
Update hashbang for alpine.

### DIFF
--- a/services/api-db/rerun_initdb.sh
+++ b/services/api-db/rerun_initdb.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 INITDB_DIR="/docker-entrypoint-initdb.d"
 


### PR DESCRIPTION
Fixes `sh: /usr/bin/sh: not found` on apline.