### PR TITLE
Removed references to docker.for.mac.localhost and ...

### DIFF
--- a/images/php/fpm/entrypoints/60-php-xdebug.sh
+++ b/images/php/fpm/entrypoints/60-php-xdebug.sh
@@ -2,18 +2,6 @@
 
 # Tries to find the Dockerhost
 get_dockerhost() {
-  # https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds
-  if busybox timeout -t 1 ping -c1 docker.for.mac.localhost &> /dev/null; then
-    echo "docker.for.mac.localhost"
-    return
-  fi
-
-  # https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-17060-win13-release-notes-2017-06-01-17060-rc1-ce-win13-edge
-  if busybox timeout -t 1 ping -c1 docker.for.win.localhost &> /dev/null; then
-    echo "docker.for.win.localhost"
-    return
-  fi
-
   # https://github.com/amazeeio/pygmy/blob/267ba143158548628f190f05ecb5cb2c19212038/lib/pygmy/resolv_osx.rb#L26
   if busybox timeout -t 1 ping -c1 172.16.172.16 &> /dev/null; then
     echo "172.16.172.16"
@@ -40,4 +28,3 @@ if [ ${XDEBUG_ENABLE+x} ]; then
   # Add the found remote_host to xdebug.ini
   echo -e "\n\nxdebug.remote_host=${DOCKERHOST}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
-


### PR DESCRIPTION
... docker.for.win.localhost which no longer work in docker.

According to https://github.com/docker/for-win/issues/1764 _docker.for.win.localhost_ is deprecated. Actually, _docker.for.win.localhost_, _docker.for.mac.localhost_ and _docker.for.linux.localhost_ are all valid domains and each resolves to ::1 in a container (linux, Docker version 18.09.0, build 4d60db4). This value is not valid for `xdebug.remote_host`.

`route -n | awk '/UG[ \t]/{print $2}'` has been verified to return the correct ip address of the host on mac, windows and linux (checked by @dan2k3k4, @VD39 and me respectively).