### PR TITLE
Add setting for HSTS header policy to a route

### DIFF
--- a/docs/using_lagoon/lagoon_yml.md
+++ b/docs/using_lagoon/lagoon_yml.md
@@ -57,6 +57,7 @@ environments:
         - "www.example.com":
             tls-acme: 'true'
             insecure: Redirect
+            hsts: max-age=31536000
     cronjobs:
      - name: drush cron
        schedule: "H * * * *" # this will run the cron once per Hour
@@ -123,10 +124,11 @@ The simplest route is the `example.com` example above. This will assume that you
 In the `"www.example.com"` example, we see two more options (also see the `:` at the end of the route and that the route is wrapped in `"`, that's important!):
 
 * `tls-acme: 'true'` tells Lagoon to issue a Let's Encrypt certificate for that route, this is the default. If you don't like a Let's Encrypt set this to `tls-acme: 'false'`
-* `Insecure` can be set to `None`, `Allow` or `Redirect`.
+* `insecure` can be set to `None`, `Allow` or `Redirect`.
     * `Allow` simply sets up both routes for http and https (this is the default).
     * `Redirect` will redirect any http requests to https
     * `None` will mean a route for http will _not_ be created, and no redirect will take place
+* `hsts` can be set to a value of `max-age=31536000;includeSubDomains;preload`. Ensure there are no spaces and no other parameters included. Only `max-age` parameter is required. The required `max-age` parameter indicates the length of time, in seconds, the HSTS policy is in effect for.
 
 #### `environments.[name].cronjobs`
 As most of the time it is not desireable to run the same cronjobs across all environments, you must explicitely define which jobs you want to run for each environment.

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -291,11 +291,13 @@ while [ -n "$(cat .lagoon.yml | shyaml keys environments.${BRANCH//./\\.}.routes
       ROUTE_DOMAIN_ESCAPED=$(cat .lagoon.yml | shyaml keys environments.${BRANCH//./\\.}.routes.$ROUTES_SERVICE_COUNTER.$ROUTES_SERVICE.$ROUTE_DOMAIN_COUNTER | sed 's/\./\\./g')
       ROUTE_TLS_ACME=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.routes.$ROUTES_SERVICE_COUNTER.$ROUTES_SERVICE.$ROUTE_DOMAIN_COUNTER.$ROUTE_DOMAIN_ESCAPED.tls-acme true)
       ROUTE_INSECURE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.routes.$ROUTES_SERVICE_COUNTER.$ROUTES_SERVICE.$ROUTE_DOMAIN_COUNTER.$ROUTE_DOMAIN_ESCAPED.insecure Redirect)
+      ROUTE_HSTS=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.routes.$ROUTES_SERVICE_COUNTER.$ROUTES_SERVICE.$ROUTE_DOMAIN_COUNTER.$ROUTE_DOMAIN_ESCAPED.hsts null)
     else
       # Only a value given, assuming some defaults
       ROUTE_DOMAIN=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.routes.$ROUTES_SERVICE_COUNTER.$ROUTES_SERVICE.$ROUTE_DOMAIN_COUNTER)
       ROUTE_TLS_ACME=true
       ROUTE_INSECURE=Redirect
+      ROUTE_HSTS=null
     fi
 
     # The very first found route is set as MAIN_CUSTOM_ROUTE

--- a/images/oc-build-deploy-dind/openshift-templates/route.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/route.yml
@@ -34,12 +34,16 @@ parameters:
   - name: ROUTE_INSECURE
     description: Setting of insecureEdgeTerminationPolicy
     required: true
+  - name: ROUTE_HSTS
+    description: Setting of HTTP Strict Transport Security policy
+    required: true
 objects:
 - apiVersion: v1
   kind: Route
   metadata:
     annotations:
       haproxy.router.openshift.io/disable_cookies: 'true'
+      haproxy.router.openshift.io/hsts_header: '${ROUTE_HSTS}'
       kubernetes.io/tls-acme: '${ROUTE_TLS_ACME}'
     creationTimestamp: null
     labels:

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-create-route.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-create-route.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+
 if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get route "$ROUTE_DOMAIN" &> /dev/null; then
-  oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} patch route "$ROUTE_DOMAIN" -p "{\"metadata\":{\"annotations\":{\"kubernetes.io/tls-acme\":\"${ROUTE_TLS_ACME}\"}},\"spec\":{\"to\":{\"name\":\"${ROUTE_SERVICE}\"},\"tls\":{\"insecureEdgeTerminationPolicy\":\"${ROUTE_INSECURE}\"}}}"
+  oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} patch route "$ROUTE_DOMAIN" -p "{\"metadata\":{\"annotations\":{\"kubernetes.io/tls-acme\":\"${ROUTE_TLS_ACME}\",\"haproxy.router.openshift.io/hsts_header\":\"${ROUTE_HSTS}\"}},\"spec\":{\"to\":{\"name\":\"${ROUTE_SERVICE}\"},\"tls\":{\"insecureEdgeTerminationPolicy\":\"${ROUTE_INSECURE}\"}}}"
 else
   oc process  --local -o yaml --insecure-skip-tls-verify \
     -n ${OPENSHIFT_PROJECT} \
