### PR TITLE
Allow dashboard log container to be "full height"

### DIFF
--- a/services/ui/src/components/LogViewer/index.js
+++ b/services/ui/src/components/LogViewer/index.js
@@ -16,7 +16,6 @@ const LogViewer = ({ logs }) => (
           font-family: 'Monaco', monospace;
           font-size: 12px;
           font-weight: 400;
-          height: 600px;
           margin: 0;
           overflow-wrap: break-word;
           overflow-x: scroll;

--- a/services/ui/src/components/LogViewer/index.js
+++ b/services/ui/src/components/LogViewer/index.js
@@ -16,6 +16,7 @@ const LogViewer = ({ logs }) => (
           font-family: 'Monaco', monospace;
           font-size: 12px;
           font-weight: 400;
+          min-height: 600px;
           margin: 0;
           overflow-wrap: break-word;
           overflow-x: scroll;


### PR DESCRIPTION
PR for #1064 

See: https://www.govcms.support/support/tickets/2073

# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

# Changelog Entry
Change - Remove the 600px hight limit for the logs container in the deployment section of the dashboard, this allows the container to be full height #1064 

# Closing issues
Closes #1064 
