### PR TITLE
#877 - do not announce retry

### DIFF
--- a/services/openshiftremove/src/index.js
+++ b/services/openshiftremove/src/index.js
@@ -194,4 +194,8 @@ ${lastError}
 
 }
 
-consumeTasks('remove-openshift', messageConsumer, deathHandler)
+const retryHandler = async (msg, error, retryCount, retryExpirationSecs) => {
+  return
+}
+
+consumeTasks('remove-openshift', messageConsumer, retryHandler, deathHandler)

--- a/services/openshiftremove/src/index.js
+++ b/services/openshiftremove/src/index.js
@@ -194,23 +194,4 @@ ${lastError}
 
 }
 
-const retryHandler = async (msg, error, retryCount, retryExpirationSecs) => {
-  const {
-    projectName,
-    branch,
-    pullrequestNumber,
-    type
-  } = JSON.parse(msg.content.toString())
-
-  const openshiftProject = ocsafety(`${projectName}-${branch || pullrequestNumber}`)
-
-  sendToLagoonLogs('warn', projectName, "", "task:remove-openshift:retry", {error: error, msg: JSON.parse(msg.content.toString()), retryCount: retryCount},
-`*[${projectName}]* remove \`${openshiftProject}\` ERROR:
-\`\`\`
-${error}
-\`\`\`
-Retrying in ${retryExpirationSecs} secs`
-  )
-}
-
-consumeTasks('remove-openshift', messageConsumer, retryHandler, deathHandler)
+consumeTasks('remove-openshift', messageConsumer, deathHandler)


### PR DESCRIPTION
Remove announcement of retry during environment deletion. The retry can be found in the logs, and announcing the retry in slack/rocketchat causes confusion for customers.

closes #877 