### PR TITLE
Allow overriding default expires.

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -34,7 +34,7 @@ server {
     }
 
     ## Expiring per default for four weeks and one second, Drupal will overwrite that if necessary
-    expires 2628001s;
+    expires ${NGINX_DEFAULT_EXPIRES:-2628001s};
 
     ## Disallow access to any dot files, but send the request to Drupal
     location ~* /\. {


### PR DESCRIPTION
The expires config inside the 'default' location can be overridden without redefining the block.

This allows updating the default expiry time and still defaults to `2628001s`.