### PR TITLE
Fix environment variables not present in environments with non-unique names

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
@@ -164,7 +164,8 @@ CREATE OR REPLACE PROCEDURE
       e.*
     FROM environment e
     WHERE e.name = name AND
-    deleted = '0000-00-00 00:00:00';
+    e.project = pid AND
+    e.deleted = '0000-00-00 00:00:00';
   END;
 $$
 


### PR DESCRIPTION
Fixes #831 

When running 'addOrUpdateEnvironment` api mutation, the stored procedure backend was not returning the correct environment.