### PR TITLE
Hotfixing #467 take two

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -450,7 +450,7 @@ do
 
       CRONJOB_SCHEDULE=$(cat ${SERVICE_CRONJOB_FILE} | shyaml get-value $CRONJOB_COUNTER.schedule)
       # Convert the Cronjob Schedule for additional features and better spread
-      CRONJOB_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "$CRONJOB_SCHEDULE")
+      CRONJOB_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "$CRONJOB_SCHEDULE")
       CRONJOB_COMMAND=$(cat ${SERVICE_CRONJOB_FILE} | shyaml get-value $CRONJOB_COUNTER.command)
 
       CRONJOBS_ARRAY+=("${CRONJOB_SCHEDULE} ${CRONJOB_COMMAND}")

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -427,7 +427,7 @@ do
 
       CRONJOB_SCHEDULE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.cronjobs.$CRONJOB_COUNTER.schedule)
       # Convert the Cronjob Schedule for additional features and better spread
-      CRONJOB_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "$CRONJOB_SCHEDULE")
+      CRONJOB_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "$CRONJOB_SCHEDULE")
       CRONJOB_COMMAND=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.cronjobs.$CRONJOB_COUNTER.command)
 
       CRONJOBS_ARRAY+=("${CRONJOB_SCHEDULE} ${CRONJOB_COMMAND}")

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb/deployment.yml
@@ -101,4 +101,4 @@ objects:
               memory: 10Mi
     test: false
     triggers:
-      - type: none
+    - type: ConfigChange

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb/deployment.yml
@@ -100,3 +100,5 @@ objects:
               cpu: 10m
               memory: 10Mi
     test: false
+    triggers:
+      - type: none

--- a/images/oc-build-deploy-dind/scripts/convert-crontab.sh
+++ b/images/oc-build-deploy-dind/scripts/convert-crontab.sh
@@ -7,6 +7,9 @@ function join { local IFS="$1"; shift; echo "$*"; }
 
 index=0
 
+# Seed is used to generate the "random" numbers
+SEED=$(echo "$1" | cksum | cut -f 1 -d " ")
+
 while read piece
 do
 
@@ -14,7 +17,7 @@ do
   if [ "$index" = "0" ]; then
     if [[ $piece =~ ^H$ ]]; then
       # If just an H is defined, we generate a random minute
-      MINUTES=$((0 + RANDOM % 59))
+      MINUTES=$((SEED % 59))
 
     elif [[ $piece =~ ^(H|\*)\/([0-5]?[0-9])$ ]]; then
       # A Minute like H/15 or (*/15 for backwards compatibility) is defined, create a list of minutes with a random start
@@ -22,7 +25,7 @@ do
       STEP=${BASH_REMATCH[2]}
       # Generate a random start within the given step to prevent that all cronjobs start at the same time
       # but still incorporate the wished step
-      COUNTER=$((0 + RANDOM % $STEP))
+      COUNTER=$((SEED % $STEP))
       MINUTES_ARRAY=()
       while [ $COUNTER -lt 60 ]; do
           MINUTES_ARRAY+=($COUNTER)
@@ -45,7 +48,7 @@ do
   elif [ "$index" = "1" ]; then
     if [[ $piece =~ ^H$ ]]; then
       # If just an H is defined, we generate a random hour
-      HOURS=$((0 + RANDOM % 23))
+      HOURS=$((SEED % 23))
     else
       HOURS=$piece
     fi
@@ -65,6 +68,6 @@ do
   #increment index
   index=$((index+1))
 
-done < <(echo $1 | tr " " "\n")
+done < <(echo $2 | tr " " "\n")
 
 echo "${MINUTES} ${HOURS} ${DAYS} ${MONTHS} ${DAY_WEEK}"


### PR DESCRIPTION
because we just removed the `triggers` and how `oc apply` works (it merges existing with new yamls), it didn't really remove the Config Trigger for existing DeploymentConfigs.
This now should remove them