### PR TITLE
Send msgs to slack/rocketchat when rest2tasks:promote is called

### DIFF
--- a/services/logs2rocketchat/src/readFromRabbitMQ.js
+++ b/services/logs2rocketchat/src/readFromRabbitMQ.js
@@ -59,6 +59,7 @@ async function readFromRabbitMQ (msg: RabbitMQMsg, channelWrapperLogs: ChannelWr
     case "gitlab:push:handled":
     case "rest:deploy:receive":
     case "rest:remove:receive":
+    case "rest:promote:receive":
       sendToRocketChat(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
       break;
 

--- a/services/logs2slack/src/readFromRabbitMQ.js
+++ b/services/logs2slack/src/readFromRabbitMQ.js
@@ -61,6 +61,7 @@ async function readFromRabbitMQ (msg: RabbitMQMsg, channelWrapperLogs: ChannelWr
     case "gitlab:merge_request:closed:handled":
     case "rest:deploy:receive":
     case "rest:remove:receive":
+    case "rest:promote:receive":
     case "github:push:skipped":
     case "gitlab:push:skipped":
     case "bitbucket:push:skipped":


### PR DESCRIPTION
Fixes #510 