### PR TITLE
Unset environment variable nginx container health check

### DIFF
--- a/images/php/fpm/check_fcgi
+++ b/images/php/fpm/check_fcgi
@@ -1,8 +1,8 @@
 #!/bin/sh -v
 
-# cgi-fcgi has issues with very big environment variables.
-# LAGOON_ROUTES can get quite long in for lagoon projects with many routes, so we set it to zero (it's not used by cgi-fcgi)
-LAGOON_ROUTES=
+# cgi-fcgi has issues with non-standard environment variables.
+for i in $(env | awk -F"=" '{print $1}') ; do
+unset $i ; done
 
 # This script calls the /ping endpoing of the php-fpm, if the return code is 0, the php-fpm has correctly started
 SCRIPT_NAME=/${1:-ping} SCRIPT_FILENAME=/${1:-ping} REQUEST_METHOD=GET /usr/bin/cgi-fcgi -bind -connect 127.0.0.1:9000


### PR DESCRIPTION
This is an attempt to fix errors in the nginx health check script with the presence of long or custom environment variables, which are able to be added by anyone via the API.

I was not able to reproduce any of the originally reported errors with the script on my local minishift instance.