### PR TITLE
support for sftp access via lagoon remote shell,

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -192,6 +192,12 @@ services:
       - auth-server
     ports:
       - '2020:2020'
+    # command:
+    #   - "/usr/sbin/sshd"
+    #   - "-e"
+    #   - "-ddd"
+    #   - "-f"
+    #   - "/etc/ssh/sshd_config"
     environment:
       - OPENSHIFT_CONSOLE_URL=https://192.168.99.100:8443
     user: '111111111'

--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -19,7 +19,9 @@ RUN apk update \
         procps \
         coreutils \
         postgresql-client \
+        openssh-sftp-server \
     && apk add nodejs-current nodejs-npm yarn --update-cache --force-overwrite --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/1.6.5/composer.phar \
     && echo "67bebe9df9866a795078bb2cf21798d8b0214f2e0b2fd81f2e907a8ef0be3434 /usr/local/bin/composer" | sha256sum \

--- a/services/ssh/etc/ssh/sshd_config
+++ b/services/ssh/etc/ssh/sshd_config
@@ -37,3 +37,6 @@ Banner none
 
 ClientAliveInterval 60
 ClientAliveCountMax 1440 # max keepalive of 24h
+
+# This will allow sftp access
+Subsystem sftp sftp-server -u 0002


### PR DESCRIPTION
it's actually quite easy:
- `Subsystem sftp sftp-server -u 0002` defines that `sftp-server -u 0002` should be used as the sftp-server
- the remote shell system via `oc rsh` will still be used as it is a forced command