### PR TITLE
Make http_resp_hdr_len and http_resp_size configurable

### DIFF
--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -30,8 +30,8 @@ EXPOSE 8080
 # tells the local development environment on which port we are running
 ENV LAGOON_LOCALDEV_HTTP_PORT=8080
 
-# Make http_resp_hdr_len and http_resp_size configurable
-ENV HTTP_RESP_HDR_LEN=${http_resp_hdr_len:-8k}
-ENV HTTP_RESP_SIZE=${http_resp_size:-32k}
+# Make http_resp_hdr_len and http_resp_size configurable (see in docker-entrypoint)
+ENV HTTP_RESP_HDR_LEN=8k
+ENV HTTP_RESP_SIZE=32k
 
 ENTRYPOINT ["/lagoon/entrypoints.sh"]

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -19,8 +19,7 @@ RUN apk --no-cache add varnish
 RUN echo "${VARNISH_SECRET:-lagoon_default_secret}" >> /etc/varnish/secret
 
 COPY default.vcl /etc/varnish/default.vcl
-COPY varnish-start.bash /lagoon/varnish-start.bash
-RUN chmod 777 /lagoon/varnish-start.bash
+COPY varnish-start.sh /lagoon/varnish-start.sh
 
 RUN fix-permissions /etc/varnish/ \
     && fix-permissions /var/run/ \
@@ -38,4 +37,4 @@ ENV HTTP_RESP_HDR_LEN=8k
 ENV HTTP_RESP_SIZE=32k
 
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
-CMD [" /lagoon/varnish-start.bash"]
+CMD [" /lagoon/varnish-start.sh"]

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -2,7 +2,6 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM alpine
 
-MAINTAINER amazee.io
 ENV LAGOON=varnish
 
 # Copying commons files

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -19,6 +19,8 @@ RUN apk --no-cache add varnish
 RUN echo "${VARNISH_SECRET:-lagoon_default_secret}" >> /etc/varnish/secret
 
 COPY default.vcl /etc/varnish/default.vcl
+COPY varnish-start.bash /lagoon/varnish-start.bash
+RUN chmod 777 /lagoon/varnish-start.bash
 
 RUN fix-permissions /etc/varnish/ \
     && fix-permissions /var/run/ \
@@ -36,3 +38,4 @@ ENV HTTP_RESP_HDR_LEN=8k
 ENV HTTP_RESP_SIZE=32k
 
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
+CMD [" /lagoon/varnish-start.bash"]

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -19,7 +19,7 @@ RUN apk --no-cache add varnish
 RUN echo "${VARNISH_SECRET:-lagoon_default_secret}" >> /etc/varnish/secret
 
 COPY default.vcl /etc/varnish/default.vcl
-COPY varnish-start.sh /lagoon/varnish-start.sh
+COPY varnish-start.sh /varnish-start.sh
 
 RUN fix-permissions /etc/varnish/ \
     && fix-permissions /var/run/ \
@@ -37,4 +37,4 @@ ENV HTTP_RESP_HDR_LEN=8k
 ENV HTTP_RESP_SIZE=32k
 
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
-CMD [" /lagoon/varnish-start.sh"]
+CMD [" /varnish-start.sh"]

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -30,5 +30,8 @@ EXPOSE 8080
 # tells the local development environment on which port we are running
 ENV LAGOON_LOCALDEV_HTTP_PORT=8080
 
+# Make http_resp_hdr_len and http_resp_size configurable
+ENV HTTP_RESP_HDR_LEN=${http_resp_hdr_len:-8k}
+ENV HTTP_RESP_SIZE=${http_resp_size:-32k}
+
 ENTRYPOINT ["/lagoon/entrypoints.sh"]
-CMD ["varnishd", "-a", ":8080", "-T", ":6082", "-F", "-f", "/etc/varnish/default.vcl", "-S", "/etc/varnish/secret"]

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -2,6 +2,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM alpine
 
+MAINTAINER amazee.io
 ENV LAGOON=varnish
 
 # Copying commons files

--- a/images/varnish/docker-entrypoint
+++ b/images/varnish/docker-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ep /etc/varnish/*
 

--- a/images/varnish/docker-entrypoint
+++ b/images/varnish/docker-entrypoint
@@ -2,4 +2,4 @@
 
 ep /etc/varnish/*
 
-exec "$@"
+exec /usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE

--- a/images/varnish/docker-entrypoint
+++ b/images/varnish/docker-entrypoint
@@ -2,4 +2,4 @@
 
 ep /etc/varnish/*
 
-exec /usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE
+exec "$@"

--- a/images/varnish/varnish-start.bash
+++ b/images/varnish/varnish-start.bash
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE

--- a/images/varnish/varnish-start.sh
+++ b/images/varnish/varnish-start.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 /usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE


### PR DESCRIPTION
Make http_resp_hdr_len and http_resp_size configurable for large header sizes. This can happen if we use varnish to cache sites that use a huge amount of cache tags
