### PR TITLE
Refactor Publishing of Lagoon Images:

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ node {
         stage ('Checkout') {
           def checkout = checkout scm
           env.GIT_COMMIT = checkout["GIT_COMMIT"]
+          sh "git fetch --tags"
         }
 
         stage ('build images') {

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ MINISHIFT_DISK_SIZE := 30GB
 CI_BUILD_TAG ?= lagoon
 
 ARCH := $(shell uname)
-VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo development)
-# Docker Image Tag that should be used when publishing to docker hub registry
-PUBLISH_TAG :=
+LAGOON_VERSION := $(shell git describe --tags)
+# Name of the Branch we are currently in
+BRANCH_NAME :=
 
 #######
 ####### Functions
@@ -77,25 +77,24 @@ PUBLISH_TAG :=
 
 # Builds a docker image. Expects as arguments: name of the image, location of Dockerfile, path of
 # Docker Build Context
-docker_build = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) -t $(CI_BUILD_TAG)/$(1) -f $(2) $(3)
+docker_build = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) -t $(CI_BUILD_TAG)/$(1) -f $(2) $(3)
 
 # Build a PHP docker image. Expects as arguments:
 # 1. PHP version
 # 2. PHP version and type of image (ie 7.0-fpm, 7.0-cli etc)
 # 3. Location of Dockerfile
 # 4. Path of Docker Build Context
-docker_build_php = docker build $(DOCKER_BUILD_PARAMS) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg PHP_VERSION=$(1) -t $(CI_BUILD_TAG)/php:$(2) -f $(3) $(4)
+docker_build_php = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg PHP_VERSION=$(1) -t $(CI_BUILD_TAG)/php:$(2) -f $(3) $(4)
 
-docker_build_node = docker build $(DOCKER_BUILD_PARAMS) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg NODE_VERSION=$(1) -t $(CI_BUILD_TAG)/node:$(2) -f $(3) $(4)
+docker_build_node = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg NODE_VERSION=$(1) -t $(CI_BUILD_TAG)/node:$(2) -f $(3) $(4)
 
-docker_build_solr = docker build $(DOCKER_BUILD_PARAMS) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg SOLR_MAJ_MIN_VERSION=$(1) -t $(CI_BUILD_TAG)/solr:$(2) -f $(3) $(4)
+docker_build_solr = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg SOLR_MAJ_MIN_VERSION=$(1) -t $(CI_BUILD_TAG)/solr:$(2) -f $(3) $(4)
 
-# Tags and image with the `amazeeio` repository and pushes it
-docker_publish_amazeeio_baseimages = docker tag $(CI_BUILD_TAG)/$(1) amazeeio/$(1) && docker push amazeeio/$(1) | cat
+# Tags an image with the `amazeeio` repository and pushes it
+docker_publish_amazeeio = echo "docker tag $(CI_BUILD_TAG)/$(1) amazeeio/$(2) && docker push amazeeio/$(2) | cat"
 
-# Tags and image with the `amazeeiolagoon` repository and pushes it
-docker_publish_amazeeiolagoon_serviceimages = docker tag $(CI_BUILD_TAG)/$(1) amazeeiolagoon/$(1):$(PUBLISH_TAG) && docker push amazeeiolagoon/$(1):$(PUBLISH_TAG) | cat
-docker_publish_amazeeiolagoon_baseimages = docker tag $(CI_BUILD_TAG)/$(1) amazeeiolagoon/$(PUBLISH_TAG)-$(1) && docker push amazeeiolagoon/$(PUBLISH_TAG)-$(1) | cat
+# Tags an image with the `amazeeiolagoon` repository and pushes it
+docker_publish_amazeeiolagoon = echo "docker tag $(CI_BUILD_TAG)/$(1) amazeeiolagoon/$(2) && docker push amazeeiolagoon/$(2) | cat"
 
 
 #######
@@ -220,7 +219,7 @@ $(build-phpimages): build/commons
 # Touch an empty file which make itself is using to understand when the image has been last build
 	touch $@
 
-base-images += $(phpimages)
+base-images-with-versions += $(phpimages)
 s3-images += php
 
 build/php__5.6-fpm build/php__7.0-fpm build/php__7.1-fpm build/php__7.2-fpm build/php__7.3-fpm: images/commons
