### PR TITLE
Check running builds and processes better in auto idler

### DIFF
--- a/services/auto-idler/idle-clis.sh
+++ b/services/auto-idler/idle-clis.sh
@@ -53,7 +53,7 @@ echo "$ALL_ENVIRONMENTS" | jq -c '.data.developmentEnvironments[] | select((.env
             continue;
           fi
 
-          # Check for Deploymentconfigs wich are clis
+          # Check for Deploymentconfigs which are clis
           DEPLOYMENTCONFIGS=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get dc -l service=cli -o name)
           if [ "$DEPLOYMENTCONFIGS" == "" ]; then
             echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: No deploymentconfigs for cli found"
@@ -74,18 +74,41 @@ echo "$ALL_ENVIRONMENTS" | jq -c '.data.developmentEnvironments[] | select((.env
             elif [ "$HAS_RUNNING_REPLICAS" == "true" ]; then
               echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has running pods, checking if they are non-busy"
 
-              # Now check if the container has only the entrypoint processes running (done with `ps --no-headers a` which only shows processes that have a tty)
-              RUNNING_PROCESSES=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "ps --no-headers a | wc -l | tr -d ' '")
+              # Set to false initially, if there are any processes or builds running they are adjusted then.
+              # Will also skip on any continue conditions
+              NO_PROCESSES=false
+              NO_BUILDS=false
 
+              # Check for any running processes
+              RUNNING_PROCESSES=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "pgrep -P 0 | tail -n +3 | wc -l | tr -d ' '")
               if [ ! $? -eq 0 ]; then
                 echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking for busy-ness of pods"
                 continue
               elif [ "$RUNNING_PROCESSES" == "0" ]; then
                 # Now we can scale
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: not busy, scaling to 0"
-                oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" scale --replicas=0 $deploymentconfig
+                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running processes"
+                NO_PROCESSES=true
               else
                 echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_PROCESSES running processes, skipping"
+              fi
+
+              # Check for any running builds
+              RUNNING_BUILDS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get --no-headers=true builds | grep "Running" | wc -l | tr -d ' ')
+              if [ ! $? -eq 0 ]; then
+                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking build status"
+                continue
+              elif [ "$RUNNING_BUILDS" == "0" ]; then
+                # Now we can scale
+                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running builds"
+                NO_BUILDS=true
+              else
+                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_BUILDS running builds, skipping"
+              fi
+
+              ## If there are no builds AND no processes, then we can idle the pods
+              if [[ "$NO_BUILDS" == "true" && "$NO_PROCESSES" == "true" ]]; then
+                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: not busy, scaling to 0"
+                oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" scale --replicas=0 $deploymentconfig
               fi
             else
               echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running pods"


### PR DESCRIPTION
This should fix #769 by checking if there are any running builds for a project, and also if there are any processes running beyond the entrypoint