### PR TITLE
Fixed typo and changed usage for adaptation

### DIFF
--- a/docs/using_lagoon/index.md
+++ b/docs/using_lagoon/index.md
@@ -36,7 +36,7 @@ This file is used by Docker Compose to start you Local Development environment. 
 
 Some Docker Images and Containers need additional customizations from the provided Images, this usually has two reasons:
 1. Application code: Containers like Nginx, PHP, Node, etc. need the actual programming code within their Images. This is done during a Docker Build step which are configured in Dockerfiles. Lagoon has full support for Docker and therefore also allows you full control over the resulting Images via Dockerfile customizations.
-2. Customization of Images: Lagoon also allows you to customize the base Images accordint to your needs. This can be to inject an addtional environment variable, change a service configuration or even install additional tools, even though we advise caution with installing additional tools to the Docker Images, as such adaptions need to be maintained by yourself in the future!
+2. Customization of Images: Lagoon also allows you to customize the base Images according to your needs. This can be to inject an addtional environment variable, change a service configuration or even install additional tools, even though we advise caution with installing additional tools to the Docker Images, as such adaptations need to be maintained by yourself in the future!
 
 ## Supported Services & Base Images by Lagoon
 


### PR DESCRIPTION
Found an actual typo while reading the docs (accordint) and also changed "adaptions" to "adaptations" as the latter is the more common form (but not incorrect! Just a small edit).