### PR TITLE
Update lagoonize.md

### DIFF
--- a/docs/using_lagoon/drupal/lagoonize.md
+++ b/docs/using_lagoon/drupal/lagoonize.md
@@ -11,6 +11,7 @@ You find these Files [here](https://github.com/amazeeio/lagoon/tree/master/docs/
 - `sites/default/*` - These .php and .yml files teach Drupal how to communicate with Lagoon containers both locally and in production. It also provides an easy system for specific overrides in development and production environments. Unlike other Drupal hosting systems, Lagoon never ever injects Drupal Settings files into your Drupal. Therefore you can edit them to your wish. Like all other files they contain sensible defaults and some commented parts.
 - `drush/aliases.drushrc.php` - These files are specific to Drush and tell Drush how to talk to the Lagoon GraphQL API in order to learn about all Site Aliases there are.
 - `drush/drushrc.php` - Some sensible defaults for Drush Commands.
+- Add `patches` directory if you choose [drupal8-composer-mariadb](https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal/drupal8-composer-mariadb).
 
 ### Remark to `.gitignore`
 


### PR DESCRIPTION
If choose [drupal8-composer-mariadb](https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal/drupal8-composer-mariadb) to set up, It will fail on `docker-compose build`  because of no patches dir is there.

```
docker-compose build
mariadb uses an image, skipping
redis uses an image, skipping
varnish uses an image, skipping
Building cli
Step 1/7 : FROM amazeeio/php:7.1-cli-drupal
 ---> 543ef51953cd
Step 2/7 : COPY composer.json composer.lock /app/
 ---> Using cache
 ---> 9060beb3a814
Step 3/7 : COPY scripts /app/scripts
 ---> Using cache
 ---> b931273f117a
Step 4/7 : COPY patches /app/patches
ERROR: Service 'cli' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder271689484/patches: no such file or directory
```
To fix this just add `patches` directory.