### PR TITLE
Updating liveness and readiness checks for PHP to use TCPsocket

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/deployment.yml
@@ -137,15 +137,13 @@ objects:
                 - containerPort: 9000
                   protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 2
                 periodSeconds: 5
               livenessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 60
                 periodSeconds: 5
               envFrom:

--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php-redis-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php-redis-persistent/deployment.yml
@@ -145,15 +145,13 @@ objects:
                 - containerPort: 9000
                   protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 2
                 periodSeconds: 5
               livenessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 60
                 periodSeconds: 5
               envFrom:

--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php/deployment.yml
@@ -121,15 +121,13 @@ objects:
                 - containerPort: 9000
                   protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 2
                 periodSeconds: 5
               livenessProbe:
-                exec:
-                  command:
-                    - /usr/sbin/check_fcgi
+                tcpSocket:
+                  port: 9000
                 initialDelaySeconds: 60
                 periodSeconds: 5
               envFrom:


### PR DESCRIPTION
Instead of running a small fcgi script. This specifically closes #1047 .