### PR TITLE
refactor deploymentconfig scaling:

### DIFF
--- a/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
@@ -3,19 +3,13 @@
 # if there is a deploymentconfig for the given service
 if [[ $(oc -n ${OPENSHIFT_PROJECT} get deploymentconfigs --no-headers=true -o name -l service=${SERVICE_NAME}| wc -l) -gt 0 ]]; then
   DEPLOYMENTCONFIG=$(oc -n ${OPENSHIFT_PROJECT} get deploymentconfigs -l service=${SERVICE_NAME} -o name)
-  # If the deploymentconfig is scaled to 0, scale to 1
-  if [[ $(oc -n ${OPENSHIFT_PROJECT} get ${DEPLOYMENTCONFIG} -o go-template --template='{{.status.replicas}}') == "0" ]]; then
-
-    # this command will fail until openshift 3.7.x
-    # https://github.com/openshift/origin/issues/17729
+  # check if deploymenconfig has at least 1 ready pod, if not, scale and check again in 3 secounds.
+  while [[ $(oc -n ${OPENSHIFT_PROJECT} get ${DEPLOYMENTCONFIG} -o go-template --template='{{.status.readyReplicas}}') = "<no value>" ]] || [[ $(oc -n ${OPENSHIFT_PROJECT} get ${DEPLOYMENTCONFIG} -o go-template --template='{{.status.readyReplicas}}') = "0" ]]
+  do
+    # Sending the scaling command while it already scaling is no problem for the Kubernetes API
     oc -n ${OPENSHIFT_PROJECT} scale --replicas=1 ${DEPLOYMENTCONFIG}
-
-    # wait until the scaling is done
-    while [[ ! $(oc -n ${OPENSHIFT_PROJECT} get ${DEPLOYMENTCONFIG} -o go-template --template='{{.status.readyReplicas}}') == "1" ]]
-    do
-      sleep 1
-    done
-  fi
+    sleep 3
+  done
 fi
 
 POD=$(oc -n ${OPENSHIFT_PROJECT} get pods -l service=${SERVICE_NAME} -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)


### PR DESCRIPTION
there was a chance for a race condition that the pod was still starting but not fully running.
chcking now for actual `readyReplicas` to be more resilient