### PR TITLE
Added rsyslog image and lagoon templates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ images :=     centos7 \
 							varnish \
 							varnish-drupal \
 							redis \
+							rsyslog \
 							mongo \
 							elasticsearch \
 							kibana \
@@ -155,6 +156,7 @@ build/nginx-drupal: build/nginx images/nginx-drupal/Dockerfile
 build/varnish: build/commons images/varnish/Dockerfile
 build/varnish-drupal: build/varnish images/varnish-drupal/Dockerfile
 build/redis: build/commons images/redis/Dockerfile
+build/rsyslog: build/commons images/rsyslog/Dockerfile
 build/mongo: build/commons images/mongo/Dockerfile
 build/elasticsearch: build/commons images/elasticsearch/Dockerfile
 build/logstash: build/commons images/logstash/Dockerfile

--- a/images/oc-build-deploy-dind/openshift-templates/rsyslog/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/rsyslog/deployment.yml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-openshift-template-rsyslog
+parameters:
+  - name: SERVICE_NAME
+    description: Name of this service
+    required: true
+  - name: SAFE_BRANCH
+    description: Which branch this belongs to, special chars replaced with dashes
+    required: true
+  - name: SAFE_PROJECT
+    description: Which project this belongs to, special chars replaced with dashes
+    required: true
+  - name: BRANCH
+    description: Which branch this belongs to, original value
+    required: true
+  - name: PROJECT
+    description: Which project this belongs to, original value
+    required: true
+  - name: LAGOON_GIT_SHA
+    description: git hash sha of the current deployment
+    required: true
+  - name: SERVICE_ROUTER_URL
+    description: URL of the Router for this service
+    value: ""
+  - name: OPENSHIFT_PROJECT
+    description: Name of the Project that this service is in
+    required: true
+  - name: REGISTRY
+    description: Registry where Images are pushed to
+    required: true
+  - name: DEPLOYMENT_STRATEGY
+    description: Strategy of Deploymentconfig
+    value: "Rolling"
+  - name: SERVICE_IMAGE
+    description: Pullable image of service
+    required: true
+  - name: CRONJOBS
+    description: Oneliner of Cronjobs
+    value: ""
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: ${SERVICE_NAME}
+      branch: ${SAFE_BRANCH}
+      project: ${SAFE_PROJECT}
+    name: ${SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      service: ${SERVICE_NAME}
+    strategy:
+      type: ${DEPLOYMENT_STRATEGY}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          service: ${SERVICE_NAME}
+          branch: ${SAFE_BRANCH}
+          project: ${SAFE_PROJECT}
+      spec:
+        containers:
+        - image: ${SERVICE_IMAGE}
+          name: ${SERVICE_NAME}
+          ports:
+          - containerPort: 1514
+            protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 1514
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          livenessProbe:
+            tcpSocket:
+              port: 1514
+            initialDelaySeconds: 120
+            periodSeconds: 5
+          envFrom:
+          - configMapRef:
+              name: lagoon-env
+          env:
+          - name: SERVICE_NAME
+            value: ${SERVICE_NAME}
+          - name: CRONJOBS
+            value: ${CRONJOBS}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+    test: false
+    triggers:
+    - type: ConfigChange

--- a/images/oc-build-deploy-dind/openshift-templates/rsyslog/services.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/rsyslog/services.yml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-openshift-template-rsyslog
+parameters:
+  - name: SERVICE_NAME
+    description: Name of this service
+    required: true
+  - name: SAFE_BRANCH
+    description: Which branch this belongs to, special chars replaced with dashes
+    required: true
+  - name: SAFE_PROJECT
+    description: Which project this belongs to, special chars replaced with dashes
+    required: true
+  - name: BRANCH
+    description: Which branch this belongs to, original value
+    required: true
+  - name: PROJECT
+    description: Which project this belongs to, original value
+    required: true
+  - name: LAGOON_GIT_SHA
+    description: git hash sha of the current deployment
+    required: true
+  - name: SERVICE_ROUTER_URL
+    description: URL of the Router for this service
+    value: ""
+  - name: OPENSHIFT_PROJECT
+    description: Name of the Project that this service is in
+    required: true
+  - name: REGISTRY
+    description: Registry where Images are pushed to
+    required: true
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: ${SERVICE_NAME}
+      branch: ${SAFE_BRANCH}
+      project: ${SAFE_PROJECT}
+    name: ${SERVICE_NAME}
+  spec:
+    ports:
+    - name: 514-udp
+      port: 514
+      protocol: UDP
+      targetPort: 1514
+    selector:
+      service: ${SERVICE_NAME}
+  status:
+    loadBalancer: {}

--- a/images/rsyslog/Dockerfile
+++ b/images/rsyslog/Dockerfile
@@ -1,0 +1,30 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM alpine:3.6
+
+MAINTAINER amazee.io
+ENV LAGOON=redis
+
+# Copying commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /home /home
+
+RUN chmod g+w /etc/passwd \
+    && mkdir -p /home
+
+# When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+# When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+ENV TMPDIR=/tmp TMP=/tmp HOME=/home ENV=/home/.bashrc BASH_ENV=/home/.bashrc
+
+RUN apk add --no-cache bash rsyslog
+
+EXPOSE 1514
+
+COPY rsyslog.conf /etc/rsyslog.conf
+
+RUN fix-permissions /etc/rsyslog.conf \
+    && fix-permissions /var/run/
+
+ENTRYPOINT ["/lagoon/entrypoints.sh"]
+CMD ["rsyslogd", "-n"]

--- a/images/rsyslog/rsyslog.conf
+++ b/images/rsyslog/rsyslog.conf
@@ -1,0 +1,9 @@
+$ModLoad imudp.so
+
+# http://www.rsyslog.com/doc/v8-stable/configuration/templates.html
+$template SimpleFormat,"%msg%\n"
+
+*.* /proc/self/fd/2;SimpleFormat
+
+$MaxMessageSize 20k
+$UDPServerRun 1514


### PR DESCRIPTION
Adds support for a `rsyslog` service which can be used by [monolog](https://www.drupal.org/project/monolog) to push Drupal logs.

Once monolog is enabled it you need to define a new handler eg.

```
parameters:
  monolog.channel_handlers:
    default: ['rsyslog']

services:
  monolog.handler.rsyslog:
    class: Monolog\Handler\SyslogUdpHandler
    arguments: ['rsyslog']
```

The service also needs to be added to the project:

```
  rsyslog:
    image: amazeeio/rsyslog
    labels:
      lagoon.type: rsyslog
```

Once in place logs will output to the rsyslog pod and piped to ELK.