### PR TITLE
Remove depth configuration for submodule cloning

### DIFF
--- a/images/oc-build-deploy-dind/scripts/git-checkout-pull.sh
+++ b/images/oc-build-deploy-dind/scripts/git-checkout-pull.sh
@@ -14,4 +14,4 @@ git fetch --depth=10 --tags --progress $REMOTE +refs/heads/*:refs/remotes/origin
 
 git checkout --force "${REF}"
 
-git submodule update --init --recursive --depth 1
+git submodule update --init --recursive


### PR DESCRIPTION
Depending of the project, sometimes when try to clone exactly hash of git submodule fails because `depth 1` only get last revision and not all the revision history. Removing depth from submodule update will prevent these errors.