### PR TITLE
Add `tini` back to mongodb image

### DIFF
--- a/images/mongo/Dockerfile
+++ b/images/mongo/Dockerfile
@@ -8,6 +8,7 @@ ENV LAGOON=mongo
 
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 
 # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
@@ -23,5 +24,5 @@ RUN mkdir -p /data/db /data/configdb && \
 VOLUME /data/db
 EXPOSE 27017 28017
 
-ENTRYPOINT ["/lagoon/entrypoints.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
 CMD [ "mongod", "--bind_ip", "0.0.0.0" ]


### PR DESCRIPTION
The revert from https://github.com/amazeeio/lagoon/commit/b55c0efdf784a323ef9b377f34e8e95ad209ba44 removed the addition of `tini` from https://github.com/amazeeio/lagoon/commit/e7f9994916608dbfcfb32c38160526232a4e192f and https://github.com/amazeeio/lagoon/commit/11fd551953e3fb0f482acfb928b172fb9dace327.

I'm assuming this was unintentional, so adding it back.