### PR TITLE
Avoid running a lot of builds for a project in a row

### DIFF
--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -125,7 +125,7 @@ const messageConsumer = async msg => {
           "nodeSelector": null,
           "postCommit": {},
           "resources": {},
-          "runPolicy": "Serial",
+          "runPolicy": "SerialLatestOnly",
           "successfulBuildsHistoryLimit": 1,
           "failedBuildsHistoryLimit": 1,
           "source": {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

> after merging multiple PRs into develop, multiple builds will be triggered on openshift. we should find a way to cancel previous builds. pls provide feasible solutions how openshift could handle that. thanks

Openshift has a `BuildConfig` `RunPolicy` of [`SerialLatestOnly`](https://docs.openshift.com/container-platform/3.9/dev_guide/builds/build_run_policy.html#build-serial-latest-only-run-policy) which is designed for this use case.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Avoid running a lot of builds for a project in a row

# Closing issues

N/A