### PR TITLE
better local development:

### DIFF
--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -24,4 +24,7 @@ ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
 
 RUN fix-permissions /usr/share/kibana
 
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=5601
+
 ENV NODE_OPTIONS="--max-old-space-size=200"

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -36,5 +36,8 @@ COPY docker-entrypoint /lagoon/entrypoints/70-nginx-entrypoint
 
 EXPOSE 8080
 
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=8080
+
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -28,5 +28,10 @@ RUN apk update \
 
 WORKDIR /app
 
+EXPOSE 3000
+
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=3000
+
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
 CMD ["yarn", "run", "start"]

--- a/images/php/cli/10-ssh-agent.sh
+++ b/images/php/cli/10-ssh-agent.sh
@@ -7,3 +7,9 @@ if [ -f /var/run/secrets/lagoon/sshkey/ssh-privatekey ]; then
   eval $(ssh-agent -a /tmp/ssh-agent)
   ssh-add /home/.ssh/id_rsa
 fi
+
+# Test if pygmy or cachalot ssh-agents are mounted and symlink them as our known ssh-auth-sock file.
+# This will only be used in local development
+if [ -S /tmp/amazeeio_ssh-agent/socket ]; then
+  ln -s /tmp/amazeeio_ssh-agent/socket $SSH_AUTH_SOCK
+fi

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -28,5 +28,8 @@ COPY docker-entrypoint /lagoon/entrypoints/70-varnish-entrypoint
 
 EXPOSE 8080
 
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=8080
+
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
 CMD ["varnishd", "-a", ":8080", "-T", ":6082", "-F", "-f", "/etc/varnish/default.vcl", "-S", "/etc/varnish/secret"]


### PR DESCRIPTION
- adding LAGOON_LOCALDEV_HTTP_PORT so the haproxy knows to which PORT it should forward
- teaching CLI about the ssh-agent at `/tmp/amazeeio_ssh-agent/socket`