### PR TITLE
Create possibility to overwrite the backend port varnish talks to via…

### DIFF
--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -4,8 +4,8 @@ import std;
 
 # set backend default
 backend default {
-  .host = "${VARNISH_HOST:-nginx}";
-  .port = "${VARNISH_PORT:-8080}";
+  .host = "${VARNISH_BACKEND_HOST:-nginx}";
+  .port = "${VARNISH_BACKEND_PORT:-8080}";
   .first_byte_timeout = 35m;
   .between_bytes_timeout = 10m;
 }

--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -5,7 +5,7 @@ import std;
 # set backend default
 backend default {
   .host = "${VARNISH_HOST:-nginx}";
-  .port = "8080";
+  .port = "${VARNISH_PORT:-8080}";
   .first_byte_timeout = 35m;
   .between_bytes_timeout = 10m;
 }

--- a/images/varnish/default.vcl
+++ b/images/varnish/default.vcl
@@ -14,8 +14,8 @@ import std;
 
 # set backend default
 backend default {
-  .host = "${VARNISH_HOST:-nginx}";
-  .port = "${VARNISH_PORT:-8080}";
+  .host = "${VARNISH_BACKEND_HOST:-nginx}";
+  .port = "${VARNISH_BACKEND_PORT:-8080}";
   .first_byte_timeout = 35m;
   .between_bytes_timeout = 10m;
 }

--- a/images/varnish/default.vcl
+++ b/images/varnish/default.vcl
@@ -15,7 +15,7 @@ import std;
 # set backend default
 backend default {
   .host = "${VARNISH_HOST:-nginx}";
-  .port = "8080";
+  .port = "${VARNISH_PORT:-8080}";
   .first_byte_timeout = 35m;
   .between_bytes_timeout = 10m;
 }


### PR DESCRIPTION
… the envrionment variable VARNISH_PORT

This would be needed for having varnish caches in front of decoupled sites. because they run on different ports.