### PR TITLE
Don't load all tasks plus logs in the UI unnecessarily

### DIFF
--- a/services/api/src/resources/task/resolvers.js
+++ b/services/api/src/resources/task/resolvers.js
@@ -38,7 +38,7 @@ const taskStatusTypeToString = R.cond([
 
 const getTasksByEnvironmentId = async (
   { id: eid },
-  args,
+  { id: filterId },
   {
     credentials: {
       role,
@@ -67,7 +67,13 @@ const getTasksByEnvironmentId = async (
 
   const requestedFields = getFieldNames(info);
 
-  return newestFirst.map(row => {
+  return newestFirst.filter(row => {
+    if (R.isNil(filterId) || R.isEmpty(filterId)) {
+      return true;
+    }
+
+    return row.id === String(filterId);
+  }).map(row => {
     if (R.contains('logs', requestedFields)) {
       return Helpers.injectLogs(row);
     }

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -338,7 +338,7 @@ const typeDefs = gql`
     monitoringUrls: String
     deployments(name: String): [Deployment]
     backups(includeDeleted: Boolean): [Backup]
-    tasks: [Task]
+    tasks(id: Int): [Task]
     services: [EnvironmentService]
   }
 

--- a/services/ui/src/lib/query/EnvironmentWithTask.js
+++ b/services/ui/src/lib/query/EnvironmentWithTask.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import TaskFragment from 'lib/fragment/Task';
 
 export default gql`
-  query getEnvironment($openshiftProjectName: String!) {
+  query getEnvironment($openshiftProjectName: String!, $taskId: Int!) {
     environmentByOpenshiftProjectName(
       openshiftProjectName: $openshiftProjectName
     ) {
@@ -22,7 +22,7 @@ export default gql`
         id
         name
       }
-      tasks {
+      tasks(id: $taskId) {
         ...taskFields
         logs
       }

--- a/services/ui/src/pages/task.js
+++ b/services/ui/src/pages/task.js
@@ -21,7 +21,8 @@ const PageTask = ({ router }) => (
     <Query
       query={EnvironmentWithTaskQuery}
       variables={{
-        openshiftProjectName: router.query.openshiftProjectName
+        openshiftProjectName: router.query.openshiftProjectName,
+        taskId: router.query.taskId
       }}
     >
       {({
@@ -48,11 +49,7 @@ const PageTask = ({ router }) => (
           );
         }
 
-        const task = environment.tasks.find(
-          task => task.id === parseInt(router.query.taskId)
-        );
-
-        if (!task) {
+        if (!environment.tasks.length) {
           return (
             <ErrorPage
               statusCode={404}
@@ -73,7 +70,7 @@ const PageTask = ({ router }) => (
             <div className="content-wrapper">
               <NavTabs activeTab="tasks" environment={environment} />
               <div className="content">
-                <Task task={task} />
+                <Task task={environment.tasks[0]} />
               </div>
             </div>
             <style jsx>{`


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

The api didn't allow the UI to load only the data it needed, which caused slowdowns and timeouts due to the api requesting a lot of task logs from elasticsearch. The api has be updated to allow more filtering and not sending the logs all the time and the UI has been updated to use the new filter.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - UI/API load too much task data and logs and causes slow page loads and timeouts (#961)

# Closing issues
closes #961
