### PR TITLE
make site aliases compatible with drush 9 `drush site:alias-convert`

### DIFF
--- a/docs/using_lagoon/drupal/drush9.md
+++ b/docs/using_lagoon/drupal/drush9.md
@@ -1,0 +1,35 @@
+# Drush 9
+
+Unfortunately Drush 9 does not provide the possibility to inject dynamic Site Aliases like Drush 8 did. We are working with the Drush team to implement this again. In the meantime we have a workaround that allows you to use Drush 9 with Lagoon.
+
+### Basic Idea
+
+Drush 9 provides a new command `drush site:alias-convert` which can convert Drush 8 style site aliases over to the Drush 9 yaml site alias style. This will create a one time export of the site aliases currently existing in Lagoon and save them within `/app/drush/sites` which then are used when running a command like `drush sa`.
+
+### Preparation
+
+In order to be able to use `drush site:alias-convert` you need to do the following:
+
+- rename the `aliases.drushrc.php` inside the `drush` folder to `lagoon.aliases.drushrc.php`
+
+### Generate Site aliases
+
+Now you can run the converting process:
+
+- `drush site:alias-convert`
+
+It's a good practice to commit the resulting yaml files into your git repo, so your fellow developers don't need to do the same all the time.
+
+### Use Site Aliases
+
+In Drush 9 all site aliases are prefixed with a group, in our case this is `lagoon`. You can show all site aliases with their prefix via:
+
+```
+drush sa --format=list
+```
+
+and to use them: `drush @lagoon.master ssh`
+
+### Update Site Aliases
+
+If a new environment in Lagoon has been created, you can just run `drush site:alias-convert` to update the site aliases file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ pages:
   - Drupal:
     - Lagoonize: using_lagoon/drupal/lagoonize.md
     - First Deployment: using_lagoon/drupal/first_deployment.md
+    - Drush 9: using_lagoon/drupal/drush9.md
     - Services:
       - Varnish: using_lagoon/drupal/services/varnish.md
   - Migrations:

--- a/services/drush-alias/web/aliases.drushrc.php.stub
+++ b/services/drush-alias/web/aliases.drushrc.php.stub
@@ -150,7 +150,8 @@ $cid = "lagoon_aliases_$project_name";
 $cache = drush_cache_get($cid);
 
 // Drush does not respect the cache expire, so we need to check it ourselves.
-if (isset($cache->data) && time() < $cache->expire && getenv('LAGOON_IGNORE_DRUSHCACHE') === FALSE) {
+// If `LAGOON_IGNORE_DRUSHCACHE` is set or we are on Drush 9, we skip the cache all together
+if (isset($cache->data) && time() < $cache->expire && getenv('LAGOON_IGNORE_DRUSHCACHE') === FALSE && DRUSH_MAJOR_VERSION !== "9") {
   drush_log('Hit lagoon project cache');
   $aliases = $cache->data;
 
@@ -268,6 +269,11 @@ $aliases = array_reduce($environments, function ($carry, $environment) use ($def
   $site_host = 'localhost';
 
   $alias = [];
+
+  // Drush 9 needs aliases prefixed with a group name in order to be able to convert them correctly
+  if (DRUSH_MAJOR_VERSION == "9") {
+    $site_name = 'lagoon.' . $site_name;
+  }
 
   $alias[$site_name] = [
     'remote-host' => "$ssh_host",


### PR DESCRIPTION
- disable cache for drush 9 as we are converting the site aliases
- prefix all enviornments with `lagoon`
- documentation why we need that