### PR TITLE
Set unsafe permissions before npm install

### DIFF
--- a/local-dev/api-data-watcher-pusher/Dockerfile
+++ b/local-dev/api-data-watcher-pusher/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 
 RUN apk add --no-cache mysql-client tini openssl bash wget curl nodejs nodejs-npm \
+    && npm config set unsafe-perm true \
     && npm -g install jwtgen
 
 ENV JWTSECRET=super-secret-string \

--- a/services/auto-idler/Dockerfile
+++ b/services/auto-idler/Dockerfile
@@ -4,6 +4,7 @@ FROM ${IMAGE_REPO:-lagoon}/oc
 ENV LAGOON=auto-idler
 
 RUN apk add --no-cache tini jq openssl bash curl nodejs nodejs-npm \
+    && npm config set unsafe-perm true \
     && npm -g install jwtgen
 
 COPY create_jwt.sh idle-services.sh idle-clis.sh /

--- a/services/ssh/Dockerfile
+++ b/services/ssh/Dockerfile
@@ -49,7 +49,8 @@ RUN curl -L https://github.com/krallin/tini/releases/download/v0.18.0/tini -o /s
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 # Needed for jwt generation
-RUN npm -g install jwtgen
+RUN npm config set unsafe-perm true \
+    && npm -g install jwtgen
 
 COPY services/ssh/etc/ /etc/
 COPY services/ssh/home/ /home/

--- a/services/storage-calculator/Dockerfile
+++ b/services/storage-calculator/Dockerfile
@@ -4,6 +4,7 @@ FROM ${IMAGE_REPO:-lagoon}/oc
 ENV LAGOON=storage-calculator
 
 RUN apk add --no-cache tini jq openssl bash curl nodejs nodejs-npm \
+    && npm config set unsafe-perm true \
     && npm -g install jwtgen
 
 COPY create_jwt.sh calculate-storage.sh /


### PR DESCRIPTION
There is an issue when try to create lagoon images from Linux. npm global installation has different working way between OS X and Linux. In Linux npm can't get uid user number and show an error. [Here](https://github.com/npm/uid-number/issues/3) more information about npm issue.