### PR TITLE
Explicitly invoke /lagoon/entrypoints.sh for pre/post rollout tasks

### DIFF
--- a/images/oc-build-deploy-dind/scripts/exec-pre-tasks-run.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-pre-tasks-run.sh
@@ -24,6 +24,7 @@ else
     CONTAINER_PARAMETER="-c ${CONTAINER}"
   fi
 
-  oc -n ${OPENSHIFT_PROJECT} exec ${POD} ${CONTAINER_PARAMETER} -i -- ${SHELL} -c "${COMMAND}"
+  # Container entrypoints aren't automatically invoked for `oc exec` or `oc rsh`
+  oc -n ${OPENSHIFT_PROJECT} exec ${POD} ${CONTAINER_PARAMETER} -i -- /lagoon/entrypoints.sh ${SHELL} -c "${COMMAND}"
 
 fi

--- a/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
@@ -25,4 +25,5 @@ else
   CONTAINER_PARAMETER="-c ${CONTAINER}"
 fi
 
-oc -n ${OPENSHIFT_PROJECT} exec ${POD} ${CONTAINER_PARAMETER} -i -- ${SHELL} -c "${COMMAND}"
+# Container entrypoints aren't automatically invoked for `oc exec` or `oc rsh`
+oc -n ${OPENSHIFT_PROJECT} exec ${POD} ${CONTAINER_PARAMETER} -i -- /lagoon/entrypoints.sh ${SHELL} -c "${COMMAND}"


### PR DESCRIPTION
Fixes #574 

According to some googling I did, running `oc exec` and `oc rsh` doesn't automatically invoke the container entrypoints.

This PR forces running `/lagoon/entrypoints.sh` for pre/post rollout tasks.