### PR TITLE
Allow deployments from UI and deprecate rest2tasks

### DIFF
--- a/local-dev/api-data/01-populate-api-data.gql
+++ b/local-dev/api-data/01-populate-api-data.gql
@@ -673,6 +673,29 @@ mutation PopulateApi {
     id
   }
 
+  CiApi: addProject(
+    input: {
+      id: 21
+      name: "ci-api"
+      customer: 3
+      openshift: 2
+      gitUrl: "ssh://git@192.168.99.1:2222/git/api.git"
+      productionEnvironment: "master"
+    }
+  ) {
+    id
+  }
+  CiApiRocketChat: addNotificationToProject(
+    input: {
+      project: "ci-api"
+      notificationType: ROCKETCHAT
+      notificationName: "amazeeio--lagoon-local-ci"
+    }
+  ) {
+    id
+  }
+
+
   #### Lagoon Kickstart Objects
   # Customer with a private key that has access to the local-git server.
   KickstartCustomer: addCustomer(

--- a/local-dev/api-data/01-populate-api-data.gql
+++ b/local-dev/api-data/01-populate-api-data.gql
@@ -271,6 +271,7 @@ mutation PopulateApi {
       name: "master"
       project: 3
       deployType: BRANCH
+      deployBaseRef: "master"
       environmentType: PRODUCTION
       openshiftProjectName: "ci-local"
     }
@@ -473,6 +474,7 @@ mutation PopulateApi {
       name: "lagoon-api-variables"
       project: 12
       deployType: BRANCH
+      deployBaseRef: "lagoon-api-variables"
       environmentType: PRODUCTION
       openshiftProjectName: "ci-features-lagoon-api-variables"
     }
@@ -757,6 +759,7 @@ mutation PopulateApi {
       name: "Master"
       project: 18
       deployType: BRANCH
+      deployBaseRef: "Master"
       environmentType: PRODUCTION
       openshiftProjectName: "high-cotton-master"
     }
@@ -940,6 +943,7 @@ mutation PopulateApi {
       name: "Staging"
       project: 18
       deployType: BRANCH
+      deployBaseRef: "Staging"
       environmentType: DEVELOPMENT
       openshiftProjectName: "high-cotton-staging"
     }
@@ -963,6 +967,7 @@ mutation PopulateApi {
       name: "Development"
       project: 18
       deployType: BRANCH
+      deployBaseRef: "Development"
       environmentType: DEVELOPMENT
       openshiftProjectName: "high-cotton-development"
     }
@@ -986,6 +991,9 @@ mutation PopulateApi {
       name: "PR-175"
       project: 18
       deployType: PULLREQUEST
+      deployBaseRef: "target"
+      deployHeadRef: "source"
+      deployTitle: "PR-175"
       environmentType: DEVELOPMENT
       openshiftProjectName: "high-cotton-pr-175"
     }
@@ -1024,6 +1032,7 @@ mutation PopulateApi {
       name: "master"
       project: 19
       deployType: BRANCH
+      deployBaseRef: "master"
       environmentType: PRODUCTION
       openshiftProjectName: "ci-env-limit"
     }
@@ -1037,6 +1046,7 @@ mutation PopulateApi {
       name: "develop"
       project: 19
       deployType: BRANCH
+      deployBaseRef: "develop"
       environmentType: DEVELOPMENT
       openshiftProjectName: "ci-env-limit"
     }
@@ -1050,6 +1060,7 @@ mutation PopulateApi {
       name: "stage"
       project: 19
       deployType: BRANCH
+      deployBaseRef: "stage"
       environmentType: DEVELOPMENT
       openshiftProjectName: "ci-env-limit"
     }

--- a/local-dev/git/Dockerfile
+++ b/local-dev/git/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -m 700 /git/.ssh && \
 	git --bare init /git/gitlab.git && \
 	git --bare init /git/bitbucket.git && \
 	git --bare init /git/rest.git && \
+	git --bare init /git/api.git && \
 	git --bare init /git/multiproject.git && \
 	git --bare init /git/node.git && \
 	git --bare init /git/drupal.git && \

--- a/node-packages/commons/src/api.js
+++ b/node-packages/commons/src/api.js
@@ -212,7 +212,10 @@ const restoreFragment = graphqlapi.createFragment(`
   }
   `);
 
-const updateRestore = (backupId: string, patch: RestorePatch): Promise<Object> =>
+const updateRestore = (
+  backupId: string,
+  patch: RestorePatch,
+): Promise<Object> =>
   graphqlapi.mutate(
     `
   ($backupId: String!, $patch: UpdateRestorePatchInput!) {
@@ -683,34 +686,49 @@ const addOrUpdateEnvironment = (
   name: string,
   projectId: number,
   deployType: string,
+  deployBaseRef: string,
   environmentType: string,
   openshiftProjectName: string,
+  deployHeadRef: ?string = null,
 ): Promise<Object> =>
-  graphqlapi.query(`
-  mutation {
-    addOrUpdateEnvironment(input: {
-        name: "${name}",
-        project: ${projectId},
-        deployType: ${deployType},
-        environmentType: ${environmentType},
-        openshiftProjectName: "${openshiftProjectName}"
-    }) {
-      id
+  graphqlapi.mutate(
+    `
+($name: String!, $project: Int!, $deployType: DeployType!, $deployBaseRef: String!, $deployHeadRef: String, $environmentType: EnvType!, $openshiftProjectName: String!) {
+  addOrUpdateEnvironment(input: {
+    name: $name,
+    project: $project,
+    deployType: $deployType,
+    deployBaseRef: $deployBaseRef,
+    deployHeadRef: $deployHeadRef,
+    environmentType: $environmentType,
+    openshiftProjectName: $openshiftProjectName
+  }) {
+    id
+    name
+    project {
       name
-      project {
-        name
-      }
-      deployType
-      environmentType
-      openshiftProjectName
-      envVariables {
-        name
-        value
-        scope
-      }
+    }
+    deployType
+    environmentType
+    openshiftProjectName
+    envVariables {
+      name
+      value
+      scope
     }
   }
-`);
+}
+`,
+    {
+      name,
+      project: projectId,
+      deployType,
+      deployBaseRef,
+      deployHeadRef,
+      environmentType,
+      openshiftProjectName,
+    },
+  );
 
 const updateEnvironment = (
   environmentId: number,

--- a/node-packages/commons/src/api.js
+++ b/node-packages/commons/src/api.js
@@ -690,16 +690,18 @@ const addOrUpdateEnvironment = (
   environmentType: string,
   openshiftProjectName: string,
   deployHeadRef: ?string = null,
+  deployTitle: ?string = null,
 ): Promise<Object> =>
   graphqlapi.mutate(
     `
-($name: String!, $project: Int!, $deployType: DeployType!, $deployBaseRef: String!, $deployHeadRef: String, $environmentType: EnvType!, $openshiftProjectName: String!) {
+($name: String!, $project: Int!, $deployType: DeployType!, $deployBaseRef: String!, $deployHeadRef: String, $deployTitle: String, $environmentType: EnvType!, $openshiftProjectName: String!) {
   addOrUpdateEnvironment(input: {
     name: $name,
     project: $project,
     deployType: $deployType,
     deployBaseRef: $deployBaseRef,
     deployHeadRef: $deployHeadRef,
+    deployTitle: $deployTitle,
     environmentType: $environmentType,
     openshiftProjectName: $openshiftProjectName
   }) {
@@ -725,6 +727,7 @@ const addOrUpdateEnvironment = (
       deployType,
       deployBaseRef,
       deployHeadRef,
+      deployTitle,
       environmentType,
       openshiftProjectName,
     },

--- a/node-packages/commons/src/util.js
+++ b/node-packages/commons/src/util.js
@@ -1,0 +1,8 @@
+// @flow
+
+const asyncPipe = (...functions) => input =>
+  functions.reduce((chain, func) => chain.then(func), Promise.resolve(input));
+
+module.exports = {
+  asyncPipe,
+};

--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -83,6 +83,7 @@ CREATE TABLE IF NOT EXISTS environment (
   deploy_type            ENUM('branch', 'pullrequest', 'promote') NOT NULL,
   deploy_base_ref        varchar(100),
   deploy_head_ref        varchar(100),
+  deploy_title           varchar(300),
   environment_type       ENUM('production', 'development') NOT NULL,
   openshift_project_name varchar(100),
   route                  varchar(300),

--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -81,6 +81,8 @@ CREATE TABLE IF NOT EXISTS environment (
   name                   varchar(100),
   project                int REFERENCES project (id),
   deploy_type            ENUM('branch', 'pullrequest', 'promote') NOT NULL,
+  deploy_base_ref        varchar(100),
+  deploy_head_ref        varchar(100),
   environment_type       ENUM('production', 'development') NOT NULL,
   openshift_project_name varchar(100),
   route                  varchar(300),

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -607,7 +607,7 @@ CREATE OR REPLACE PROCEDURE
 $$
 
 CREATE OR REPLACE PROCEDURE
-  add_deploy_base_head_ref_to_environment()
+  add_deploy_base_head_ref_title_to_environment()
 
   BEGIN
     IF NOT EXISTS(
@@ -620,7 +620,8 @@ CREATE OR REPLACE PROCEDURE
     ) THEN
       ALTER TABLE `environment`
       ADD `deploy_base_ref` varchar(100),
-      ADD `deploy_head_ref` varchar(100);
+      ADD `deploy_head_ref` varchar(100),
+      ADD `deploy_title` varchar(300);
     END IF;
   END;
 $$
@@ -656,7 +657,7 @@ CALL add_scope_to_env_vars();
 CALL add_deleted_to_environment_backup();
 CALL convert_task_command_to_text();
 CALL add_key_fingerprint_to_ssh_key();
-CALL add_deploy_base_head_ref_to_environment();
+CALL add_deploy_base_head_ref_title_to_environment();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -606,6 +606,25 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
+CREATE OR REPLACE PROCEDURE
+  add_deploy_base_head_ref_to_environment()
+
+  BEGIN
+    IF NOT EXISTS(
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'deploy_base_ref'
+    ) THEN
+      ALTER TABLE `environment`
+      ADD `deploy_base_ref` varchar(100),
+      ADD `deploy_head_ref` varchar(100);
+    END IF;
+  END;
+$$
+
 DELIMITER ;
 
 CALL add_production_environment_to_project();
@@ -637,6 +656,7 @@ CALL add_scope_to_env_vars();
 CALL add_deleted_to_environment_backup();
 CALL convert_task_command_to_text();
 CALL add_key_fingerprint_to_ssh_key();
+CALL add_deploy_base_head_ref_to_environment();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
@@ -128,9 +128,11 @@ CREATE OR REPLACE PROCEDURE
     IN id                     int,
     IN name                   varchar(100),
     IN pid                    int,
-    IN deploy_type               ENUM('branch', 'pullrequest', 'promote'),
+    IN deploy_type            ENUM('branch', 'pullrequest', 'promote'),
+    IN deploy_base_ref        varchar(100),
+    IN deploy_head_ref        varchar(100),
     IN environment_type       ENUM('production', 'development'),
-    IN openshift_project_name  varchar(100)
+    IN openshift_project_name varchar(100)
   )
   BEGIN
     INSERT INTO environment (
@@ -138,6 +140,8 @@ CREATE OR REPLACE PROCEDURE
         name,
         project,
         deploy_type,
+        deploy_base_ref,
+        deploy_head_ref,
         environment_type,
         openshift_project_name,
         deleted
@@ -147,6 +151,8 @@ CREATE OR REPLACE PROCEDURE
         name,
         p.id,
         deploy_type,
+        deploy_base_ref,
+        deploy_head_ref,
         environment_type,
         openshift_project_name,
         '0000-00-00 00:00:00'
@@ -156,6 +162,8 @@ CREATE OR REPLACE PROCEDURE
         p.id = pid
     ON DUPLICATE KEY UPDATE
         deploy_type=deploy_type,
+        deploy_base_ref=deploy_base_ref,
+        deploy_head_ref=deploy_head_ref,
         environment_type=environment_type,
         updated=NOW();
 

--- a/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
@@ -131,6 +131,7 @@ CREATE OR REPLACE PROCEDURE
     IN deploy_type            ENUM('branch', 'pullrequest', 'promote'),
     IN deploy_base_ref        varchar(100),
     IN deploy_head_ref        varchar(100),
+    IN deploy_title           varchar(300),
     IN environment_type       ENUM('production', 'development'),
     IN openshift_project_name varchar(100)
   )
@@ -142,6 +143,7 @@ CREATE OR REPLACE PROCEDURE
         deploy_type,
         deploy_base_ref,
         deploy_head_ref,
+        deploy_title,
         environment_type,
         openshift_project_name,
         deleted
@@ -153,6 +155,7 @@ CREATE OR REPLACE PROCEDURE
         deploy_type,
         deploy_base_ref,
         deploy_head_ref,
+        deploy_title,
         environment_type,
         openshift_project_name,
         '0000-00-00 00:00:00'
@@ -164,6 +167,7 @@ CREATE OR REPLACE PROCEDURE
         deploy_type=deploy_type,
         deploy_base_ref=deploy_base_ref,
         deploy_head_ref=deploy_head_ref,
+        deploy_title=deploy_title,
         environment_type=environment_type,
         updated=NOW();
 

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -20,6 +20,9 @@ const {
   deleteDeployment,
   updateDeployment,
   deployEnvironmentLatest,
+  deployEnvironmentBranch,
+  deployEnvironmentPullrequest,
+  deployEnvironmentPromote,
   deploymentSubscriber,
 } = require('./resources/deployment/resolvers');
 
@@ -286,6 +289,9 @@ const resolvers /* : { [string]: ResolversObj | typeof GraphQLDate } */ = {
     uploadFilesForTask,
     deleteFilesForTask,
     deployEnvironmentLatest,
+    deployEnvironmentBranch,
+    deployEnvironmentPullrequest,
+    deployEnvironmentPromote,
   },
   Subscription: {
     backupChanged: backupSubscriber,

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -19,6 +19,7 @@ const {
   addDeployment,
   deleteDeployment,
   updateDeployment,
+  deployEnvironmentLatest,
   deploymentSubscriber,
 } = require('./resources/deployment/resolvers');
 
@@ -284,6 +285,7 @@ const resolvers /* : { [string]: ResolversObj | typeof GraphQLDate } */ = {
     setEnvironmentServices,
     uploadFilesForTask,
     deleteFilesForTask,
+    deployEnvironmentLatest,
   },
   Subscription: {
     backupChanged: backupSubscriber,

--- a/services/api/src/resources/deployment/resolvers.js
+++ b/services/api/src/resources/deployment/resolvers.js
@@ -378,6 +378,23 @@ const deployEnvironmentLatest = async (
       };
       break;
 
+    case 'pullrequest':
+      deployData = {
+        ...deployData,
+        pullrequestTitle: environment.deployTitle,
+        pullrequestNumber: environment.name.replace('pr-', ''),
+        headBranchName: environment.deployHeadRef,
+        headSha: `origin/${environment.deployHeadRef}`,
+        baseBranchName: environment.deployBaseRef,
+        baseSha: `origin/${environment.deployBaseRef}`,
+        branchName: environment.name,
+      };
+      meta = {
+        ...meta,
+        pullrequestTitle: deployData.pullrequestTitle,
+      };
+      break;
+
     default:
       return `Error: Unkown deploy type ${environment.deployType}`;
   }

--- a/services/api/src/resources/environment/helpers.js
+++ b/services/api/src/resources/environment/helpers.js
@@ -4,11 +4,56 @@ const R = require('ramda');
 const sqlClient = require('../../clients/sqlClient');
 const { query } = require('../../util/db');
 const Sql = require('./sql');
+const projectHelpers = require('../project/helpers');
+
+const getEnvironmentById = async (environmentID /* : number */) => {
+  const rows = await query(sqlClient, Sql.selectEnvironmentById(environmentID));
+  return R.prop(0, rows);
+};
 
 const Helpers = {
-  getEnvironmentById: async (environmentID /* : number */) => {
-    const rows = await query(sqlClient, Sql.selectEnvironmentById(environmentID));
-    return R.prop(0, rows);
+  getEnvironmentById,
+  getEnvironmentByEnvironmentInput: async environmentInput => {
+    const notEmpty = R.complement(R.anyPass([R.isNil, R.isEmpty]));
+    const hasId = R.both(R.has('id'), R.propSatisfies(notEmpty, 'id'));
+    const hasName = R.both(R.has('name'), R.propSatisfies(notEmpty, 'name'));
+    const hasProject = R.both(
+      R.has('project'),
+      R.propSatisfies(notEmpty, 'project'),
+    );
+    const hasNameAndProject = R.both(hasName, hasProject);
+
+    const envFromId = R.pipe(
+      R.prop('id'),
+      getEnvironmentById,
+    );
+
+    const envFromNameProject = async input => {
+      const project = await projectHelpers.getProjectByProjectInput(
+        R.prop('project', input),
+      );
+      const rows = await query(
+        sqlClient,
+        Sql.selectEnvironmentByNameAndProject(
+          R.prop('name', input),
+          project.id,
+        ),
+      );
+      return R.prop(0, rows);
+    };
+
+    return R.cond([
+      [hasId, envFromId],
+      [hasNameAndProject, envFromNameProject],
+      [
+        R.T,
+        () => {
+          throw new Error(
+            'Must provide environment (id) or (name and project)',
+          );
+        },
+      ],
+    ])(environmentInput);
   },
 };
 

--- a/services/api/src/resources/environment/helpers.js
+++ b/services/api/src/resources/environment/helpers.js
@@ -32,7 +32,7 @@ const Helpers = {
           throw new Error('Unauthorized');
         }
 
-        return environment;
+        return [environment];
       },
     );
 

--- a/services/api/src/resources/environment/resolvers.js
+++ b/services/api/src/resources/environment/resolvers.js
@@ -399,6 +399,7 @@ const addOrUpdateEnvironment = async (
   const input = R.compose(
     R.over(R.lensProp('environmentType'), envTypeToString),
     R.over(R.lensProp('deployType'), deployTypeToString),
+    R.over(R.lensProp('deployHeadRef'), R.defaultTo(null)),
   )(unformattedInput);
 
   const pid = input.project.toString();
@@ -414,6 +415,8 @@ const addOrUpdateEnvironment = async (
         :name,
         :project,
         :deploy_type,
+        :deploy_base_ref,
+        :deploy_head_ref,
         :environment_type,
         :openshift_project_name
       );

--- a/services/api/src/resources/environment/resolvers.js
+++ b/services/api/src/resources/environment/resolvers.js
@@ -400,6 +400,7 @@ const addOrUpdateEnvironment = async (
     R.over(R.lensProp('environmentType'), envTypeToString),
     R.over(R.lensProp('deployType'), deployTypeToString),
     R.over(R.lensProp('deployHeadRef'), R.defaultTo(null)),
+    R.over(R.lensProp('deployTitle'), R.defaultTo(null)),
   )(unformattedInput);
 
   const pid = input.project.toString();
@@ -417,6 +418,7 @@ const addOrUpdateEnvironment = async (
         :deploy_type,
         :deploy_base_ref,
         :deploy_head_ref,
+        :deploy_title,
         :environment_type,
         :openshift_project_name
       );

--- a/services/api/src/resources/project/sql.js
+++ b/services/api/src/resources/project/sql.js
@@ -20,6 +20,10 @@ const Sql /* : SqlObj */ = {
   selectAllProjects: () =>
     knex('project')
       .toString(),
+  selectProjectByName: (name /* : string */) =>
+    knex('project')
+      .where('name', name)
+      .toString(),
   selectProjectIdByName: (name /* : string */) =>
     knex('project')
       .where('name', name)

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -479,6 +479,19 @@ const typeDefs = gql`
     allEnvironments(createdAfter: String, type: EnvType): [Environment]
   }
 
+  # Must provide id OR name
+  input ProjectInput {
+    id: Int
+    name: String
+  }
+
+  # Must provide id OR name and project
+  input EnvironmentInput {
+    id: Int
+    name: String
+    project: ProjectInput
+  }
+
   input AddSshKeyInput {
     id: Int
     name: String!
@@ -861,6 +874,10 @@ const typeDefs = gql`
     id: Int!
   }
 
+  input DeployEnvironmentLatestInput {
+    environment: EnvironmentInput!
+  }
+
   type Mutation {
     addCustomer(input: AddCustomerInput!): Customer
     updateCustomer(input: UpdateCustomerInput!): Customer
@@ -957,6 +974,7 @@ const typeDefs = gql`
     setEnvironmentServices(input: SetEnvironmentServicesInput!): [EnvironmentService]
     uploadFilesForTask(input: UploadFilesForTaskInput!): Task
     deleteFilesForTask(input: DeleteFilesForTaskInput!): String
+    deployEnvironmentLatest(input: DeployEnvironmentLatestInput!): String
   }
 
   type Subscription {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -294,6 +294,14 @@ const typeDefs = gql`
     """
     deployType: String
     """
+    The version control base ref for deployments (e.g., branch name, tag, or commit id)
+    """
+    deployBaseRef: String
+    """
+    The version control head ref for deployments (e.g., branch name, tag, or commit id)
+    """
+    deployHeadRef: String
+    """
     Which Environment Type this environment is, can be \`production\`, \`development\`
     """
     environmentType: String
@@ -509,6 +517,8 @@ const typeDefs = gql`
     name: String!
     project: Int!
     deployType: DeployType!
+    deployBaseRef: String!
+    deployHeadRef: String
     environmentType: EnvType!
     openshiftProjectName: String!
   }
@@ -810,6 +820,8 @@ const typeDefs = gql`
   input UpdateEnvironmentPatchInput {
     project: Int
     deployType: DeployType
+    deployBaseRef: String
+    deployHeadRef: String
     environmentType: EnvType
     openshiftProjectName: String
     route: String

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -302,6 +302,10 @@ const typeDefs = gql`
     """
     deployHeadRef: String
     """
+    The title of the last deployment (PR title)
+    """
+    deployTitle: String
+    """
     Which Environment Type this environment is, can be \`production\`, \`development\`
     """
     environmentType: String
@@ -532,6 +536,7 @@ const typeDefs = gql`
     deployType: DeployType!
     deployBaseRef: String!
     deployHeadRef: String
+    deployTitle: String
     environmentType: EnvType!
     openshiftProjectName: String!
   }
@@ -835,6 +840,7 @@ const typeDefs = gql`
     deployType: DeployType
     deployBaseRef: String
     deployHeadRef: String
+    deployTitle: String
     environmentType: EnvType
     openshiftProjectName: String
     route: String

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -884,6 +884,28 @@ const typeDefs = gql`
     environment: EnvironmentInput!
   }
 
+  input DeployEnvironmentBranchInput {
+    project: ProjectInput!
+    branchName: String!
+    branchRef: String
+  }
+
+  input DeployEnvironmentPullrequestInput {
+    project: ProjectInput!
+    number: Int!
+    title: String!
+    baseBranchName: String!
+    baseBranchRef: String!
+    headBranchName: String!
+    headBranchRef: String!
+  }
+
+  input DeployEnvironmentPromoteInput {
+    sourceEnvironment: EnvironmentInput!
+    project: ProjectInput!
+    destinationEnvironment: String!
+  }
+
   type Mutation {
     addCustomer(input: AddCustomerInput!): Customer
     updateCustomer(input: UpdateCustomerInput!): Customer
@@ -981,6 +1003,9 @@ const typeDefs = gql`
     uploadFilesForTask(input: UploadFilesForTaskInput!): Task
     deleteFilesForTask(input: DeleteFilesForTaskInput!): String
     deployEnvironmentLatest(input: DeployEnvironmentLatestInput!): String
+    deployEnvironmentBranch(input: DeployEnvironmentBranchInput!): String
+    deployEnvironmentPullrequest(input: DeployEnvironmentPullrequestInput!): String
+    deployEnvironmentPromote(input: DeployEnvironmentPromoteInput!): String
   }
 
   type Subscription {

--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -89,14 +89,20 @@ const messageConsumer = async msg => {
     case "branch":
       // if we have a sha given, we use that, if not we fall back to the branch (which needs be prefixed by `origin/`
       var gitRef = gitSha ? gitSha : `origin/${branchName}`
+      var deployBaseRef = branchName
+      var deployHeadRef = null
       break;
 
     case "pullrequest":
       var gitRef = gitSha
+      var deployBaseRef = prBaseBranchName
+      var deployHeadRef = prHeadBranchName
       break;
 
     case "promote":
       var gitRef = `origin/${promoteSourceEnvironment}`
+      var deployBaseRef = promoteSourceEnvironment
+      var deployHeadRef = null
       break;
   }
 
@@ -304,7 +310,7 @@ const messageConsumer = async msg => {
   // Update GraphQL API with information about this environment
   let environment;
   try {
-    environment = await addOrUpdateEnvironment(branchName, projectId, graphqlGitType, graphqlEnvironmentType, openshiftProject)
+    environment = await addOrUpdateEnvironment(branchName, projectId, graphqlGitType, deployBaseRef, graphqlEnvironmentType, openshiftProject, deployHeadRef)
     logger.info(`${openshiftProject}: Created/Updated Environment in API`)
   } catch (err) {
     logger.error(err)

--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -91,18 +91,21 @@ const messageConsumer = async msg => {
       var gitRef = gitSha ? gitSha : `origin/${branchName}`
       var deployBaseRef = branchName
       var deployHeadRef = null
+      var deployTitle = null
       break;
 
     case "pullrequest":
       var gitRef = gitSha
       var deployBaseRef = prBaseBranchName
       var deployHeadRef = prHeadBranchName
+      var deployTitle = prPullrequestTitle
       break;
 
     case "promote":
       var gitRef = `origin/${promoteSourceEnvironment}`
       var deployBaseRef = promoteSourceEnvironment
       var deployHeadRef = null
+      var deployTitle = null
       break;
   }
 
@@ -310,7 +313,7 @@ const messageConsumer = async msg => {
   // Update GraphQL API with information about this environment
   let environment;
   try {
-    environment = await addOrUpdateEnvironment(branchName, projectId, graphqlGitType, deployBaseRef, graphqlEnvironmentType, openshiftProject, deployHeadRef)
+    environment = await addOrUpdateEnvironment(branchName, projectId, graphqlGitType, deployBaseRef, graphqlEnvironmentType, openshiftProject, deployHeadRef, deployTitle)
     logger.info(`${openshiftProject}: Created/Updated Environment in API`)
   } catch (err) {
     logger.error(err)

--- a/services/rest2tasks/src/index.js
+++ b/services/rest2tasks/src/index.js
@@ -23,8 +23,15 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use(expressValidator());
 
+const deprecationMessage = 'Deprecated API - This will be removed in the future, use GraphQL API instead.'
+
+app.use(function(req, res, next) {
+  res.setHeader('Warning', '299 - "' + deprecationMessage + '"');
+  next();
+})
+
 app.get('/', (req, res) => {
-  return res.status(200).send('welcome to rest2tasks')
+  return res.status(200).send('welcome to rest2tasks - ' + deprecationMessage)
 })
 
 app.post('/pullrequest/deploy', async (req, res) => {
@@ -91,7 +98,7 @@ app.post('/pullrequest/deploy', async (req, res) => {
   const result = await req.getValidationResult()
 
   if (!result.isEmpty()) {
-    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()));
+    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()) + ' - ' + deprecationMessage);
     return;
   }
 
@@ -118,24 +125,24 @@ app.post('/pullrequest/deploy', async (req, res) => {
     sendToLagoonLogs('info', data.projectName, '', `rest:pullrequest:deploy`, meta,
       `*[${data.projectName}]* REST deploy trigger \`${data.pullrequestTitle}\``
     )
-    res.status(200).type('json').send({ "ok": "true", "message": taskResult})
+    res.status(200).type('json').send({ "ok": "true", "message": taskResult, "warning": deprecationMessage})
     return;
   } catch (error) {
     switch (error.name) {
       case "ProjectNotFound":
       case "ActiveSystemsNotFound":
-          res.status(404).type('json').send({ "ok": "false", "message": error.message})
+          res.status(404).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       case "NoNeedToDeployBranch":
-          res.status(501).type('json').send({ "ok": "false", "message": error.message})
+          res.status(501).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       default:
           logger.error(error)
-          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`})
+          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`, "warning": deprecationMessage})
           return;
         break;
     }
@@ -178,7 +185,7 @@ app.post('/deploy', async (req, res) => {
   const result = await req.getValidationResult()
 
   if (!result.isEmpty()) {
-    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()));
+    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()) + ' - ' + deprecationMessage);
     return;
   }
 
@@ -208,24 +215,24 @@ app.post('/deploy', async (req, res) => {
     sendToLagoonLogs('info', data.projectName, '', `rest:deploy:receive`, meta,
       `*[${data.projectName}]* REST deploy trigger ${logMessage}`
     )
-    res.status(200).type('json').send({ "ok": "true", "message": taskResult})
+    res.status(200).type('json').send({ "ok": "true", "message": taskResult, "warning": deprecationMessage})
     return;
   } catch (error) {
     switch (error.name) {
       case "ProjectNotFound":
       case "ActiveSystemsNotFound":
-          res.status(404).type('json').send({ "ok": "false", "message": error.message})
+          res.status(404).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       case "NoNeedToDeployBranch":
-          res.status(501).type('json').send({ "ok": "false", "message": error.message})
+          res.status(501).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       default:
           logger.error(error)
-          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`})
+          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`, "warning": deprecationMessage})
           return;
         break;
     }
@@ -262,7 +269,7 @@ app.post('/promote', async (req, res) => {
   const result = await req.getValidationResult()
 
   if (!result.isEmpty()) {
-    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()));
+    res.status(400).send('There have been validation errors: ' + util.inspect(result.mapped()) + ' - ' + deprecationMessage);
     return;
   }
 
@@ -287,24 +294,24 @@ app.post('/promote', async (req, res) => {
     sendToLagoonLogs('info', data.projectName, '', `rest:promote:receive`, meta,
       `*[${data.projectName}]* REST promote trigger ${logMessage}`
     )
-    res.status(200).type('json').send({ "ok": "true", "message": taskResult})
+    res.status(200).type('json').send({ "ok": "true", "message": taskResult, "warning": deprecationMessage})
     return;
   } catch (error) {
     switch (error.name) {
       case "ProjectNotFound":
       case "ActiveSystemsNotFound":
-          res.status(404).type('json').send({ "ok": "false", "message": error.message})
+          res.status(404).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       case "NoNeedToDeployBranch":
-          res.status(501).type('json').send({ "ok": "false", "message": error.message})
+          res.status(501).type('json').send({ "ok": "false", "message": error.message, "warning": deprecationMessage})
           return;
         break;
 
       default:
           logger.error(error)
-          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`})
+          res.status(500).type('json').send({ "ok": "false", "message": `Internal Error: ${error}`, "warning": deprecationMessage})
           return;
         break;
     }

--- a/services/ui/src/components/DeployLatest/index.js
+++ b/services/ui/src/components/DeployLatest/index.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Mutation } from 'react-apollo';
+import gql from 'graphql-tag';
+import { bp, color, fontSize } from '../../variables';
+
+const DEPLOY_ENVIRONMENT_LATEST_MUTATION = gql`
+  mutation deployEnvironmentLatest(
+    $environmentId: Int!
+  ) {
+    deployEnvironmentLatest(
+      input: {
+        environment: {
+          id: $environmentId
+        }
+      }
+    )
+  }
+`;
+
+const DeployLatest = ({
+  pageEnvironment,
+}) => {
+  return (
+    <React.Fragment>
+      <div className="newDeploymentWrapper">
+        <div className="newDeployment">
+          <Mutation
+            mutation={DEPLOY_ENVIRONMENT_LATEST_MUTATION}
+          >
+            {(deploy, { loading, called, error, data }) => {
+              const success = data && data.deployEnvironmentLatest === 'success';
+              return (
+                <React.Fragment>
+                  <button
+                    onClick={() =>
+                      deploy({
+                        variables: {
+                          environmentId: pageEnvironment.id,
+                        }
+                      })
+                    }
+                    disabled={loading}
+                  >
+                    Deploy
+                  </button>
+
+                  {success &&
+                    <div className="deploy_result">
+                      Deployment queued.
+                    </div>}
+
+                  {error &&
+                    <div className="deploy_result">
+                      <p>There was a problem deploying.</p>
+                      <p>{error.message}</p>
+                    </div>}
+                </React.Fragment>
+              );
+            }}
+          </Mutation>
+        </div>
+      </div>
+      <style jsx>
+        {`
+          .newDeploymentWrapper {
+            @media ${bp.wideUp} {
+              display: flex;
+            }
+            &::before {
+              @media ${bp.wideUp} {
+                content: '';
+                display: block;
+                flex-grow: 1;
+              }
+            }
+          }
+          .newDeployment {
+            background: ${color.white};
+            border: 1px solid ${color.lightestGrey};
+            border-radius: 3px;
+            box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.03);
+            display: flex;
+            flex-flow: column;
+            margin-bottom: 32px;
+            padding: 32px 20px;
+            @media ${bp.tabletUp} {
+              margin-bottom: 0;
+            }
+            @media ${bp.wideUp} {
+              min-width: 52%;
+            }
+            .deploy_result {
+              margin-top: 20px;
+            }
+          }
+          button {
+            align-self: flex-end;
+            background-color: ${color.lightestGrey};
+            border: none;
+            border-radius: 20px;
+            color: ${color.darkGrey};
+            font-family: 'source-code-pro', sans-serif;
+            ${fontSize(13)};
+            padding: 3px 20px 2px;
+            text-transform: uppercase;
+            @media ${bp.tinyUp} {
+              align-self: auto;
+            }
+          }
+        `}
+      </style>
+    </React.Fragment>
+  );
+};
+
+export default DeployLatest;

--- a/services/ui/src/components/DeployLatest/index.js
+++ b/services/ui/src/components/DeployLatest/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Mutation } from 'react-apollo';
 import gql from 'graphql-tag';
-import { bp, color, fontSize } from '../../variables';
+import { bp, color, fontSize } from 'lib/variables';
 
 const DEPLOY_ENVIRONMENT_LATEST_MUTATION = gql`
   mutation deployEnvironmentLatest(

--- a/services/ui/src/pages/deployments.js
+++ b/services/ui/src/pages/deployments.js
@@ -11,6 +11,7 @@ import Breadcrumbs from 'components/Breadcrumbs';
 import ProjectBreadcrumb from 'components/Breadcrumbs/Project';
 import EnvironmentBreadcrumb from 'components/Breadcrumbs/Environment';
 import NavTabs from 'components/NavTabs';
+import DeployLatest from 'components/DeployLatest';
 import Deployments from 'components/Deployments';
 import { bp } from 'lib/variables';
 
@@ -100,6 +101,7 @@ const PageDeployments = ({ router }) => {
               <div className="content-wrapper">
                 <NavTabs activeTab="deployments" environment={environment} />
                 <div className="content">
+                  <DeployLatest pageEnvironment={environment} />
                   <Deployments
                     deployments={environment.deployments}
                     projectName={environment.openshiftProjectName}

--- a/tests/tasks/api/deploy-no-sha.yaml
+++ b/tests/tasks/api/deploy-no-sha.yaml
@@ -1,0 +1,8 @@
+- name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} (no sha) to {{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+  uri:
+    url: "{{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token.stdout }}"
+    body_format: json
+    body: '{ "query": "mutation($branchName: String!, $projectName: String!) {deployEnvironmentBranch(input:{branchName:$branchName,project:{name:$projectName}})}", "variables": {"branchName":"{{ branch }}","projectName":"{{ project }}"}}'

--- a/tests/tasks/api/deploy-sha.yaml
+++ b/tests/tasks/api/deploy-sha.yaml
@@ -1,0 +1,8 @@
+- name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} and sha {{ sha }} to {{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+  uri:
+    url: "{{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token.stdout }}"
+    body_format: json
+    body: '{ "query": "mutation($branchName: String!, $branchRef: String!, $projectName: String!) {deployEnvironmentBranch(input:{branchName:$branchName,branchRef:$branchRef,project:{name:$projectName}})}", "variables": {"branchName":"{{ branch }}","branchRef":"{{ sha }}","projectName":"{{ project }}"}}'

--- a/tests/tasks/api/promote.yaml
+++ b/tests/tasks/api/promote.yaml
@@ -1,0 +1,8 @@
+- name: "{{ testname }} - POST api deployEnvironmentPromote with source environment {{ source_environment }}, target environment {{ promote_environment }} and project {{ project }} to {{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+  uri:
+    url: "{{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token.stdout }}"
+    body_format: json
+    body: '{ "query": "mutation($destinationEnvironment: String!, $projectName: String!, $sourceEnvironmentName: String!) {deployEnvironmentPromote(input:{destinationEnvironment:$destinationEnvironment,project:{name:$projectName},sourceEnvironment:{name:$sourceEnvironmentName,project:{name:$projectName}}})}", "variables": {"destinationEnvironment":"{{ promote_environment }}","sourceEnvironmentName":"{{ source_environment }}","projectName":"{{ project }}"}}'

--- a/tests/tasks/api/pullrequest-deploy.yaml
+++ b/tests/tasks/api/pullrequest-deploy.yaml
@@ -1,0 +1,8 @@
+- name: "{{ testname }} - POST api deployEnvironmentPullrequest with pr number {{ git_pr_number }}, git base branch {{ git_base_branch }}, base commit hash {{ git_base_commit_hash }}, pr branch {{ git_pr_branch }}, pr commit hash {{ git_pr_commit_hash }} to {{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+  uri:
+    url: "{{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/graphql"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token.stdout }}"
+    body_format: json
+    body: '{ "query": "mutation($projectName:String!, $number:Int!, $title:String!, $baseName:String!, $baseRef:String!, $headName:String!, $headRef:String!) {deployEnvironmentPullrequest(input:{project:{name:$projectName},number:$number,title:$title,baseBranchName:$baseName,baseBranchRef:$baseRef,headBranchName:$headName,headBranchRef:$headRef})}", "variables": {"projectName":"{{ project }}","number":"{{ git_pr_number }}","title":"{{ git_pr_title }}","baseName":"{{ git_base_branch }}","baseRef":"{{ git_base_commit_hash }}","headName":"{{ git_pr_branch }}","headRef":"{{ git_pr_commit_hash }}"}}'

--- a/tests/tasks/rest/promote.yaml
+++ b/tests/tasks/rest/promote.yaml
@@ -1,8 +1,0 @@
-- name: "{{ testname }} - POST rest2task /promote with source environment {{ source_environment }}, target environment {{ promote_environment }}  and project {{ project }} to {{ lookup('env','REST2TASKS_PROTOCOL') }}://{{ lookup('env','REST2TASKS_HOST') }}:{{ lookup('env','REST2TASKS_PORT') }}"
-  uri:
-    url: "{{ lookup('env','REST2TASKS_PROTOCOL') }}://{{ lookup('env','REST2TASKS_HOST') }}:{{ lookup('env','REST2TASKS_PORT') }}/promote"
-    method: POST
-    follow_redirects: yes
-    body_format: json
-    body: '{"branchName": "{{ promote_environment }}","sourceEnvironmentName": "{{ source_environment }}","projectName": "{{ project }}"}'
-

--- a/tests/tests/api.yaml
+++ b/tests/tests/api.yaml
@@ -1,0 +1,22 @@
+---
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/deploy-pullrequest.yaml
+  vars:
+    testname: "API - deploy pullrequest"
+    node_version: 8
+    git_repo_name: api.git
+    project: ci-api
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.pr-1.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+
+- include: api/deploy-branch.yaml
+  vars:
+    testname: "API - deploy regular branch"
+    node_version: 8
+    git_repo_name: api.git
+    project: ci-api
+    branch: api/slash/branch
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"

--- a/tests/tests/api/deploy-branch.yaml
+++ b/tests/tests/api/deploy-branch.yaml
@@ -1,0 +1,108 @@
+
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "node{{ node_version }}/"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ current_head }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- name: "{{ testname }} - second commit (empty) and git push into same git repo"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - include: ../../tasks/git-empty-commit-push.yaml
+  - set_fact:
+      second_commit_hash: "{{ current_head }}"
+
+- name: "{{ testname }} - third commit (empty) and git push into same git repo"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - include: ../../tasks/git-empty-commit-push.yaml
+
+- name: "{{ testname }} - api deployEnvironmentBranch with sha of second commit on {{ project }}, which should deploy the second commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+    sha: "{{ second_commit_hash }}"
+  tasks:
+  - include: ../../tasks/api/deploy-sha.yaml
+
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ second_commit_hash }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the third commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ current_head }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- name: "{{ testname }} - api deployEnvironmentBranch with sha of second commit on {{ project }}, which should deploy again the second commit even we had a deployment of the branch before"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+    sha: "{{ second_commit_hash }}"
+  tasks:
+  - include: ../../tasks/api/deploy-sha.yaml
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ second_commit_hash }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- name: "{{ testname }} - api deleteEnvironment on {{ project }}, which should remove all resources"
+  hosts: localhost
+  serial: 1
+  vars:
+    project: "{{ project }}"
+    branch: "{{ branch }}"
+  tasks:
+  - include: ../../tasks/api/remove.yaml
+
+- name: "{{ testname }} - check if site for {{ project }} does not exist anymore"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "http://{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
+    expected_returncode: 503
+  tasks:
+  - include: ../../checks/check-url-returncode.yaml

--- a/tests/tests/api/deploy-pullrequest.yaml
+++ b/tests/tests/api/deploy-pullrequest.yaml
@@ -1,0 +1,126 @@
+
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "node{{ node_version }}/"
+    branch: "pullrequest_base"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - save base branch commit"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - set_fact:
+      base_commit_hash: "{{ current_head }}"
+
+- name: "{{ testname }} - git commit "
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "pullrequest_pr"
+  tasks:
+  - include: ../../tasks/git-empty-commit-push.yaml
+
+- name: "{{ testname }} - save pr branch commit"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - set_fact:
+      pr_commit_hash: "{{ current_head }}"
+
+- name: "{{ testname }} - api deployEnvironmentPullrequest"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_base_branch: "pullrequest_base"
+    git_base_commit_hash: "{{ base_commit_hash }}"
+    git_pr_branch: "pullrequest_pr"
+    git_pr_commit_hash: "{{ pr_commit_hash }}"
+    git_pr_number: "1"
+    git_pr_title: "PR Title"
+  tasks:
+  - include: ../../tasks/api/pullrequest-deploy.yaml
+
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ pr_commit_hash }}"
+    expected_branch: "pr-1"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- include: ../../checks/check-pullrequest.yaml
+  vars:
+    url: "{{ check_url }}"
+    expected_build_type: "pullrequest"
+    expected_pr_base_branch: "pullrequest_base"
+    expected_pr_base_sha: "{{ base_commit_hash }}"
+    expected_pr_head_branch: "pullrequest_pr"
+    expected_pr_head_sha: "{{ pr_commit_hash }}"
+    expected_pr_title: "PR Title"
+
+- name: "{{ testname }} - git commit a second time into pull request branch"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "pullrequest_pr"
+  tasks:
+  - include: ../../tasks/git-empty-commit-push.yaml
+
+- name: "{{ testname }} - save pr branch commit"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - set_fact:
+      pr_2nd_commit_hash: "{{ current_head }}"
+
+- name: "{{ testname }} - api deployEnvironmentPullrequest"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_base_branch: "pullrequest_base"
+    git_base_commit_hash: "{{ base_commit_hash }}"
+    git_pr_branch: "pullrequest_pr"
+    git_pr_commit_hash: "{{ pr_2nd_commit_hash }}"
+    git_pr_number: "1"
+    git_pr_title: "PR Title - UPDATE"
+  tasks:
+  - include: ../../tasks/api/pullrequest-deploy.yaml
+
+- include: ../../checks/check-branch-sha.yaml
+  vars:
+    expected_head: "{{ pr_2nd_commit_hash }}"
+    expected_branch: "pr-1"
+    project: "{{ project }}"
+    url: "{{ check_url }}"
+
+- include: ../../checks/check-pullrequest.yaml
+  vars:
+    url: "{{ check_url }}"
+    expected_build_type: "pullrequest"
+    expected_pr_base_branch: "pullrequest_base"
+    expected_pr_base_sha: "{{ base_commit_hash }}"
+    expected_pr_head_branch: "pullrequest_pr"
+    expected_pr_head_sha: "{{ pr_2nd_commit_hash }}"
+    expected_pr_title: "PR Title - UPDATE"
+
+- name: "{{ testname }} - api deleteEnvironment on {{ project }}, which should remove all resources"
+  hosts: localhost
+  serial: 1
+  vars:
+    project: "{{ project }}"
+    branch: "pr-1"
+  tasks:
+  - include: ../../tasks/api/remove.yaml
+
+- name: "{{ testname }} - check if site for project does not exist anymore"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "{{ check_url }}"
+    expected_returncode: 503
+  tasks:
+  - include: ../../checks/check-url-returncode.yaml

