### PR TITLE
add findutils to extend php-cli image

### DIFF
--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache git \
         coreutils \
         postgresql-client \
         openssh-sftp-server \
+        findutils \
     && apk add --no-cache "mariadb-client=10.2.22-r0" --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ \
     && apk add --no-cache nodejs-current nodejs-npm yarn --force-overwrite --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

As outlined in #1076 - the version of find provided with busybox is missing some common command-line options 

# Changelog Entry
Improvement - add findutils to php-cli image (#1076 )

# Closing issues
Closes #1076 
