### PR TITLE
Ensure bytes are returned from du

### DIFF
--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -102,7 +102,7 @@ do
 
       for PVC in "${PVCS[@]}"
       do
-        STORAGE_BYTES=$(${OC} exec ${POD} -- sh -c "du -s /storage/${PVC} | cut -f1")
+        STORAGE_BYTES=$(${OC} exec ${POD} -- sh -c "du -sb /storage/${PVC} | cut -f1")
         # STORAGE_BYTES=$(echo "${DF}" | grep /storage/${PVC} | awk '{ print $4 }')
         echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: ${PVC} uses ${STORAGE_BYTES} bytes"
 


### PR DESCRIPTION
Adding `-b` to ensure bytes are returned from `du` as the storage unit.