### PR TITLE
Add specific task mutations to the api

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -568,6 +568,26 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
+CREATE OR REPLACE PROCEDURE
+  convert_task_command_to_text()
+
+  BEGIN
+    DECLARE column_type varchar(50);
+
+    SELECT DATA_TYPE INTO column_type
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE
+      table_name = 'task'
+      AND table_schema = 'infrastructure'
+      AND column_name = 'command';
+
+    IF (column_type = 'varchar') THEN
+      ALTER TABLE task
+      MODIFY command text NOT NULL;
+    END IF;
+  END;
+$$
+
 DELIMITER ;
 
 CALL add_production_environment_to_project();
@@ -597,6 +617,7 @@ CALL add_active_systems_task_to_project();
 CALL add_default_value_to_task_status();
 CALL add_scope_to_env_vars();
 CALL add_deleted_to_environment_backup();
+CALL convert_task_command_to_text();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -27,6 +27,9 @@ const {
   addTask,
   deleteTask,
   updateTask,
+  taskDrushArchiveDump,
+  taskDrushSqlSync,
+  taskDrushRsyncFiles,
 } = require('./resources/task/resolvers');
 
 const {
@@ -257,6 +260,9 @@ const resolvers /* : { [string]: ResolversObj | typeof GraphQLDate } */ = {
     addEnvVariable,
     deleteEnvVariable,
     addTask,
+    taskDrushArchiveDump,
+    taskDrushSqlSync,
+    taskDrushRsyncFiles,
     deleteTask,
     updateTask,
     setEnvironmentServices,

--- a/services/api/src/resources/environment/helpers.js
+++ b/services/api/src/resources/environment/helpers.js
@@ -1,0 +1,15 @@
+// @flow
+
+const R = require('ramda');
+const sqlClient = require('../../clients/sqlClient');
+const { query } = require('../../util/db');
+const Sql = require('./sql');
+
+const Helpers = {
+  getEnvironmentById: async (environmentID /* : number */) => {
+    const rows = await query(sqlClient, Sql.selectEnvironmentById(environmentID));
+    return R.prop(0, rows);
+  },
+};
+
+module.exports = Helpers;

--- a/services/api/src/resources/environment/validators.js
+++ b/services/api/src/resources/environment/validators.js
@@ -1,0 +1,72 @@
+// @flow
+
+const R = require('ramda');
+const { prepare, query } = require('../../util/db');
+const sqlClient = require('../../clients/sqlClient');
+const Sql = require('./sql');
+
+const Validators = {
+  environmentExists: async (environmentId /* : number */) => {
+    const env = await query(
+      sqlClient,
+      Sql.selectEnvironmentById(environmentId),
+    );
+
+    if (R.has('info', env)) {
+      throw new Error(`Environment ID ${environmentId} doesn't exist.`);
+    }
+  },
+  environmentsHaveSameProject: async (environmentIds /* : number[] */) => {
+    const preparedQuery = prepare(
+      sqlClient,
+      `
+      SELECT DISTINCT project FROM environment WHERE id in (?)
+    `,
+    );
+
+    const rows = await query(sqlClient, preparedQuery([environmentIds]));
+    const projectIds = R.pluck('project', rows);
+
+    if (R.length(R.uniq(projectIds)) > 1) {
+      throw new Error(
+        `Environments ${environmentIds.join(
+          ',',
+        )} do not belong to the same project.`,
+      );
+    }
+  },
+  environmentHasService: async (environmentId /* : number */, service /* : string */) => {
+    const rows = await query(sqlClient, Sql.selectServicesByEnvironmentId(environmentId));
+
+    if (!R.contains(service, R.pluck('name', rows))) {
+      throw new Error(`Environment ${environmentId} has no service ${service}`);
+    }
+  },
+  userAccessEnvironment: async (
+    credentials /* : Object */,
+    environmentId /* : number */,
+  ) => {
+    const {
+      role,
+      permissions: { customers, projects },
+    } = credentials;
+
+    if (role === 'admin') {
+      return;
+    }
+
+    const rows = await query(
+      sqlClient,
+      Sql.selectPermsForEnvironment(environmentId),
+    );
+
+    if (
+      !R.contains(R.path(['0', 'pid'], rows), projects) &&
+      !R.contains(R.path(['0', 'cid'], rows), customers)
+    ) {
+      throw new Error(`No access to environment ${environmentId}.`);
+    }
+  },
+};
+
+module.exports = Validators;

--- a/services/api/src/resources/task/helpers.js
+++ b/services/api/src/resources/task/helpers.js
@@ -1,0 +1,111 @@
+// @flow
+
+const R = require('ramda');
+const { sendToLagoonLogs } = require('@lagoon/commons/src/logs');
+const { createTaskTask } = require('@lagoon/commons/src/tasks');
+const { query } = require('../../util/db');
+const sqlClient = require('../../clients/sqlClient');
+const esClient = require('../../clients/esClient');
+const Sql = require('./sql');
+const projectSql = require('../project/sql');
+const environmentSql = require('../environment/sql');
+
+const Helpers = {
+  addTask: async ({
+    id,
+    name,
+    status,
+    created,
+    started,
+    completed,
+    environment,
+    service,
+    command,
+    remoteId,
+    execute,
+  } /* : { id?: number, name: string, status?: string, created?: string, started?: string, completed?: string, environment: number, service: string, command: string, remoteId?: string, execute: boolean } */) => {
+    const {
+      info: { insertId },
+    } = await query(
+      sqlClient,
+      Sql.insertTask({
+        id,
+        name,
+        status,
+        created,
+        started,
+        completed,
+        environment,
+        service,
+        command,
+        remoteId,
+      }),
+    );
+
+    let rows = await query(sqlClient, Sql.selectTask(insertId));
+    const taskData = R.prop(0, rows);
+
+    // Allow creating task data w/o executing the task
+    if (execute === false) {
+      return taskData;
+    }
+
+    rows = await query(sqlClient, environmentSql.selectEnvironmentById(taskData.environment));
+    const environmentData = R.prop(0, rows);
+
+    rows = await query(sqlClient, projectSql.selectProject(environmentData.project));
+    const projectData = R.prop(0, rows);
+
+    try {
+      await createTaskTask({ task: taskData, project: projectData, environment: environmentData });
+    } catch (error) {
+      sendToLagoonLogs(
+        'error',
+        projectData.name,
+        '',
+        'api:addTask',
+        { taskId: taskData.id },
+        `*[${projectData.name}]* Task not initiated, reason: ${error}`,
+      );
+    }
+
+    return taskData;
+  },
+  injectLogs: async (task /* : Object */) => {
+    if (!task.remoteId) {
+      return {
+        ...task,
+        logs: null,
+      };
+    }
+
+    const result = await esClient.search({
+      index: 'lagoon-logs-*',
+      sort: '@timestamp:desc',
+      body: {
+        query: {
+          bool: {
+            must: [
+              { match_phrase: { 'meta.remoteId': task.remoteId } },
+              { match_phrase: { 'meta.jobStatus': task.status } },
+            ],
+          },
+        },
+      },
+    });
+
+    if (!result.hits.total) {
+      return {
+        ...task,
+        logs: null,
+      };
+    }
+
+    return {
+      ...task,
+      logs: R.path(['hits', 'hits', 0, '_source', 'message'], result),
+    };
+  },
+};
+
+module.exports = Helpers;

--- a/services/api/src/resources/task/resolvers.js
+++ b/services/api/src/resources/task/resolvers.js
@@ -1,9 +1,6 @@
 // @flow
 
 const R = require('ramda');
-const { sendToLagoonLogs } = require('@lagoon/commons/src/logs');
-const { createTaskTask } = require('@lagoon/commons/src/tasks');
-const esClient = require('../../clients/esClient');
 const sqlClient = require('../../clients/sqlClient');
 const {
   knex,
@@ -14,8 +11,9 @@ const {
   isPatchEmpty,
 } = require('../../util/db');
 const Sql = require('./sql');
-const projectSql = require('../project/sql');
-const environmentSql = require('../environment/sql');
+const Helpers = require('./helpers');
+const environmentHelpers = require('../environment/helpers');
+const envValidators = require('../environment/validators');
 
 /* ::
 
@@ -29,42 +27,6 @@ const taskStatusTypeToString = R.cond([
   [R.equals('FAILED'), R.toLower],
   [R.T, R.identity],
 ]);
-
-const injectLogs = async task => {
-  if (!task.remoteId) {
-    return {
-      ...task,
-      logs: null,
-    };
-  }
-
-  const result = await esClient.search({
-    index: 'lagoon-logs-*',
-    sort: '@timestamp:desc',
-    body: {
-      query: {
-        bool: {
-          must: [
-            { match_phrase: { 'meta.remoteId': task.remoteId } },
-            { match_phrase: { 'meta.jobStatus': task.status } },
-          ],
-        },
-      },
-    },
-  });
-
-  if (!result.hits.total) {
-    return {
-      ...task,
-      logs: null,
-    };
-  }
-
-  return {
-    ...task,
-    logs: R.path(['hits', 'hits', 0, '_source', 'message'], result),
-  };
-};
 
 const getTasksByEnvironmentId = async (
   { id: eid },
@@ -93,7 +55,7 @@ const getTasksByEnvironmentId = async (
 
   const rows = await query(sqlClient, prep({ eid }));
 
-  return rows.map(row => injectLogs(row));
+  return rows.map(row => Helpers.injectLogs(row));
 };
 
 const getTaskByRemoteId = async (
@@ -128,7 +90,7 @@ const getTaskByRemoteId = async (
     }
   }
 
-  return injectLogs(task);
+  return Helpers.injectLogs(task);
 };
 
 const addTask = async (
@@ -145,78 +107,37 @@ const addTask = async (
       service,
       command,
       remoteId,
-      execute,
+      execute: executeRequest,
     },
   },
   {
+    credentials,
     credentials: {
       role,
-      permissions: { customers, projects },
     },
   },
 ) => {
   const status = taskStatusTypeToString(unformattedStatus);
+  const execute = role === 'admin' ? executeRequest : true;
 
-  if (role !== 'admin') {
-    const rows = await query(
-      sqlClient,
-      Sql.selectPermsForEnvironment(environment),
-    );
+  await envValidators.environmentExists(environment);
+  await envValidators.userAccessEnvironment(credentials, environment);
 
-    if (
-      !R.contains(R.path(['0', 'pid'], rows), projects) &&
-      !R.contains(R.path(['0', 'cid'], rows), customers)
-    ) {
-      throw new Error('Unauthorized.');
-    }
-  }
+  const taskData = await Helpers.addTask({
+    id,
+    name,
+    status,
+    created,
+    started,
+    completed,
+    environment,
+    service,
+    command,
+    remoteId,
+    execute,
+  });
 
-  const {
-    info: { insertId },
-  } = await query(
-    sqlClient,
-    Sql.insertTask({
-      id,
-      name,
-      status,
-      created,
-      started,
-      completed,
-      environment,
-      service,
-      command,
-      remoteId,
-    }),
-  );
-
-  let rows = await query(sqlClient, Sql.selectTask(insertId));
-  const taskData = R.prop(0, rows);
-
-  // Allow creating task data w/o executing the task
-  if (role === 'admin' && execute === false) {
-    return injectLogs(taskData);
-  }
-
-  rows = await query(sqlClient, environmentSql.selectEnvironmentById(taskData.environment));
-  const environmentData = R.prop(0, rows);
-
-  rows = await query(sqlClient, projectSql.selectProject(environmentData.project));
-  const projectData = R.prop(0, rows);
-
-  try {
-    await createTaskTask({ task: taskData, project: projectData, environment: environmentData });
-  } catch (error) {
-    sendToLagoonLogs(
-      'error',
-      projectData.name,
-      '',
-      'api:addTask',
-      { taskId: taskData.id },
-      `*[${projectData.name}]* Task not initiated, reason: ${error}`,
-    );
-  }
-
-  return injectLogs(taskData);
+  return Helpers.injectLogs(taskData);
 };
 
 const deleteTask = async (
@@ -265,6 +186,7 @@ const updateTask = async (
     },
   },
   {
+    credentials,
     credentials: {
       role,
       permissions: { customers, projects },
@@ -273,8 +195,8 @@ const updateTask = async (
 ) => {
   const status = taskStatusTypeToString(unformattedStatus);
 
+  // Check access to modify task as it currently stands
   if (role !== 'admin') {
-    // Check access to modify task as it currently stands
     const rowsCurrent = await query(sqlClient, Sql.selectPermsForTask(id));
 
     if (
@@ -283,20 +205,10 @@ const updateTask = async (
     ) {
       throw new Error('Unauthorized.');
     }
-
-    // Check access to modify task as it will be updated
-    const rowsNew = await query(
-      sqlClient,
-      Sql.selectPermsForEnvironment(environment),
-    );
-
-    if (
-      !R.contains(R.path(['0', 'pid'], rowsNew), projects) &&
-      !R.contains(R.path(['0', 'cid'], rowsNew), customers)
-    ) {
-      throw new Error('Unauthorized.');
-    }
   }
+
+  // Check access to modify task as it will be updated
+  await envValidators.userAccessEnvironment(credentials, environment);
 
   if (isPatchEmpty({ patch })) {
     throw new Error('Input patch requires at least 1 attribute');
@@ -322,7 +234,93 @@ const updateTask = async (
 
   const rows = await query(sqlClient, Sql.selectTask(id));
 
-  return injectLogs(R.prop(0, rows));
+  return Helpers.injectLogs(R.prop(0, rows));
+};
+
+const taskDrushArchiveDump = async (
+  root,
+  {
+    environment,
+  },
+  {
+    credentials,
+  },
+) => {
+  await envValidators.environmentExists(environment);
+  await envValidators.userAccessEnvironment(credentials, environment);
+  await envValidators.environmentHasService(environment, 'cli');
+
+  const taskData = await Helpers.addTask({
+    name: 'Drush archive-dump',
+    environment,
+    service: 'cli',
+    command: 'drush archive-dump',
+    execute: true,
+  });
+
+  return Helpers.injectLogs(taskData);
+};
+
+const taskDrushSqlSync = async (
+  root,
+  {
+    sourceEnvironment: sourceEnvironmentId,
+    destinationEnvironment: destinationEnvironmentId,
+  },
+  {
+    credentials,
+  },
+) => {
+  await envValidators.environmentExists(sourceEnvironmentId);
+  await envValidators.environmentExists(destinationEnvironmentId);
+  await envValidators.environmentsHaveSameProject([sourceEnvironmentId, destinationEnvironmentId]);
+  await envValidators.userAccessEnvironment(credentials, sourceEnvironmentId);
+  await envValidators.userAccessEnvironment(credentials, destinationEnvironmentId);
+  await envValidators.environmentHasService(sourceEnvironmentId, 'cli');
+
+  const sourceEnvironment = await environmentHelpers.getEnvironmentById(sourceEnvironmentId);
+  const destinationEnvironment = await environmentHelpers.getEnvironmentById(destinationEnvironmentId);
+
+  const taskData = await Helpers.addTask({
+    name: `Sync DB ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
+    environment: destinationEnvironmentId,
+    service: 'cli',
+    command: `drush -y sql-sync @${sourceEnvironment.name} @self`,
+    execute: true,
+  });
+
+  return Helpers.injectLogs(taskData);
+};
+
+const taskDrushRsyncFiles = async (
+  root,
+  {
+    sourceEnvironment: sourceEnvironmentId,
+    destinationEnvironment: destinationEnvironmentId,
+  },
+  {
+    credentials,
+  },
+) => {
+  await envValidators.environmentExists(sourceEnvironmentId);
+  await envValidators.environmentExists(destinationEnvironmentId);
+  await envValidators.environmentsHaveSameProject([sourceEnvironmentId, destinationEnvironmentId]);
+  await envValidators.userAccessEnvironment(credentials, sourceEnvironmentId);
+  await envValidators.userAccessEnvironment(credentials, destinationEnvironmentId);
+  await envValidators.environmentHasService(sourceEnvironmentId, 'cli');
+
+  const sourceEnvironment = await environmentHelpers.getEnvironmentById(sourceEnvironmentId);
+  const destinationEnvironment = await environmentHelpers.getEnvironmentById(destinationEnvironmentId);
+
+  const taskData = await Helpers.addTask({
+    name: `Sync files ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
+    environment: destinationEnvironmentId,
+    service: 'cli',
+    command: `drush -y rsync @${sourceEnvironment.name}:%files @self:%files`,
+    execute: true,
+  });
+
+  return Helpers.injectLogs(taskData);
 };
 
 const Resolvers /* : ResolversObj */ = {
@@ -331,6 +329,9 @@ const Resolvers /* : ResolversObj */ = {
   addTask,
   deleteTask,
   updateTask,
+  taskDrushArchiveDump,
+  taskDrushSqlSync,
+  taskDrushRsyncFiles,
 };
 
 module.exports = Resolvers;

--- a/services/api/src/resources/task/sql.js
+++ b/services/api/src/resources/task/sql.js
@@ -69,12 +69,6 @@ const Sql /* : SqlObj */ = {
       .join('project', 'environment.project', '=', 'project.id')
       .where('task.id', id)
       .toString(),
-  selectPermsForEnvironment: (id /* : number */) =>
-    knex('environment')
-      .select({ pid: 'project.id', cid: 'project.customer' })
-      .join('project', 'environment.project', '=', 'project.id')
-      .where('environment.id', id)
-      .toString(),
 };
 
 module.exports = Sql;

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -908,6 +908,15 @@ const typeDefs = gql`
     addEnvVariable(input: EnvVariableInput!): EnvKeyValue
     deleteEnvVariable(input: DeleteEnvVariableInput!): String
     addTask(input: TaskInput!): Task
+    taskDrushArchiveDump(environment: Int!): Task
+    taskDrushSqlSync(
+      sourceEnvironment: Int!
+      destinationEnvironment: Int!
+    ): Task
+    taskDrushRsyncFiles(
+      sourceEnvironment: Int!
+      destinationEnvironment: Int!
+    ): Task
     deleteTask(input: DeleteTaskInput!): String
     updateTask(input: UpdateTaskInput): Task
     setEnvironmentServices(input: SetEnvironmentServicesInput!): [EnvironmentService]

--- a/services/openshiftjobs/src/index.js
+++ b/services/openshiftjobs/src/index.js
@@ -158,7 +158,9 @@ const messageConsumer = async msg => {
       '/sbin/tini',
       '--',
       '/lagoon/entrypoints.sh',
-      ...task.command.split(' '),
+      '/bin/sh',
+      '-c',
+      task.command,
     ]);
 
     taskPodSpec = R.pipe(


### PR DESCRIPTION
Added three new mutations for specific tasks to support the UI and CLI. Inputs requirements are lowered and validated. The generic `addTask` is still available.

```graphql
mutation taskDrushArchiveDump {
  taskDrushArchiveDump(environment:9) {
    ...TaskFields 
  }
}

mutation taskDrushSqlSync {
  taskDrushSqlSync(sourceEnvironment:5, destinationEnvironment:6) {
    ...TaskFields
  }
}

mutation taskDrushRsyncFiles {
  taskDrushRsyncFiles(sourceEnvironment:1, destinationEnvironment:2) {
    ...TaskFields
  }
}

fragment TaskFields on Task {
  id
  name
  status
  command
  environment {
    name
  }
  service
  created
  started
  completed
  remoteId
  logs
}
```