@@ -262,7 +261,7 @@ $(build-solrimages): build/commons
 # Touch an empty file which make itself is using to understand when the image has been last build
 	touch $@
 
-base-images += $(solrimages)
+base-images-with-versions += $(solrimages)
 s3-images += solr
 
 build/solr__5.5  build/solr__6.6 build/solr__7.5: images/commons
@@ -299,7 +298,7 @@ $(build-nodeimages): build/commons
 # Touch an empty file which make itself is using to understand when the image has been last build
 	touch $@
 
-base-images += $(nodeimages)
+base-images-with-versions += $(nodeimages)
 s3-images += node
 
 build/node__9 build/node__8 build/node__6: images/commons images/node/Dockerfile
@@ -427,7 +426,7 @@ s3-images += $(service-images)
 
 # Builds all Images
 .PHONY: build
-build: $(foreach image,$(base-images) $(service-images),build/$(image))
+build: $(foreach image,$(base-images) $(base-images-with-versions) $(service-images),build/$(image))
 # Outputs a list of all Images we manage
 .PHONY: build-list
 build-list:
@@ -509,7 +508,7 @@ end2end-tests/clean:
 		docker-compose -f docker-compose.yaml -f docker-compose.end2end.yaml -p end2end down -v
 
 # push command of our base images into minishift
-push-minishift-images = $(foreach image,$(base-images),[push-minishift]-$(image))
+push-minishift-images = $(foreach image,$(base-images) $(base-images-with-versions),[push-minishift]-$(image))
 # tag and push all images
 .PHONY: push-minishift
 push-minishift: minishift/login-docker-registry $(push-minishift-images)
@@ -536,46 +535,81 @@ lagoon-kickstart: $(foreach image,$(deployment-test-services-rest),build/$(image
 
 # Publish command to amazeeio docker hub, this should probably only be done during a master deployments
 publish-amazeeio-baseimages = $(foreach image,$(base-images),[publish-amazeeio-baseimages]-$(image))
-
+publish-amazeeio-baseimages-with-versions = $(foreach image,$(base-images-with-versions),[publish-amazeeio-baseimages-with-versions]-$(image))
 # tag and push all images
 .PHONY: publish-amazeeio-baseimages
-publish-amazeeio-baseimages: $(publish-amazeeio-baseimages)
+publish-amazeeio-baseimages: $(publish-amazeeio-baseimages) $(publish-amazeeio-baseimages-with-versions)
+
+
 # tag and push of each image
 .PHONY: $(publish-amazeeio-baseimages)
 $(publish-amazeeio-baseimages):
-#   Calling docker_publish for image, but remove the prefix '[[publish]]-' first
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeio-baseimages]-' first
 		$(eval image = $(subst [publish-amazeeio-baseimages]-,,$@))
+# 	Publish images as :latest
+		$(call docker_publish_amazeeio,$(image),$(image):latest)
+# 	Publish images with version tag
+		$(call docker_publish_amazeeio,$(image),$(image):$(LAGOON_VERSION))
+
+
+# tag and push of base image with version
+.PHONY: $(publish-amazeeio-baseimages-with-versions)
+$(publish-amazeeio-baseimages-with-versions):
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeio-baseimages-with-versions]-' first
+		$(eval image = $(subst [publish-amazeeio-baseimages-with-versions]-,,$@))
+#   The underline is a placeholder for a colon, replace that
 		$(eval image = $(subst __,:,$(image)))
-		$(call docker_publish_amazeeio_baseimages,$(image))
+#		These images already use a tag to differentiate between different versions of the service itself (like node:9 and node:10)
+#		Therefore they don't have any latest tag
+		$(call docker_publish_amazeeio,$(image),$(image))
+#		We add the Lagoon Version just as a dash
+		$(call docker_publish_amazeeio,$(image),$(image)-$(LAGOON_VERSION))
+
 
 
 # Publish command to amazeeio docker hub, this should probably only be done during a master deployments
 publish-amazeeiolagoon-baseimages = $(foreach image,$(base-images),[publish-amazeeiolagoon-baseimages]-$(image))
-
+publish-amazeeiolagoon-baseimages-with-versions = $(foreach image,$(base-images-with-versions),[publish-amazeeiolagoon-baseimages-with-versions]-$(image))
 # tag and push all images
 .PHONY: publish-amazeeiolagoon-baseimages
