### PR TITLE
handle hostnames longer than 64 characters

### DIFF
--- a/services/openshiftbuilddeploy/package.json
+++ b/services/openshiftbuilddeploy/package.json
@@ -19,6 +19,7 @@
     "es7-sleep": "^1.0.0",
     "flow-remove-types": "^1.2.1",
     "openshift-client": "^3.10.8",
+    "sha1" : "1.1.1",
     "ramda": "^0.25.0"
   },
   "devDependencies": {

--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -4,6 +4,7 @@ const Promise = require("bluebird");
 const OpenShiftClient = require('openshift-client');
 const sleep = require("es7-sleep");
 const R = require('ramda');
+const sha1 = require('sha1');
 const { logger } = require('@lagoon/commons/src/local-logging');
 const { getOpenShiftInfoForProject, addOrUpdateEnvironment, getEnvironmentByName, addDeployment } = require('@lagoon/commons/src/api');
 
@@ -40,6 +41,16 @@ const messageConsumer = async msg => {
   try {
     var safeBranchName = ocsafety(branchName)
     var safeProjectName = ocsafety(projectName)
+
+
+    var overlength = 58 - safeProjectName.length;
+    if ( safeBranchName.length > overlength ) {
+      var hash = sha1(safeBranchName).substring(0,4)
+
+      safeBranchName = safeBranchName.substring(0, overlength-5)
+      safeBranchName = safeBranchName.concat('-' + hash)
+    }
+
     var environmentType = branchName === projectOpenShift.productionEnvironment ? 'production' : 'development';
     var gitSha = sha
     var projectId = projectOpenShift.id

--- a/tests/tests/features.yaml
+++ b/tests/tests/features.yaml
@@ -42,6 +42,15 @@
     custom_domain1: "multiproject1.com"
     custom_domain2: "multiproject2.com"
 
+- include: features/openshift-limit.yaml
+  vars:
+    testname: "openshift-character-limit"
+    node_version: 8
+    git_repo_name: features.git
+    project: ci-features
+    branch: very-long-branch-name-what-would-otherwise-overflow-the-sixty-three-limit
+    # not going to try hashing something in yaml.
+    check_url: "http://node.ci-features.very-long-branch-name-what-would-otherwise-aae9.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
 - include: features/production-environment-protection.yaml
   vars:

--- a/tests/tests/features/openshift-limit.yaml
+++ b/tests/tests/features/openshift-limit.yaml
@@ -1,0 +1,25 @@
+---
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "features/"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - rest2tasks deploy of {{ project }}"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/rest/deploy-no-sha.yaml
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ current_head }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+    url: "{{ check_url }}"


### PR DESCRIPTION
this in effect shortens the branch name, which is used in openshift projects and dns names.

fixes #784 .