--- a/tests/tests/api/push.yaml
+++ b/tests/tests/api/push.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 #- include: ../../checks/check-branch-sha.yaml
 #  #  when:

--- a/tests/tests/drupal/drupal.yaml
+++ b/tests/tests/drupal/drupal.yaml
@@ -9,14 +9,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-deployed.yaml
   vars:
@@ -32,14 +32,14 @@
   - set_fact:
       second_commit_hash: "{{ current_head }}"
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the second commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the second commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-deployed.yaml
   vars:

--- a/tests/tests/drupal/drush.yaml
+++ b/tests/tests/drupal/drush.yaml
@@ -11,14 +11,14 @@
   - set_fact:
       current_head_first: "{{ current_head }}"
 
-- name: "{{ testname }} FIRST - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} FIRST - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "drush-first"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} SECOND - init git, add files, commit, git push"
   hosts: localhost
@@ -33,14 +33,14 @@
   - set_fact:
       current_head_second: "{{ current_head }}"
 
-- name: "{{ testname }} SECOND - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} SECOND - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "drush-second"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-deployed.yaml
   vars:
@@ -160,14 +160,14 @@
   - set_fact:
       current_head_third: "{{ current_head }}"
 
-- name: "{{ testname }} third - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} third - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "foo/bar"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-deployed.yaml
   vars:

--- a/tests/tests/elasticsearch/elasticsearch.yaml
+++ b/tests/tests/elasticsearch/elasticsearch.yaml
@@ -8,7 +8,7 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
@@ -17,7 +17,7 @@
     expected_key: "number_of_nodes"
     expected_value: "{{ node_count }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed by testing for cluster status"
   hosts: localhost

--- a/tests/tests/features/autogenerated-routes-disabled.yaml
+++ b/tests/tests/features/autogenerated-routes-disabled.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with accessing the custom domain and searching for the environment variable LAGOON_ROUTES"
   hosts: localhost

--- a/tests/tests/features/cronjobs.yaml
+++ b/tests/tests/features/cronjobs.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for 'CRONJOB_SINGLE' which is added via a cronjob"
   hosts: localhost

--- a/tests/tests/features/dot-env.yaml
+++ b/tests/tests/features/dot-env.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the env variable set by .env file"
   hosts: localhost

--- a/tests/tests/features/environment-templates.yaml
+++ b/tests/tests/features/environment-templates.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the env variable set by .env file"
   hosts: localhost

--- a/tests/tests/features/environment-type.yaml
+++ b/tests/tests/features/environment-type.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the correct environment type"
   hosts: localhost

--- a/tests/tests/features/lagoon-api-variables.yaml
+++ b/tests/tests/features/lagoon-api-variables.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is built with project environment variables"
   hosts: localhost