-publish-amazeeiolagoon-baseimages: $(publish-amazeeiolagoon-baseimages)
+publish-amazeeiolagoon-baseimages: $(publish-amazeeiolagoon-baseimages) $(publish-amazeeiolagoon-baseimages-with-versions)
+
+
 # tag and push of each image
 .PHONY: $(publish-amazeeiolagoon-baseimages)
 $(publish-amazeeiolagoon-baseimages):
-#   Calling docker_publish for image, but remove the prefix '[[publish]]-' first
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeiolagoon-baseimages]-' first
 		$(eval image = $(subst [publish-amazeeiolagoon-baseimages]-,,$@))
+# 	Publish images with version tag
+		$(call docker_publish_amazeeiolagoon,$(image),$(image):$(BRANCH_NAME))
+
+
+# tag and push of base image with version
+.PHONY: $(publish-amazeeiolagoon-baseimages-with-versions)
+$(publish-amazeeiolagoon-baseimages-with-versions):
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeiolagoon-baseimages-with-versions]-' first
+		$(eval image = $(subst [publish-amazeeiolagoon-baseimages-with-versions]-,,$@))
+#   The underline is a placeholder for a colon, replace that
 		$(eval image = $(subst __,:,$(image)))
-		$(call docker_publish_amazeeiolagoon_baseimages,$(image))
+#		We add the Lagoon Version just as a dash
+		$(call docker_publish_amazeeiolagoon,$(image),$(image)-$(BRANCH_NAME))
 
-# Publish command to amazeeiolagoon docker hub, we want all branches there, so this is save to run on every deployment
+
+# Publish command to amazeeio docker hub, this should probably only be done during a master deployments
 publish-amazeeiolagoon-serviceimages = $(foreach image,$(service-images),[publish-amazeeiolagoon-serviceimages]-$(image))
-
 # tag and push all images
 .PHONY: publish-amazeeiolagoon-serviceimages
 publish-amazeeiolagoon-serviceimages: $(publish-amazeeiolagoon-serviceimages)
+
+
 # tag and push of each image
-.PHONY: $(publish-amazeeiolagoon-serviceimagesimages)
+.PHONY: $(publish-amazeeiolagoon-serviceimages)
 $(publish-amazeeiolagoon-serviceimages):
-#   Calling docker_publish for image, but remove the prefix '[[publish]]-' first
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeiolagoon-serviceimages]-' first
 		$(eval image = $(subst [publish-amazeeiolagoon-serviceimages]-,,$@))
-		$(eval image = $(subst __,:,$(image)))
-		$(call docker_publish_amazeeiolagoon_serviceimages,$(image))
+# 	Publish images with version tag
+		$(call docker_publish_amazeeiolagoon,$(image),$(image):$(BRANCH_NAME))
+
 
 s3-save = $(foreach image,$(s3-images),[s3-save]-$(image))
 # save all images to s3

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ MINISHIFT_DISK_SIZE := 30GB
 CI_BUILD_TAG ?= lagoon
 
 ARCH := $(shell uname)
-LAGOON_VERSION := $(shell git describe --tags)
+LAGOON_VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo development)
 # Name of the Branch we are currently in
 BRANCH_NAME :=
 

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -26,6 +26,7 @@ RUN chmod g+w /etc/passwd
 
 ARG LAGOON_VERSION
 RUN echo $LAGOON_VERSION > /lagoon/version
+ENV LAGOON_VERSION=$LAGOON_VERSION
 
 ENV TMPDIR=/tmp \
     TMP=/tmp \

