### PR TITLE
Add error recovery for wrongly formatted sshKeys

### DIFF
--- a/services/api/src/routes/keys.js
+++ b/services/api/src/routes/keys.js
@@ -5,11 +5,16 @@ const R = require('ramda');
 const sshpk = require('sshpk');
 const bodyParser = require('body-parser');
 
-const toFingerprint = sshKey =>
-  sshpk
-    .parseKey(sshKey, 'ssh')
-    .fingerprint()
-    .toString();
+const toFingerprint = sshKey => {
+  try {
+    return sshpk
+      .parseKey(sshKey, 'ssh')
+      .fingerprint()
+      .toString();
+  } catch(e) {
+    logger.error(`Invalid ssh key detected: ${sshKey}`);
+  }
+}
 
 
 const keysRoute = async (req, res) => {
@@ -34,6 +39,7 @@ const keysRoute = async (req, res) => {
 
   const fingerprintKeyMap = R.compose(
     R.fromPairs,
+    R.reject(([fingerprint]) => fingerprint === undefined),
     R.map(sshKey => [toFingerprint(sshKey), sshKey]),
   )(sshKeys);
 


### PR DESCRIPTION
PR for fixing issue #250 

**Steps for testing:**

- Add broken sshKey and attach it to a customer:

```graphql
mutation setupWrongSsh {
  addSshKey(input: {
    name: "wrong"
    keyType:SSH_RSA
    keyValue: "wrongformat"
  }) {
    id
  }
  addSshKeyToCustomer(input: {
    customer: "ci-customer"
    sshKey: "wrong"
  }) {
    id
  }
}
```

- Open postman and query `api/keys`

**Resulting Output:**

Normal GET response for the Rest endpoint, additional logger error messages in the docker container: `error: Invalid ssh key detected: ssh-rsa wrongformat`