### PR TITLE
Ensure the searchguard init script is only run on initial deployment

### DIFF
--- a/docs/administering_lagoon/install.md
+++ b/docs/administering_lagoon/install.md
@@ -62,6 +62,13 @@ In order to use a local Lagoon to deploy itself on an OpenShift, we need a subse
 
 4.  As soon as the build is done, go to the `Application > Deployments` section of the OpenShift Project and you should see all the Lagoon Deployment Configs deployed and running. Also go to `Application > Routes` and click on the generated route for `rest2tasks` (for a local OpenShift this will be http://rest2tasks-lagoon-develop.192.168.99.100.xip.io/), if you get `welcome to rest2tasks` as result, you did everything correct, bravo!
 
+### Searchguard
+
+Once Lagoon is install operational you need to initialise Searchguard to allow Kibana multitenancy. This only needs to be run once in a new setup of lagoon.
+
+1. Open a shell of an elasticsearch pod in logs-db.
+2. run ./sgadmin_demo.sh
+
 ### Configure Installed Lagoon
 
 We have now a fully running Lagoon. Now it's time to configure the first project inside of it. Follow the examples in [GraphQL API](/administering_lagoon/graphql_api.md)

--- a/services/logs-db/start.sh
+++ b/services/logs-db/start.sh
@@ -28,10 +28,4 @@ while [[ RET -ne 0 ]]; do
     sleep 5
 done
 
-if [[ $(curl -s -XGET -k -u "admin:$LOGSDB_ADMIN_PASSWORD" "http://localhost:9200/_searchguard") =~ "Search Guard not initialized" ]]; then
-
-    echo "SearchGuard: Initializing..."
-    ./sgadmin_demo.sh
-fi
-
 fg


### PR DESCRIPTION
We have had a number of cases where the init script is run on a restart of the `logs-db` pod and resets the tenants to the default configuration.

This PR ensures that the searchguard init script `sgadmin_demo.sh` is only run on the initial deployment of `logs-db`.

You can also delete the state file and redeploy if you need to reset an existing deployment. 