--- a/images/curator/Dockerfile
+++ b/images/curator/Dockerfile
@@ -7,6 +7,9 @@ USER root
 LABEL maintainer="amazee.io"
 ENV LAGOON=curator
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -5,6 +5,9 @@ FROM docker:stable-dind
 LABEL maintainer="amazee.io"
 ENV LAGOON=docker-host
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -5,6 +5,9 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.1
 LABEL maintainer="amazee.io"
 ENV LAGOON=elasticsearch
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -7,6 +7,9 @@ ENV LAGOON=kibana
 
 USER root
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/logstash/Dockerfile
+++ b/images/logstash/Dockerfile
@@ -7,6 +7,9 @@ ENV LAGOON=logstash
 
 USER root
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/mariadb-galera/Dockerfile
+++ b/images/mariadb-galera/Dockerfile
@@ -4,6 +4,9 @@ FROM alpine:3.7
 
 MAINTAINER amazee.io
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copying commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -4,6 +4,9 @@ FROM alpine:3.8
 
 LABEL maintainer="amazee.io"
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/mongo/Dockerfile
+++ b/images/mongo/Dockerfile
@@ -5,6 +5,8 @@ FROM alpine:3.8
 LABEL maintainer="amazee.io"
 ENV LAGOON=mongo
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
 
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -5,6 +5,9 @@ FROM openresty/openresty:alpine
 LABEL maintainer="amazee.io"
 ENV LAGOON=nginx
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -6,6 +6,9 @@ FROM node:${NODE_VERSION}-alpine
 LABEL maintainer="amazee.io"
 ENV LAGOON=node
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -12,6 +12,9 @@ ENV LAGOON=oc
 
 COPY --from=golang /go/bin/envsubst /bin/envsubst
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -6,6 +6,9 @@ FROM php:${PHP_VERSION}-fpm-alpine
 LABEL maintainer="amazee.io"
 ENV LAGOON=php
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -2,6 +2,9 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM postgres:alpine
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,5 +1,8 @@
 FROM rabbitmq:3-management
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 COPY rabbitmq_delayed_message_exchange-3.7.0.ez /plugins
 
 RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange;

--- a/images/redis/Dockerfile
+++ b/images/redis/Dockerfile
@@ -6,6 +6,9 @@ LABEL maintainer="amazee.io"
 ENV LAGOON=redis
 ENV FLAVOR=ephemeral
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/solr/Dockerfile
+++ b/images/solr/Dockerfile
@@ -6,6 +6,9 @@ FROM solr:${SOLR_MAJ_MIN_VERSION}-alpine
 LABEL maintainer="amazee.io"
 ENV LAGOON=solr
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/images/varnish/Dockerfile
+++ b/images/varnish/Dockerfile
@@ -19,6 +19,9 @@ FROM alpine:3.7
 LABEL maintainer="amazee.io"
 ENV LAGOON=varnish
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/

--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -15,7 +15,10 @@ initSendToLagoonLogs();
 initSendToLagoonTasks();
 
 const CI = process.env.CI || "false"
-const gitSafeBranch = process.env.LAGOON_GIT_SAFE_BRANCH || "master"
+const lagoonGitSafeBranch = process.env.LAGOON_GIT_SAFE_BRANCH || "master"
+const lagoonVersion = process.env.LAGOON_VERSION
+const overwriteOcBuildDeployDindImage = process.env.OVERWRITE_OC_BUILD_DEPLOY_DIND_IMAGE
+const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
 
 const messageConsumer = async msg => {
   const {
@@ -103,13 +106,25 @@ const messageConsumer = async msg => {
       buildFromImage = {
         "kind": "ImageStreamTag",
         "namespace": "lagoon",
-        "name": "oc-build-deploy-dind:latest"
+        "name": "oc-build-deploy-dind:latest",
       }
-    } else {
-    // By default we load oc-build-deploy-dind from DockerHub with our current branch as tag
+    } else if (overwriteOcBuildDeployDindImage) {
+      // allow to overwrite the image we use via OVERWRITE_OC_BUILD_DEPLOY_DIND_IMAGE env variable
       buildFromImage = {
         "kind": "DockerImage",
-        "name": `amazeeiolagoon/${gitSafeBranch}-oc-build-deploy-dind`
+        "name": overwriteOcBuildDeployDindImage,
+      }
+    } else if (lagoonEnvironmentType == 'production') {
+      // we are a production environment, use the amazeeio/ image with our current lagoon version
+      buildFromImage = {
+        "kind": "DockerImage",
+        "name": `amazeeio/oc-build-deploy-dind:${lagoonVersion}`,
+      }
+    } else {
+      // we are a development enviornment, use the amazeeiolagoon image with the same branch name
+      buildFromImage = {
+        "kind": "DockerImage",
+        "name": `amazeeiolagoon/oc-build-deploy-dind:${lagoonGitSafeBranch}`,
       }
     }
 


### PR DESCRIPTION
- Jenkins only publishes images to amazeeio/* during a tag build
- also publishing Lagoon Images with a Version tag
- Inject Version Number into all Images
- openshiftbuilddeploy uses Version Number to choose which oc-build-deploy-dind to use and does not blindly use master anymore