### PR TITLE
Fix problems when using SSH keys with a non-root users.

### DIFF
--- a/images/php/cli/05-ssh-key.sh
+++ b/images/php/cli/05-ssh-key.sh
@@ -16,5 +16,5 @@ if [ -f /home/.ssh/key ]; then
   # add a new line to the key. OpenSSH is very picky that keys are always end with a newline
   echo >> /home/.ssh/key
   # Fix permissions of SSH key
-  chmod 400 /home/.ssh/key
+  chmod 600 /home/.ssh/key
 fi


### PR DESCRIPTION
I'm using the CLI image with a SSH key set via environment variable. However this is currently not possible as non root.

I got it working with a line like
>RUN /lagoon/entrypoints/05-ssh-key.sh && chown -R 1000:1000 /home/.ssh
in the dockerfile, but since the key file is made readonly this errors out on repeated runs. 600 should be just as safe (owner can change it anyway) and makes starting the container work.

TL/DR to repeat the problem:
- Add the line above the add the key
- Start the container as non-root user with the environment variable being still set

Result:
- Error due to /home/.ssh/key being not writable anymore.

The PR fixes the problem.

