### PR TITLE
unifying alpine repos by switching over to dl-cdn.alpinelinux.org whi…

### DIFF
--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -17,8 +17,8 @@ RUN apk update \
         patch \
         procps \
         coreutils \
-    && apk add --no-cache postgresql-dev postgresql-client --repository http://nl.alpinelinux.org/alpine/edge/main \
-    && apk add nodejs-current yarn --update-cache  --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
+    && apk add --no-cache postgresql-dev postgresql-client --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    && apk add nodejs-current yarn --update-cache  --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/1.6.5/composer.phar \
     && echo "67bebe9df9866a795078bb2cf21798d8b0214f2e0b2fd81f2e907a8ef0be3434 /usr/local/bin/composer" | sha256sum \

--- a/images/php/cli/README.md
+++ b/images/php/cli/README.md
@@ -8,12 +8,12 @@ Add these commands as parts of your customized Dockerfile within `RUN` commands.
 
 #### Remove current version (needed for installing any other Version)
 
-    RUN apk del --no-cache nodejs-current yarn --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --repository http://dl-3.alpinelinux.org/alpine/edge/community/
+    RUN apk del --no-cache nodejs-current yarn --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 #### Install Nodejs Version 6
 
-    RUN apk add --no-cache nodejs yarn --repository http://dl-3.alpinelinux.org/alpine/edge/community/
+    RUN apk add --no-cache nodejs yarn --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 #### Install Nodejs Version 8
 
-    RUN apk add --no-cache nodejs yarn --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --repository http://dl-3.alpinelinux.org/alpine/edge/main/
+    RUN apk add --no-cache nodejs yarn --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -43,7 +43,7 @@ RUN apk update \
         libxml2-dev \
         # for xsl
         libxslt-dev \
-    && apk add --no-cache postgresql-dev --repository http://nl.alpinelinux.org/alpine/edge/main \
+    && apk add --no-cache postgresql-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && if [ ${PHP_VERSION%.*.*} == "7" ]; then \
         yes '' | pecl install -f apcu \


### PR DESCRIPTION
…ch picks the closest mirror

using the `dl-cdn` domain instead of several different ones. as everything goes via fastly we will get the fastest mirror - https://mirrors.alpinelinux.org/