### PR TITLE
876 environment limit display

### DIFF
--- a/services/ui/src/components/Project/index.js
+++ b/services/ui/src/components/Project/index.js
@@ -68,11 +68,11 @@ class Project extends React.Component {
               <div className='field'>{this.props.project.pullrequests}</div>
             </div>
           </div>
-        </div>
-        <div className='field-wrapper envlimit'>
-          <div>
-            <label>Non-Production environments in use</label>
-            <div className='field'>{this.props.project.environments.length} of {this.props.project.developmentEnvironmentsLimit} </div>
+          <div className='field-wrapper envlimit'>
+            <div>
+              <label>Non-Production environments in use</label>
+              <div className='field'>{this.props.project.environments.length} of {this.props.project.developmentEnvironmentsLimit} </div>
+            </div>
           </div>
         </div>
         <div className="environments-wrapper">

--- a/services/ui/src/components/Project/index.js
+++ b/services/ui/src/components/Project/index.js
@@ -74,7 +74,7 @@ class Project extends React.Component {
           </div>
           <div className='field-wrapper envlimit'>
             <div>
-              <label>Non-Production environments in use</label>
+              <label>Development environments in use</label>
               <div className='field'>{this.state.developEnvironmentCount} of {R.defaultTo('unlimited', this.props.project.developmentEnvironmentsLimit)}</div>
             </div>
           </div>

--- a/services/ui/src/components/Project/index.js
+++ b/services/ui/src/components/Project/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as R from 'ramda';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import moment from 'moment';
 import Environment from '../EnvironmentTeaser';
@@ -11,6 +12,8 @@ class Project extends React.Component {
 
     const gitUrlParsed = giturlparse(this.props.project.gitUrl);
     const gitLink = `${gitUrlParsed.resource}/${gitUrlParsed.full_name}`;
+    const environmentCount = R.countBy(R.prop('environmentType'))(this.props.project.environments)
+    const developEnvironmentCount = environmentCount.development ? environmentCount.development: 0;
 
     this.state = {
       project: [],
@@ -18,6 +21,7 @@ class Project extends React.Component {
       copied: false,
       gitLinkWithScheme: `https://${gitLink}`,
       gitLink: gitLink,
+      developEnvironmentCount: developEnvironmentCount,
     };
   }
 
@@ -71,7 +75,7 @@ class Project extends React.Component {
           <div className='field-wrapper envlimit'>
             <div>
               <label>Non-Production environments in use</label>
-              <div className='field'>{this.props.project.environments.length} of {this.props.project.developmentEnvironmentsLimit} </div>
+              <div className='field'>{this.state.developEnvironmentCount} of {this.props.project.developmentEnvironmentsLimit} </div>
             </div>
           </div>
         </div>

--- a/services/ui/src/components/Project/index.js
+++ b/services/ui/src/components/Project/index.js
@@ -69,6 +69,12 @@ class Project extends React.Component {
             </div>
           </div>
         </div>
+        <div className='field-wrapper envlimit'>
+          <div>
+            <label>Non-Production environments in use</label>
+            <div className='field'>{this.props.project.environments.length} of {this.props.project.developmentEnvironmentsLimit} </div>
+          </div>
+        </div>
         <div className="environments-wrapper">
           <h3>Environments</h3>
           <div className="environments">

--- a/services/ui/src/components/Project/index.js
+++ b/services/ui/src/components/Project/index.js
@@ -75,7 +75,7 @@ class Project extends React.Component {
           <div className='field-wrapper envlimit'>
             <div>
               <label>Non-Production environments in use</label>
-              <div className='field'>{this.state.developEnvironmentCount} of {this.props.project.developmentEnvironmentsLimit} </div>
+              <div className='field'>{this.state.developEnvironmentCount} of {R.defaultTo('unlimited', this.props.project.developmentEnvironmentsLimit)}</div>
             </div>
           </div>
         </div>

--- a/services/ui/src/pages/project.js
+++ b/services/ui/src/pages/project.js
@@ -18,6 +18,7 @@ const query = gql`
       created
       gitUrl
       productionEnvironment
+      developmentEnvironmentsLimit
       environments {
         id
         name


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Previously, there was no way to determine what the development environment limit was. This change will add it as a field to the UI.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
--> 
Improvement - Displays number of used and limit of non-production environments (#876 )

# Closing issues
Closes #876 