--- a/tests/tests/features/limits.yaml
+++ b/tests/tests/features/limits.yaml
@@ -1,5 +1,5 @@
 ---
-- include: ../rest/push.yaml
+- include: ../api/push.yaml
   vars:
     testname: "environment limits - allow production"
     node_version: 8
@@ -8,7 +8,7 @@
     branch: master
     expected_status: 200
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
-- include: ../rest/push.yaml
+- include: ../api/push.yaml
   vars:
     testname: "environment limits - allow deployment of existing branch"
     node_version: 8
@@ -18,7 +18,7 @@
     expected_status: 200
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: ../rest/push.yaml
+- include: ../api/push.yaml
   vars:
     testname: "environment limits - prevent deployment of new branch"
     node_version: 8

--- a/tests/tests/features/multiproject.yaml
+++ b/tests/tests/features/multiproject.yaml
@@ -8,23 +8,23 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on first project {{ project1 }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on first project {{ project1 }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project1 }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on second project {{ project2 }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on second project {{ project2 }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project2 }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: ../../checks/check-branch-sha.yaml
   vars:

--- a/tests/tests/features/openshift-limit.yaml
+++ b/tests/tests/features/openshift-limit.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy of {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: ../../checks/check-branch-sha.yaml
   vars:

--- a/tests/tests/features/promote.yaml
+++ b/tests/tests/features/promote.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for git branch {{ source_environment }} on {{ project }}, which will deploy our source environment"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }} for branch {{ source_environment }}, which will deploy our source environment"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ source_environment }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: ../../checks/check-branch-sha.yaml
   vars:
@@ -24,7 +24,7 @@
     project: "{{ project }}"
     url: "{{ check_url_source }}"
 
-- name: "{{ testname }} - rest2tasks promote post for target environment {{ promote_environment }} with source environment {{ source_environment }} on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentPromote for target environment {{ promote_environment }} with source environment {{ source_environment }} on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
@@ -32,7 +32,7 @@
     source_environment: "{{ source_environment }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/promote.yaml
+  - include: ../../tasks/api/promote.yaml
 
 - include: ../../checks/check-branch-sha.yaml
   vars:

--- a/tests/tests/features/remote-shell.yaml
+++ b/tests/tests/features/remote-shell.yaml
@@ -7,14 +7,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if we can connect via lagoon user"
   hosts: localhost

--- a/tests/tests/features/route-env-variables.yaml
+++ b/tests/tests/features/route-env-variables.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the environment variable LAGOON_ROUTE"
   hosts: localhost

--- a/tests/tests/features/subfolder.yaml
+++ b/tests/tests/features/subfolder.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks deploy post for just git branch on {{ project }}"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: ../../checks/check-branch-sha.yaml
   vars:

--- a/tests/tests/nginx/nginx.yaml
+++ b/tests/tests/nginx/nginx.yaml
@@ -8,14 +8,14 @@
   - include: ../../tasks/git-init.yaml
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the first commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-first.yaml
   vars:
@@ -31,14 +31,14 @@
   tasks:
   - include: ../../tasks/git-add-commit-push.yaml
 
-- name: "{{ testname }} - rest2tasks /deploy POST for just git branch on {{ project }}, which should deploy the second commit"
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the second commit"
   hosts: localhost
   serial: 1
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
   tasks:
-  - include: ../../tasks/rest/deploy-no-sha.yaml
+  - include: ../../tasks/api/deploy-no-sha.yaml
 
 - include: check-second.yaml
   vars:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

### API
New mutations added to the API to trigger deployments. Examples:

```graphql
# Deploy latest code for an environment that already exists
mutation deployEnvironmentLatest {
  deployEnvironmentLatest (input: {
    environment: {
      name: "nginx"
      project: {
        name: "ci-nginx"
      }
    }
  })
}

# Deploy latest or specific commit for an environment that does or does not already exist
mutation deployEnvironmentBranch {
  deployEnvironmentBranch(input:{
    project: {
      name: "ci-nginx"
    }
    branchName: "nginx"
    branchRef: "b82sx9234"
  })
}

mutation deployEnvironmentPullrequest {
  deployEnvironmentPullrequest(input: {
    project: {
      name: "ci-nginx"
    }
    number: 5
    title: "111 Add New Feature"
    baseBranchName: "master"
    baseBranchRef: "origin/master"
    headBranchName: "111-add-new-feature"
    headBranchRef: "origin/111-add-new-feature"
  })
}

mutation deployEnvironmentPromote {
  deployEnvironmentPromote(input: {
    sourceEnvironment: {
      name: "source"
      project: {
        name: "ci-features"
      }
    }
    branchName:"target"
    project: {
      name:"ci-features"
    }
  })
}
```

In order to facilitate deployments, new information is tracked for environments and is now required when creating/updating them. Example:

```json
"environmentByOpenshiftProjectName": {
  "id": 3,
  "openshiftProjectName": "high-cotton-master",
  "name": "Master",
  "deployType": "branch",
  "deployTitle": null,
  "deployBaseRef": "Master",
  "deployHeadRef": null
}
```

### UI

Environments that have been configured with deployment information will have a new button on the deployments page to trigger a deploy of the latest code for that environment.

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/92499/54063677-a98ce980-41d3-11e9-87a5-8137c18ca6c7.png">


# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Feature - API has new mutations for triggering deployments
Change - API requires new deployment information when creating/updating environments
Improvement - UI can now trigger new deployments for environments (#838)
Change - rest2tasks is deprecated in favor of API

## Deployment notes
For existing environments, at lest one deployment must happen via non-ui methods before the "deploy" button will show up in the ui. New environments will get the button immediately.

# Closing issues
Closes #838