### PR TITLE
HOTFIX - only replace x-fwd-for if present

### DIFF
--- a/images/nginx/helpers/030_ipv6-xfwdfor.conf
+++ b/images/nginx/helpers/030_ipv6-xfwdfor.conf
@@ -1,11 +1,13 @@
 rewrite_by_lua_block {
   local xff = {}
-  for ip in string.gmatch(ngx.var.http_x_forwarded_for, '([^,]+)') do
-    if string.find(ip, "^::ffff:") then
-      table.insert(xff,string.match(ip, "^::ffff:(.*)"))
-    else
-      table.insert(xff,ip)
+  if ngx.var.http_x_forwarded_for then
+    for ip in string.gmatch(ngx.var.http_x_forwarded_for, '([^,]+)') do
+      if string.find(ip, "^::ffff:") then
+        table.insert(xff,string.match(ip, "^::ffff:(.*)"))
+      else
+        table.insert(xff,ip)
+      end
+      ngx.req.set_header("X-Forwarded-For", table.concat(xff, ","))
     end
-    ngx.req.set_header("X-Forwarded-For", table.concat(xff, ","))
   end
 }


### PR DESCRIPTION
Some users have reported an error relating to shit, appears to be the x-forwarded-for header is not set all the time.