### PR TITLE
Add docker-compose as dependency and fix broken links

### DIFF
--- a/docs/developing_lagoon/index.md
+++ b/docs/developing_lagoon/index.md
@@ -6,6 +6,10 @@ Development of Lagoon happens locally via Docker. We are using the new [Docker M
 
 Please check the [official Docs of Docker](https://docs.docker.com/engine/installation/) how to install Docker.
 
+## On Linux Install Docker Compose
+
+Docker compose is included in Docker for Mac installations.  For linux installations see the directions here: [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/).
+
 ## Start Services
 
 1. Add `192.168.99.0/24` to insecure registries in Docker (see [here](https://docs.docker.com/registry/insecure/) how to do that). Also make sure that you give your Docker Host minimum 4 CPUs and 4GB Ram.
@@ -41,7 +45,7 @@ make logs
 make tests
 ```
 
-6. Look what happens in OpenShift: [https://192.168.99.100:8443/console]() (developer/developer)
+6. Look what happens in OpenShift: [https://192.168.99.100:8443/console](https://192.168.99.100:8443/console) (developer/developer)
 
 ## Local Development
 
@@ -78,7 +82,7 @@ Some ISPs set up a "search domain" to catch domain name errors. Virtualbox will 
 into minishift which can cause domain resolution errors in the openshift pods. To check for this
 problem, look at the `/etc/resolv.conf` in your failing pod and check for errant search domains.
 
-![OpenShift pod resolver settings](/images/pod_search_domains.jpg)
+![OpenShift pod resolver settings](../images/pod_search_domains.jpg)
 
 To fix, you must remove the extra search domain. Login to the minishift vm (`minishift ssh`) and
 remove the setting from `/etc/resolv.conf`. Restart openshift docker, `sudo docker restart origin`.

--- a/docs/developing_lagoon/index.md
+++ b/docs/developing_lagoon/index.md
@@ -6,7 +6,7 @@ Development of Lagoon happens locally via Docker. We are using the new [Docker M
 
 Please check the [official Docs of Docker](https://docs.docker.com/engine/installation/) how to install Docker.
 
-## On Linux Install Docker Compose
+### On Linux Install Docker Compose
 
 Docker compose is included in Docker for Mac installations.  For linux installations see the directions here: [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/).
 
@@ -61,7 +61,7 @@ The services not only share many node packages, but also share actual custom cod
 
 The API uses a puppet compatible yaml format to store it's data. On production this hiera is in another git repository. For local development there is a folder `local-hiera` which contains testdata that is used during development and testing, plus has no client related data in them. For easier development there is `local-hiera-watcher-pusher` which watches the `local-hiera` folder and on every changes pushes the changes into `local-git-server` which emulates a git server like it is on production. The api service is connecting to this local git server and updates it's data from it.
 
-### Troubleshooting
+## Troubleshooting
 
 **I can't build any docker image for any Node.js based service**
 


### PR DESCRIPTION
## Purpose:
- Add docker-compose as dependency and fix broken links

## Changes:
- Adds a brief section describing that docker-compose is a dependency that will need to be installed on linux systems. (found this by running `make tests` and received failures)

- Fixes broken link to demo the console: https://lagoon.readthedocs.io/en/latest/developing_lagoon/#start-services

- Broken image link on github master: https://github.com/amazeeio/lagoon/blob/master/docs/developing_lagoon/index.md#troubleshooting

This change should allow the image to be loaded on both make docs and GH, compare to: https://lagoon.readthedocs.io/en/latest/developing_lagoon/#local-development

## Finished version:
- https://github.com/ccjjmartin/lagoon/blob/master/docs/developing_lagoon/index.md