### PR TITLE
Add LAGOON_API_OPERATION_BLACKLIST environment variable to api

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -36,6 +36,7 @@
     "graphql": "^0.13.2",
     "graphql-iso-date": "^3.5.0",
     "graphql-list-fields": "^2.0.2",
+    "graphql-middleware": "^3.0.2",
     "graphql-rabbitmq-subscriptions": "^1.1.0",
     "graphql-subscriptions": "^1.0.0",
     "graphql-tools": "^2.5.0",

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -9,6 +9,7 @@ const gql = require('./util/gql');
 // Ref: https://github.com/prettier/prettier/issues/4974
 // prettier-ignore
 const typeDefs = gql`
+  scalar Upload
   scalar Date
 
   enum SshKeyType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5657,6 +5657,13 @@ graphql-list-fields@^2.0.2:
   resolved "https://registry.yarnpkg.com/graphql-list-fields/-/graphql-list-fields-2.0.2.tgz#a4ade3cfa2028a2ac32d3f2870f5f8c5b5d5b466"
   integrity sha512-9TSAwcVA3KWw7JWYep5NCk2aw3wl1ayLtbMpmG7l26vh1FZ+gZexNPP+XJfUFyJa71UU0zcKSgtgpsrsA3Xv9Q==
 
+graphql-middleware@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-3.0.2.tgz#c8cdb67615eec02aec237b455e679f5fc973ddc4"
+  integrity sha512-sRqu1sF+77z42z1OVM1QDHKQWnWY5K3nAgqWiZwx3U4tqNZprrDuXxSChPMliV343IrVkpYdejUYq9w24Ot3FA==
+  dependencies:
+    graphql-tools "^4.0.4"
+
 graphql-rabbitmq-subscriptions@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/graphql-rabbitmq-subscriptions/-/graphql-rabbitmq-subscriptions-1.1.0.tgz#43a8de9f8a6ab8e8d48e60d0c8b8bc6e6ec16bc2"
@@ -5703,6 +5710,17 @@ graphql-tools@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.3.tgz#23b5cb52c519212b1b2e4630a361464396ad264b"
   integrity sha512-NNZM0WSnVLX1zIMUxu7SjzLZ4prCp15N5L2T2ro02OVyydZ0fuCnZYRnx/yK9xjGWbZA0Q58yEO//Bv/psJWrg==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
+graphql-tools@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
+  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
   dependencies:
     apollo-link "^1.2.3"
     apollo-utilities "^1.0.1"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

Add new environment variable `LAGOON_API_OPERATION_BLACKLIST` to require `admin` role for operations (Query, Mutation, or Subscription) listed in the environment variable. The list is case and whitespace sensitive, comma separated. Values are the names of the operations from the API.

Example:
`LAGOON_API_OPERATION_BLACKLIST=updateProject,addUserToProject,allEnvironments`

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Add environment variable to restrict API operations to admins only (#967)

# Closing issues
closes #967 
