### PR TITLE
add restic backup support:

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -362,6 +362,20 @@ else
   done
 fi
 
+# If restic backups are supported by this cluster we create the schedule definition
+if oc apply --insecure-skip-tls-verify customresourcedefinition schedules.backup.appuio.ch > /dev/null; then
+  TEMPLATE_PARAMETERS=()
+
+  BACKUP_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "H 0 * * *")
+  TEMPLATE_PARAMETERS+=(-p BACKUP_SCHEDULE="${BACKUP_SCHEDULE}")
+
+  PRUNE_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "H 3 * * *")
+  TEMPLATE_PARAMETERS+=(-p PRUNE_SCHEDULE="${PRUNE_SCHEDULE}")
+
+  OPENSHIFT_TEMPLATE="/oc-build-deploy/openshift-templates/backup/schedule.yml"
+  .  /oc-build-deploy/scripts/exec-openshift-resources.sh
+fi
+
 if [ -f /oc-build-deploy/lagoon/${YAML_CONFIG_FILE}.yml ]; then
   oc apply --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} -f /oc-build-deploy/lagoon/${YAML_CONFIG_FILE}.yml
 fi
@@ -594,7 +608,7 @@ do
   OPENSHIFT_SERVICES_TEMPLATE="/oc-build-deploy/openshift-templates/${SERVICE_TYPE}/pvc.yml"
   if [ -f $OPENSHIFT_SERVICES_TEMPLATE ]; then
     OPENSHIFT_TEMPLATE=$OPENSHIFT_SERVICES_TEMPLATE
-    .  /oc-build-deploy/scripts/exec-openshift-create-pvc.sh
+    . /oc-build-deploy/scripts/exec-openshift-resources.sh
   fi
 
   CRONJOB_COUNTER=0

--- a/images/oc-build-deploy-dind/openshift-templates/backup/schedule.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/backup/schedule.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Template
 metadata:
   creationTimestamp: null
-  name: lagoon-openshift-template-solr
+  name: lagoon-openshift-template-schedule
 parameters:
   - name: SERVICE_NAME
     description: Name of this service
@@ -31,22 +31,25 @@ parameters:
   - name: REGISTRY
     description: Registry where Images are pushed to
     required: true
-  - name: DEPLOYMENT_STRATEGY
-    description: Strategy of Deploymentconfig
-    value: "Rolling"
-  - name: PERSISTENT_STORAGE_SIZE
-    description: Size of the Storage to request
-    value: "1Gi"
+  - name: BACKUP_SCHEDULE
+    description: Schedule of the Backup in Cron format
+    required: true
+  - name: PRUNE_SCHEDULE
+    description: Schedule of the Pruning in Cron format
+    required: true
 objects:
-- apiVersion: v1
-  kind: PersistentVolumeClaim
+- apiVersion: backup.appuio.ch/v1alpha1
+  kind: Schedule
   metadata:
-    annotations:
-      appuio.ch/backup: "true"
-    name: ${SERVICE_NAME}
+    name: backup-schedule
   spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${PERSISTENT_STORAGE_SIZE}
+    backup:
+      keepJobs: 2
+      schedule: '${BACKUP_SCHEDULE}'
+    check:
+      schedule: 0 0 * * 0
+    prune:
+      retention:
+        keepDaily: 7
+        keepWeekly: 4
+      schedule: '${PRUNE_SCHEDULE}'

--- a/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
@@ -72,6 +72,10 @@ objects:
         type: ${DEPLOYMENT_STRATEGY}
       template:
         metadata:
+          annotations:
+            appuio.ch/backupcommand: >-
+              mysqldump --all-databases -h $MARIADB_HOST -u $MARIADB_USERNAME
+              -p$MARIADB_PASSWORD
           creationTimestamp: null
           labels:
             service: ${SERVICE_NAME}

--- a/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
@@ -58,6 +58,10 @@ objects:
         type: ${DEPLOYMENT_STRATEGY}
       template:
         metadata:
+          annotations:
+            appuio.ch/backupcommand: >-
+              mysqldump --all-databases -h $MARIADB_HOST -u $MARIADB_USERNAME
+              -p$MARIADB_PASSWORD
           creationTimestamp: null
           labels:
             service: ${SERVICE_NAME}

--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/pvc.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/pvc.yml
@@ -47,6 +47,8 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
+    annotations:
+      appuio.ch/backup: "true"
     name: ${SERVICE_NAME}
   spec:
     accessModes:

--- a/images/oc-build-deploy-dind/openshift-templates/node-persistent/pvc.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/node-persistent/pvc.yml
@@ -47,6 +47,8 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
+    annotations:
+      appuio.ch/backup: "true"
     name: ${SERVICE_NAME}
   spec:
     accessModes:

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-create-pvc.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-create-pvc.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Only generate PVC if it does not exist yet
-if ! oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get pvc "$SERVICE_NAME" &> /dev/null; then
-    . /oc-build-deploy/scripts/exec-openshift-resources.sh
-fi


### PR DESCRIPTION
- create crd Schedule: backup-schedule if supported by cluster
- add annotations to PVCs
- always apply PVCs even if they already exist (never worked with mariadb-data anyway and is needed for the new annotations)
- support for mysql dumps via CLI