@@ -16,5 +17,6 @@ else
     -p ROUTE_SERVICE="${ROUTE_SERVICE}" \
     -p ROUTE_TLS_ACME="${ROUTE_TLS_ACME}" \
     -p ROUTE_INSECURE="${ROUTE_INSECURE}" \
+    -p ROUTE_HSTS="${ROUTE_HSTS}" \
     | outputToYaml
 fi

--- a/tests/checks/check-url-header-absent.yaml
+++ b/tests/checks/check-url-header-absent.yaml
@@ -1,0 +1,9 @@
+---
+- name: "{{ testname }} - Check if URL {{url}} returns without Header set to {{expected_header}}"
+  uri:
+    url: "{{ url }}"
+    validate_certs: no
+    HEADER_Host: "{{ host }}"
+  register: result
+  failed_when: result.{{expected_header}} is defined
+- debug: msg="Success!!!"

--- a/tests/checks/check-url-header.yaml
+++ b/tests/checks/check-url-header.yaml
@@ -1,0 +1,12 @@
+---
+- name: "{{ testname }} - Check if URL {{url}} returns with Header set to {{expected_header}} with value of '{{expected_header_value}}'"
+  uri:
+    url: "{{ url }}"
+    validate_certs: no
+    HEADER_Host: "{{ host }}"
+  register: result
+  until: result.{{expected_header}} is defined
+  failed_when: result.{{expected_header}} != '{{expected_header_value}}'
+  retries: 20
+  delay: 10
+- debug: msg="Success!!!"

--- a/tests/files/nginx/first/.lagoon.yml
+++ b/tests/files/nginx/first/.lagoon.yml
@@ -11,5 +11,8 @@ environments:
       - insecure-none.com:
           insecure: None
       - moving-route.com
+      - hsts-header.com:
+          hsts: max-age=15768000
+      - hsts-header-null.com
     - nginx-basic-auth:
       - nginx-basic-auth.com

--- a/tests/files/nginx/second/.lagoon.yml
+++ b/tests/files/nginx/second/.lagoon.yml
@@ -17,6 +17,9 @@ environments:
       - insecure-none.com:
           tls-acme: 'false'
           insecure: Allow
+      - hsts-header.com
+      - hsts-header-null.com:
+          hsts: max-age=15768000
     - nginx-basic-auth:
       - nginx-basic-auth.com
       - moving-route.com

--- a/tests/tests/nginx/check-first.yaml
+++ b/tests/tests/nginx/check-first.yaml
@@ -87,6 +87,29 @@
   tasks:
   - include: ../../checks/check-url-content-host.yaml
 
+- name: "{{ testname }} - check if custom domain 'hsts-header.com' is created and has HSTS header set"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "https://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    host: "hsts-header.com"
+    expected_returncode: 200
+    expected_header: "strict_transport_security"
+    expected_header_value: "max-age=15768000"
+  tasks:
+  - include: ../../checks/check-url-header.yaml
+
+- name: "{{ testname }} - check if custom domain 'hsts-header-null.com' is created and does not have HSTS header set"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "https://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    host: "hsts-header-null.com"
+    expected_returncode: 200
+    expected_header: "strict_transport_security"
+  tasks:
+  - include: ../../checks/check-url-header-absent.yaml
+
 - name: "{{ testname }} - check if {{ project }} is redirecting correctly with no preserve'"
   hosts: localhost
   serial: 1

--- a/tests/tests/nginx/check-second.yaml
+++ b/tests/tests/nginx/check-second.yaml
@@ -56,3 +56,26 @@
     expected_returncode: 401
   tasks:
   - include: ../../checks/check-url-returncode-host.yaml
+
+- name: "{{ testname }} - SECOND TEST: check if custom domain 'hsts-header-null.com' now has HSTS header set"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "https://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    host: "hsts-header-null.com"
+    expected_returncode: 200
+    expected_header: "strict_transport_security"
+    expected_header_value: "max-age=15768000"
+  tasks:
+  - include: ../../checks/check-url-header.yaml
+
+- name: "{{ testname }} - SECOND TEST: check if custom domain 'hsts-header.com' is created and does not have HSTS header set"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "https://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    host: "hsts-header.com"
+    expected_returncode: 200
+    expected_header: "strict_transport_security"
+  tasks:
+  - include: ../../checks/check-url-header-absent.yaml


### PR DESCRIPTION
Adds "hsts" key for a route which tells Lagoon to create an appropriate
annotation on that route with the supplied to the key options. Which in
turn will enable and distribute HSTS header for that route.

More info:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
https://docs.openshift.com/dedicated/admin_guide/managing_networking.html#admin-guide-enabling-hsts