### PR TITLE
Fix env_vars api delete error when not admin

### DIFF
--- a/services/api/src/resources/env-variables/sql.js
+++ b/services/api/src/resources/env-variables/sql.js
@@ -47,11 +47,11 @@ const Sql /* : SqlObj */ = {
       .del()
       .toString(),
   selectPermsForEnvVariable: (id /* : number */) =>
-    knex('ev')
+    knex('env_vars')
       .select({ pid: 'project.id', cid: 'project.customer' })
-      .leftJoin('environment', 'ev.environment', '=', 'environment.id')
-      .leftJoin('project', 'ev.project', '=', 'project.id')
-      .where('ev.id', id)
+      .leftJoin('environment', 'env_vars.environment', '=', 'environment.id')
+      .leftJoin('project', 'env_vars.project', '=', 'project.id')
+      .where('env_vars.id', id)
       .toString(),
   selectPermsForProject: (id /* : number */) =>
     knex('project')


### PR DESCRIPTION
Fixes this bug when running api queries as non-admin:

```
mutation deleteEnv{
  deleteEnvVariable(input: {id: 19})
}
```

return 

```
{
  "errors": [
    {
      "message": "Table 'infrastructure.ev' doesn't exist",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "deleteEnvVariable"
      ]
    }
  ],
  "data": {
    "deleteEnvVariable": null
  }
}
```