### PR TITLE
Drush 9 alias conversion must run in container

### DIFF
--- a/docs/using_lagoon/drupal/drush9.md
+++ b/docs/using_lagoon/drupal/drush9.md
@@ -14,9 +14,9 @@ In order to be able to use `drush site:alias-convert` you need to do the followi
 
 ### Generate Site aliases
 
-Now you can run the converting process:
+You can now convert your Drush aliases by running the following command in your project using the CLI container
 
-- `drush site:alias-convert`
+- `docker-compose exec cli drush site:alias-convert /app/drush/sites --yes`
 
 It's a good practice to commit the resulting yaml files into your git repo, so your fellow developers don't need to do the same all the time.
 


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

This updates the documentation to give a copy and pastable command for generating Drush 9 aliases using the provided alias stub file.

# Changelog Entry
Documentation - #1067 document Drush 9 alias generation.

# Closing issues
Closes #1067