### PR TITLE
Small changes to the redirects-map.conf

### DIFF
--- a/images/nginx/redirects-map.conf
+++ b/images/nginx/redirects-map.conf
@@ -6,21 +6,21 @@
 ## A couple of examples:
 
 ## Simple www to non www redirect, with preserving the URL string and arguments
-# ~^www.foo.com   foo.com$request_uri;
+# ~^www.example.com   http://example.com$request_uri;
 
 ## Simple non-www to www redirect, with preserving the URL string and arguments
-#~^foo.com   www.foo.com$request_uri;
+#~^example.com   http://www.example.com$request_uri;
 
-## Redirect every request to foo.com to bar.com with preserving the URL string and arguments, eg: foo.com/bla -> bar.com/bla, foo.com/bla?test -> bar.com/bla?test
+## Redirect every request to example.com to example.net with preserving the URL string and arguments, eg: example.com/bla -> example.net/bla, example.com/bla?test -> example.net/bla?test
 ##
-# ~^foo.com   bar.com$request_uri;
+# ~^example.com   http://example.net$request_uri;
 
-## Redirect request only to foo.com/test (no regex matching) to test.com without preserving the URL string, eg: foo.com/test -> test.com
-## Requestes to foo.com/test/bla or foo.com/bla are not matched
+## Redirect request only to example.com/test (no regex matching) to example.net without preserving the URL string, eg: example.com/test -> example.net
+## Requestes to example.com/test/bla or example.com/bla are not matched
 ##
-# foo.com/test   test.com;
+# example.com/test   http://example.net;
 
-## Redirect request only to foo.com/test to test.com with preserving the rest of the URL string and arguments, eg: foo.com/test/bla -> test.com/bla, foo.com/test/bla?test -> test.com/bla?test
-## Requestes to foo.com/bla are not matched
+## Redirect request only to example.com/test to example.net with preserving the rest of the URL string and arguments, eg: example.com/test/bla -> example.net/bla, example.com/test/bla?test -> example.net/bla?test
+## Requestes to example.com/bla are not matched
 ##
-# ~^foo.com/test/(.*)   test.com/$1$is_args$args;
+# ~^example.com/test/(.*)   http://example.net/$1$is_args$args;


### PR DESCRIPTION
- prefix the destinations of the redirect maps with http:// to prevent human error
- adapting from foo.com / test.com to example.com/example.net