### PR TITLE
Expose additional configuration options for php.ini

### DIFF
--- a/images/php/fpm/php.ini
+++ b/images/php/fpm/php.ini
@@ -479,11 +479,11 @@ post_max_size = 2048M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
-auto_prepend_file =
+auto_prepend_file = ${PHP_AUTO_PREPEND_FILE:-none}
 
 ; Automatically add files after PHP document.
 ; http://php.net/auto-append-file
-auto_append_file =
+auto_append_file = ${PHP_AUTO_APPEND_FILE:-none}
 
 ; By default, PHP will output a character encoding using
 ; the Content-type: header.  To disable sending of the charset, simply


### PR DESCRIPTION
Rather than leaving these options blank we can allow overriding with environment variables.