### PR TITLE
refactor php.ini templating

### DIFF
--- a/images/php/fpm/00-lagoon-php.ini.tpl
+++ b/images/php/fpm/00-lagoon-php.ini.tpl
@@ -1,0 +1,15 @@
+[PHP]
+max_execution_time = ${PHP_MAX_EXECUTION_TIME:-900}
+max_input_vars = ${PHP_MAX_INPUT_VARS:-1000}
+memory_limit = ${PHP_MEMORY_LIMIT:-400M}
+display_errors = ${PHP_DISPLAY_ERRORS:-Off}
+display_startup_errors = ${PHP_DISPLAY_STARTUP_ERRORS:-Off}
+auto_prepend_file = ${PHP_AUTO_PREPEND_FILE:-none}
+auto_append_file = ${PHP_AUTO_APPEND_FILE:-none}
+
+[APC]
+apc.shm_size = ${PHP_APC_SHM_SIZE:-32m}
+apc.enabled = ${PHP_APC_ENABLED:-1}
+
+[xdebug]
+xdebug.remote_enable = on

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -23,6 +23,7 @@ COPY check_fcgi /usr/sbin/
 COPY entrypoints/70-php-config.sh entrypoints/60-php-xdebug.sh entrypoints/50-ssmtp.sh entrypoints/71-php-newrelic.sh /lagoon/entrypoints/
 
 COPY php.ini /usr/local/etc/php/
+COPY 00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/
 COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 

--- a/images/php/fpm/entrypoints/70-php-config.sh
+++ b/images/php/fpm/entrypoints/70-php-config.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
-ep /usr/local/etc/php/php.ini
+cp /usr/local/etc/php/conf.d/00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/00-lagoon-php.ini && ep /usr/local/etc/php/conf.d/00-lagoon-php.ini
 ep /usr/local/etc/php-fpm.conf
 ep /usr/local/etc/php-fpm.d/*

--- a/images/php/fpm/php.ini
+++ b/images/php/fpm/php.ini
@@ -187,7 +187,7 @@ expose_php = 0
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = ${PHP_MAX_EXECUTION_TIME:-900}
+max_execution_time = 900
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly
@@ -204,11 +204,11 @@ max_input_time = 900
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-max_input_vars = ${PHP_MAX_INPUT_VARS:-1000}
+max_input_vars = 1000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = ${PHP_MEMORY_LIMIT:-400M}
+memory_limit = 400M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -281,7 +281,7 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/display-errors
-display_errors = ${PHP_DISPLAY_ERRORS:-Off}
+display_errors = Off
 
 ; The display of errors which occur during PHP's startup sequence are handled
 ; separately from display_errors. PHP's default behavior is to suppress those
@@ -292,7 +292,7 @@ display_errors = ${PHP_DISPLAY_ERRORS:-Off}
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/display-startup-errors
-display_startup_errors = ${PHP_DISPLAY_STARTUP_ERRORS:-Off}
+display_startup_errors = Off
 
 ; Besides displaying errors, PHP can also log errors to locations such as a
 ; server-specific log, STDERR, or a location specified by the error_log
@@ -479,11 +479,11 @@ post_max_size = 2048M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
-auto_prepend_file = ${PHP_AUTO_PREPEND_FILE:-none}
+auto_prepend_file = none
 
 ; Automatically add files after PHP document.
 ; http://php.net/auto-append-file
-auto_append_file = ${PHP_AUTO_APPEND_FILE:-none}
+auto_append_file = none
 
 ; By default, PHP will output a character encoding using
 ; the Content-type: header.  To disable sending of the charset, simply
@@ -1580,8 +1580,8 @@ opcache.huge_code_pages=1
 ; End:
 
 [APC]
-apc.shm_size = ${PHP_APC_SHM_SIZE:-32m}
-apc.enabled = ${PHP_APC_ENABLED:-1}
+apc.shm_size = 32m
+apc.enabled = 1
 
 [xdebug]
 xdebug.remote_enable = on


### PR DESCRIPTION
- default php.ini is not envplated so during buildtime we have proper php settings (envplating does not run during buildtime)
- customizeable php.ini settings now life inside conf.d/00-lagoon-php.ini.tpl which is envplated with copying it to 00-lagoon-php.ini