### PR TITLE
Varnish optimisations for #408

### DIFF
--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -33,9 +33,10 @@ EXPOSE 8080
 # tells the local development environment on which port we are running
 ENV LAGOON_LOCALDEV_HTTP_PORT=8080
 
-# Make http_resp_hdr_len and http_resp_size configurable (see in docker-entrypoint)
-ENV HTTP_RESP_HDR_LEN=8k
-ENV HTTP_RESP_SIZE=32k
+ENV HTTP_RESP_HDR_LEN=8k \
+    HTTP_RESP_SIZE=32k \
+    NUKE_LIMIT=150 \
+    CACHE_SIZE=100M
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
 CMD [" /varnish-start.sh"]

--- a/images/varnish/docker-entrypoint
+++ b/images/varnish/docker-entrypoint
@@ -1,5 +1,3 @@
 #!/bin/sh
 
 ep /etc/varnish/*
-
-exec /usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE

--- a/images/varnish/varnish-start.sh
+++ b/images/varnish/varnish-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE -s malloc,$CACHE_SIZE -p nuke_limit=$NUKE_LIMIT
+/usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE -p nuke_limit=$NUKE_LIMIT -s malloc,$CACHE_SIZE

--- a/images/varnish/varnish-start.sh
+++ b/images/varnish/varnish-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE
+/usr/sbin/varnishd -a :8080 -T :6082 -F -f /etc/varnish/default.vcl -S /etc/varnish/secret -p http_resp_hdr_len=$HTTP_RESP_HDR_LEN -p http_resp_size=$HTTP_RESP_SIZE -s malloc,$CACHE_SIZE -p nuke_limit=$NUKE_LIMIT


### PR DESCRIPTION
- Make the nuke_limit configurable `NUKE_LIMIT` 
- Make varnish cachesize configurable `CACHE_SIZE`
- Removing varnish start from docker-entrypoint