### PR TITLE
Fix paths to sgerrand.rsa.pub

### DIFF
--- a/images/node/builder/Dockerfile
+++ b/images/node/builder/Dockerfile
@@ -26,7 +26,7 @@ RUN apk update \
         ca-certificates \
         wget \
         libpng-dev \
-    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk \
     && apk add glibc-2.26-r0.apk \
     && rm -rf /var/cache/apk/*

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -33,7 +33,7 @@ ENV OC_VERSION=v3.6.0 \
 # To run the openshift client library `oc` we need glibc, install that first. Copied from https://github.com/jeanblanchard/docker-alpine-glibc/blob/master/Dockerfile
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util && \
 		apk add --update curl jq parallel && \
-		curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+		curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
 		curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
 		curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
 		apk add glibc-bin.apk glibc.apk && \


### PR DESCRIPTION
The path to a public key used for installing software has changed causing builds of some docker images to fail.

See https://github.com/sgerrand/alpine-pkg-glibc#please-note