### PR TITLE
Allow Drupal sites to have paths that begin with /vendor, and other regex tweaks.

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -86,35 +86,35 @@ server {
   }
 
   ## Disallow access to patches directory.
-  location ^~ /patches {
+  location ^~ /patches/ {
     deny all;
     access_log off;
     log_not_found off;
   }
 
   ## Disallow access to backup directory.
-  location ^~ /backup {
+  location ^~ /backup/ {
     deny all;
     access_log off;
     log_not_found off;
   }
 
   ## Disallow access to vagrant directory.
-  location ^~ /vagrant {
+  location ^~ /vagrant/ {
     deny all;
     access_log off;
     log_not_found off;
   }
 
-  ## Disallow access to /core/vendor.
-  location ^~ /core/vendor {
+  ## Disallow access to vendor directory.
+  location ^~ /core/vendor/ {
     deny all;
     access_log off;
     log_not_found off;
   }
 
-  ## Disallow access to /vendor.
-  location ^~ /vendor {
+  ## Disallow access to vendor directory.
+  location ^~ /vendor/ {
     deny all;
     access_log off;
     log_not_found off;


### PR DESCRIPTION
In this particular case, the URL path was `/vendors-assistance` and was being blocked by the regex in question.

Fixes #553