### PR TITLE
Expose variable for PHP_MAX_INPUT_VARS.

### DIFF
--- a/images/php/fpm/php.ini
+++ b/images/php/fpm/php.ini
@@ -204,7 +204,7 @@ max_input_time = 900
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-; max_input_vars = 1000
+max_input_vars = ${PHP_MAX_INPUT_VARS:-1000}
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
A common setting which needs to be increased particularly on Drupal site with large menus.