### PR TITLE
Get job pod templates from DeploymentConfig instead of running Pods

### DIFF
--- a/services/openshiftjobs/src/index.js
+++ b/services/openshiftjobs/src/index.js
@@ -99,16 +99,6 @@ const messageConsumer = async msg => {
     }
   });
 
-  // Kubernetes API Object - needed as some API calls are done to the Kubernetes API part of OpenShift and
-  // the OpenShift API does not support them.
-  const kubernetes = new OpenShiftClient.Core({
-    url: openshiftConsole,
-    insecureSkipTlsVerify: true,
-    auth: {
-      bearer: openshiftToken
-    }
-  });
-
   const batchApi = new OpenShiftClient.Batch({
     url: openshiftConsole,
     insecureSkipTlsVerify: true,
@@ -134,17 +124,17 @@ const messageConsumer = async msg => {
   // Get pod spec for desired service
   let taskPodSpec;
   try {
-    const podsGet = promisify(kubernetes.ns(openshiftProject).pods.get);
-    const pods = await podsGet();
+    const deploymentConfigsGet = promisify(openshift.ns(openshiftProject).deploymentconfigs.get);
+    const deploymentConfigs = await deploymentConfigsGet();
 
-    const oneContainerPerSpec = pods.items.reduce(
-      (specs, pod) => ({
+    const oneContainerPerSpec = deploymentConfigs.items.reduce(
+      (specs, deploymentConfig) => ({
         ...specs,
-        ...pod.spec.containers.reduce(
+        ...deploymentConfig.spec.template.spec.containers.reduce(
           (specs, container) => ({
             ...specs,
             [container.name]: {
-              ...pod.spec,
+              ...deploymentConfig.spec.template.spec,
               containers: [container]
             }
           }),


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Changelog entry has been written

The current task system uses existing openshift pods as a source for creating new openshift job pods. If the pods are idled, the task system will not find a running pod of the correct service and the `openshiftjob` service will bail out. This causes the task to not be able to run.

This PR changes to querying the openshift `DeploymentConfigs` instead of the pods, so a template can always be found (assuming an appropriate service exists for the project). Testing showed that pods created this way have the same config as if the template was copied from another pod.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Get job pod templates from DeploymentConfig instead of running Pods (#895)

# Closing issues
closes #895 