### PR TITLE
Updated lagoon/docs/developing_lagoon/index.md docker version requirement

### DIFF
--- a/docs/developing_lagoon/index.md
+++ b/docs/developing_lagoon/index.md
@@ -1,6 +1,6 @@
 # Development of Lagoon
 
-Development of Lagoon happens locally via Docker. We are using the new [Docker Multi Stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) very heavily, so it requires at least Docker Version 17.05.
+Development of Lagoon happens locally via Docker. We are using the new [Docker Multi Stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) very heavily, so it requires at least Docker Version 17.06.1.
 
 ## Install Docker
 


### PR DESCRIPTION
Docker version 17.05 was made obsolete and removed from the official Cent Os repository: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/

Version 17.06.0 has a few builder bugs that are fixed in 17.06.1, and that should be the minimal recommended release:
https://docs.docker.com/v17.12/release-notes/docker-ce/#17061-ce-2017-08-15