### PR TITLE
Fix auth errors when running `local-dev/es-kibana-watcher-pusher`

### DIFF
--- a/local-dev/es-kibana-watcher-pusher/Dockerfile
+++ b/local-dev/es-kibana-watcher-pusher/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.7
 
 RUN apk add --no-cache tini bash wget curl
 
-ENV KIBANA_HOST=logs-db-ui
+ENV KIBANA_HOST=logs-db-ui \
+    LOGSDB_KIBANASERVER_PASSWORD=kibanaserver \
+    LOGSDB_ADMIN_PASSWORD=admin
 
 COPY watch-push.sh /home/
 


### PR DESCRIPTION
When running the full stack locally, I would get `logs-db` auth errors and had difficulty viewing indexed data in kibana.

I traced the auth errors to a change in some scripts in `logs-db-ui` which added credential environment variables. These variables were not added to `local-dev/es-kibana-watcher-pusher` which uses the same scripts as `logs-db-ui` so it was failing.