### PR TITLE
run backup daily instead of hourly

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-galera/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-galera/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: mariadb backup
-  schedule: "1 * * * *"
+  schedule: "0 1 * * *"
   command: /lagoon/mysql-backup.sh localhost

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-galera/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-galera/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: mariadb backup
-  schedule: "0 1 * * *"
+  schedule: "H 1 * * *"
   command: /lagoon/mysql-backup.sh localhost

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: backup
-  schedule: "1 * * * *"
+  schedule: "0 1 * * *"
   command: /lagoon/mysql-backup.sh localhost

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: backup
-  schedule: "0 1 * * *"
+  schedule: "H 1 * * *"
   command: /lagoon/mysql-backup.sh localhost

--- a/images/oc-build-deploy-dind/openshift-templates/postgres/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/postgres/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: backup
-  schedule: "1 * * * *"
+  schedule: "0 1 * * *"
   command: /lagoon/postgres-backup.sh localhost

--- a/images/oc-build-deploy-dind/openshift-templates/postgres/cronjobs.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/postgres/cronjobs.yml
@@ -1,3 +1,3 @@
 - name: backup
-  schedule: "0 1 * * *"
+  schedule: "H 1 * * *"
   command: /lagoon/postgres-backup.sh localhost


### PR DESCRIPTION
I saw that the cron expression is `1 * * * *` which runs every hour at minute 1 instead of every day.

Fixed that with `0 1 * * *` but i'm not 100% sure if we have a way to spread the backups around a bit because that way every backup will fire at 1am