### PR TITLE
Fix updateProject query error when running as admin

### DIFF
--- a/services/api/src/dao/__snapshots__/project.test.js.snap
+++ b/services/api/src/dao/__snapshots__/project.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`Queries selectProject should create query 1`] = `"select * from \`project\` where \`id\` = '1'"`;
 
-exports[`Queries updateProject should return proper update statement 1`] = `"update \`project\` set \`name\` = 'test' where \`id\` = '1' and \`id\` in (1, 2, 3)"`;
+exports[`Queries updateProject should return proper update statement 1`] = `"update \`project\` set \`name\` = 'test' where \`id\` = '1'"`;

--- a/services/api/src/dao/project.js
+++ b/services/api/src/dao/project.js
@@ -11,13 +11,11 @@ const {
 
 // This contains the sql query generation logic
 const Sql = {
-  updateProject: (cred, input) => {
+  updateProject: (input) => {
     const { id, patch } = input;
-    const { projects } = cred.permissions;
 
     const ret = knex('project')
       .where('id', '=', id)
-      .whereIn('id', projects)
       .update(patch);
 
     return ret.toString();
@@ -83,10 +81,7 @@ const getProjectByEnvironmentId = ({ sqlClient }) => async (cred, eid) => {
       WHERE e.id = :eid
       ${ifNotAdmin(
     cred.role,
-    `AND (${inClauseOr([
-      ['p.customer', customers],
-      ['p.id', projects],
-    ])})`,
+    `AND (${inClauseOr([['p.customer', customers], ['p.id', projects]])})`,
   )}
       LIMIT 1
     `,
@@ -160,9 +155,7 @@ const addProject = ({ sqlClient }) => async (cred, input) => {
         ${input.subfolder ? ':subfolder' : 'NULL'},
         :openshift,
         ${
-  input.openshiftProjectPattern
-    ? ':openshift_project_pattern'
-    : 'NULL'
+  input.openshiftProjectPattern ? ':openshift_project_pattern' : 'NULL'
 },
         ${
   input.activeSystemsDeploy
@@ -225,7 +218,7 @@ const updateProject = ({ sqlClient }) => async (cred, input) => {
     throw new Error('input.patch requires at least 1 attribute');
   }
 
-  await query(sqlClient, Sql.updateProject(cred, input));
+  await query(sqlClient, Sql.updateProject(input));
   const rows = await query(sqlClient, Sql.selectProject(pid));
   const project = R.path([0], rows);
 

--- a/services/api/src/dao/project.test.js
+++ b/services/api/src/dao/project.test.js
@@ -3,19 +3,13 @@ const { Sql } = require('./project');
 describe('Queries', () => {
   describe('updateProject', () => {
     it('should return proper update statement', () => {
-      const cred = {
-        role: 'user',
-        permissions: {
-          projects: [1, 2, 3],
-        },
-      };
       const input = {
         id: '1',
         patch: {
           name: 'test',
         },
       };
-      const ret = Sql.updateProject(cred, input);
+      const ret = Sql.updateProject(input);
 
       expect(ret).toMatchSnapshot();
     });


### PR DESCRIPTION
When running `updateProject` graphql query as an admin, there are no projects in the credentials object which causes a SQL error. The `updateProject` function already has a non-SQL based check to verify the user has permission to edit the project and takes into account the admin credentials.

This removes duplicate auth check of projects in SQL query.