### PR TITLE
Disable debug in build script.

### DIFF
--- a/images/oc-build-deploy-dind/docker-entrypoint.sh
+++ b/images/oc-build-deploy-dind/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -e
 
 if docker -H docker-host.lagoon.svc info &> /dev/null; then
     export DOCKER_HOST=docker-host.lagoon.svc


### PR DESCRIPTION
https://github.com/amazeeio/lagoon/pull/600 introduced an issue where the SSH key is output in build logs. Disabling debug flag will hide the `export` command.