### PR TITLE
Skip PR deployments if only the body has changed

### DIFF
--- a/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.js
+++ b/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.js
@@ -16,7 +16,14 @@ async function bitbucketPullRequestUpdated(webhook: WebhookRequestData, project:
       body,
     } = webhook;
 
-    console.log(body);
+    const meta = {
+      projectName: project.name,
+      pullrequestTitle: body.pullrequest.title,
+      pullrequestNumber: body.pullrequest.id,
+      pullrequestUrl: body.pullrequest.destination.repository.links.html.href,
+      repoName: body.repository.full_name,
+      repoUrl: body.repository.links.html.href,
+    }
 
     const headBranchName = body.pullrequest.source.branch.name
     const headSha = body.pullrequest.source.commit.hash
@@ -51,7 +58,7 @@ async function bitbucketPullRequestUpdated(webhook: WebhookRequestData, project:
         case "UnknownActiveSystem":
           // These are not real errors and also they will happen many times. We just log them locally but not throw an error
           sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
-            `*[${project.name}]* PR ${body.object_attributes.id} opened. No remove task created, reason: ${error}`
+            `*[${project.name}]* PR ${body.object_attributes.id} updated. No deploy task created, reason: ${error}`
           )
           return;
 

--- a/services/webhooks2tasks/src/handlers/githubPullRequestOpened.js
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestOpened.js
@@ -21,6 +21,14 @@ async function githubPullRequestOpened(webhook: WebhookRequestData, project: Pro
     const baseBranchName = body.pull_request.base.ref
     const baseSha = body.pull_request.base.sha
 
+    const meta = {
+      projectName: project.name,
+      pullrequestTitle: body.pull_request.title,
+      pullrequestNumber: body.number,
+      pullrequestUrl: body.pull_request.html_url,
+      repoName: body.repository.full_name,
+      repoUrl: body.repository.html_url,
+    }
 
     const data: deployData = {
       repoUrl: body.repository.html_url,
@@ -50,7 +58,7 @@ async function githubPullRequestOpened(webhook: WebhookRequestData, project: Pro
         case "UnknownActiveSystem":
           // These are not real errors and also they will happen many times. We just log them locally but not throw an error
           sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
-            `*[${project.name}]* PR ${body.number} opened. No remove task created, reason: ${error}`
+            `*[${project.name}]* PR ${body.number} opened. No deploy task created, reason: ${error}`
           )
           return;
 

--- a/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.js
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.js
@@ -27,9 +27,18 @@ async function githubPullRequestSynchronize(webhook: WebhookRequestData, project
       body,
     } = webhook;
 
+    const meta = {
+      projectName: project.name,
+      pullrequestTitle: body.pull_request.title,
+      pullrequestNumber: body.number,
+      pullrequestUrl: body.pull_request.html_url,
+      repoName: body.repository.full_name,
+      repoUrl: body.repository.html_url,
+    }
+
     // Don't trigger deploy if only the PR body was edited.
     if (skipRedeploy(body)) {
-      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, {},
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
         `*[${project.name}]* PR ${body.number} updated. No deploy task created, reason: Only body changed`
       )
       return;
@@ -68,7 +77,7 @@ async function githubPullRequestSynchronize(webhook: WebhookRequestData, project
         case "UnknownActiveSystem":
           // These are not real errors and also they will happen many times. We just log them locally but not throw an error
           sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
-            `*[${project.name}]* PR ${body.number} opened. No remove task created, reason: ${error}`
+            `*[${project.name}]* PR ${body.number} opened. No deploy task created, reason: ${error}`
           )
           return;
 

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.js
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.js
@@ -16,6 +16,15 @@ async function gitlabPullRequestOpened(webhook: WebhookRequestData, project: Pro
       body,
     } = webhook;
 
+    const meta = {
+      projectName: project.name,
+      pullrequestNumber: body.object_attributes.id,
+      pullrequestTitle: body.object_attributes.title,
+      pullrequestUrl: body.object_attributes.url,
+      repoName: body.object_attributes.target.name,
+      repoUrl: body.object_attributes.target.web_url,
+    }
+
     const headBranchName = body.object_attributes.source_branch
     const headSha = body.object_attributes.last_commit.id
     const baseBranchName = body.object_attributes.target_branch
@@ -50,7 +59,7 @@ async function gitlabPullRequestOpened(webhook: WebhookRequestData, project: Pro
         case "UnknownActiveSystem":
           // These are not real errors and also they will happen many times. We just log them locally but not throw an error
           sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
-            `*[${project.name}]* PR ${body.object_attributes.id} opened. No remove task created, reason: ${error}`
+            `*[${project.name}]* PR ${body.object_attributes.id} opened. No deploy task created, reason: ${error}`
           )
           return;
 

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.js
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.js
@@ -16,6 +16,15 @@ async function gitlabPullRequestUpdated(webhook: WebhookRequestData, project: Pr
       body,
     } = webhook;
 
+    const meta = {
+      projectName: project.name,
+      pullrequestNumber: body.object_attributes.id,
+      pullrequestTitle: body.object_attributes.title,
+      pullrequestUrl: body.object_attributes.url,
+      repoName: body.object_attributes.target.name,
+      repoUrl: body.object_attributes.target.web_url,
+    }
+
     const headBranchName = body.object_attributes.source_branch
     const headSha = body.object_attributes.last_commit.id
     const baseBranchName = body.object_attributes.target_branch
@@ -51,7 +60,7 @@ async function gitlabPullRequestUpdated(webhook: WebhookRequestData, project: Pr
         case "UnknownActiveSystem":
           // These are not real errors and also they will happen many times. We just log them locally but not throw an error
           sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
-            `*[${project.name}]* PR ${body.object_attributes.id} opened. No remove task created, reason: ${error}`
+            `*[${project.name}]* PR ${body.object_attributes.id} updated. No deploy task created, reason: ${error}`
           )
           return;
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

In order to reduce the number of unnecessary deploys for some clients, this change will not re-deploy a PR if it detects that only the body has changed. Title and code changes will still trigger a deploy.

While making this change, I noticed that several log messages were copy/pasted but the text didn't match very well to the logging action. I have also updated the log messages.

I didn't see anywhere that needed documentation changes.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Skip github PR deployments if only the body has changed (#601)
Improvement - Log messages related to PR tasks are more consistent
# Closing issues
Closes #601 
