### PR TITLE
Disable newrelic during builds and enable at runtime.

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -74,6 +74,7 @@ RUN apk update \
 	&& sed -i -e "s/;newrelic.daemon.loglevel = .*/newrelic.daemon.loglevel = \"\${NEWRELIC_DAEMON_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
 	&& sed -i -e "s/newrelic.logfile = .*/newrelic.logfile = \"\/dev\/stdout\"/" /usr/local/etc/php/conf.d/newrelic.ini \
 	&& sed -i -e "s/newrelic.daemon.logfile = .*/newrelic.daemon.logfile = \"\/dev\/stdout\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+	&& mv /usr/local/etc/php/conf.d/newrelic.ini /usr/local/etc/php/conf.d/newrelic.disable \
     && cd / && rm -rf /tmp/newrelic \
     && mkdir -p /app \
     && fix-permissions /usr/local/etc/ \

--- a/images/php/fpm/entrypoints/71-php-newrelic.sh
+++ b/images/php/fpm/entrypoints/71-php-newrelic.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 # envplate the newrelic ini file
-ep /usr/local/etc/php/conf.d/newrelic.ini
+ep /usr/local/etc/php/conf.d/newrelic.disable
+
+# enable newrelic
+mv /usr/local/etc/php/conf.d/newrelic.disable /usr/local/etc/php/conf.d/newrelic.ini

--- a/images/php/fpm/entrypoints/71-php-newrelic.sh
+++ b/images/php/fpm/entrypoints/71-php-newrelic.sh
@@ -3,5 +3,7 @@
 # envplate the newrelic ini file
 ep /usr/local/etc/php/conf.d/newrelic.disable
 
-# enable newrelic
-mv /usr/local/etc/php/conf.d/newrelic.disable /usr/local/etc/php/conf.d/newrelic.ini
+# enable newrelic only if XDEBUG_ENABLE is set
+if [ ${XDEBUG_ENABLE+x} ]; then
+  mv /usr/local/etc/php/conf.d/newrelic.disable /usr/local/etc/php/conf.d/newrelic.ini
+fi


### PR DESCRIPTION
There's any issue with having a pre envplated `newrelic.ini` when running build that require valid PHP config eg. `docker-php-ext-enable`.

This basically moves `newrelic.ini` to `newrelic.disable` then will move it back after the file has been envplated.