### PR TITLE
Add a .lagoon.env catchall option for variables

### DIFF
--- a/docs/using_lagoon/environment_variables.md
+++ b/docs/using_lagoon/environment_variables.md
@@ -9,9 +9,10 @@ As there can be environment variables defined in either the Dockerfile of during
 1. Environment variables (defined via Lagoon API) - Environment specific
 2. Environment variables (defined via Lagoon API) - Project wide
 3. Environment variables defined in Dockerfile (`ENV` command)
-4. Environment variables defined in `.lagoon.env.$BRANCHNAME` (if file exists and where $BRANCHNAME is the Branch this Dockerimage has been uilt for), use this for overwriting variables for only specific branches
-5. Environment variables defined in `.env`
-6. Environment variables defined in `.env.defaults`
+4. Environment variables defined in `.lagoon.env` (if exists), use this for overwriting variables for all branches
+5. Environment variables defined in `.lagoon.env.$BRANCHNAME` (if file exists and where $BRANCHNAME is the Branch this Dockerimage has been uilt for), use this for overwriting variables for only specific branches
+6. Environment variables defined in `.env`
+7. Environment variables defined in `.env.defaults`
 
 ## Environment Variables (Lagoon API)
 

--- a/docs/using_lagoon/environment_variables.md
+++ b/docs/using_lagoon/environment_variables.md
@@ -9,8 +9,8 @@ As there can be environment variables defined in either the Dockerfile of during
 1. Environment variables (defined via Lagoon API) - Environment specific
 2. Environment variables (defined via Lagoon API) - Project wide
 3. Environment variables defined in Dockerfile (`ENV` command)
-4. Environment variables defined in `.lagoon.env` (if exists), use this for overwriting variables for all branches
-5. Environment variables defined in `.lagoon.env.$BRANCHNAME` (if file exists and where $BRANCHNAME is the Branch this Dockerimage has been uilt for), use this for overwriting variables for only specific branches
+4. Environment variables defined in `.lagoon.env.$BRANCHNAME` (if file exists and where $BRANCHNAME is the Branch this Dockerimage has been built for), use this for overwriting variables for only specific branches
+5. Environment variables defined in `.lagoon.env` (if exists), use this for overwriting variables for all branches
 6. Environment variables defined in `.env`
 7. Environment variables defined in `.env.defaults`
 

--- a/images/commons/lagoon/entrypoints/50-dotenv.sh
+++ b/images/commons/lagoon/entrypoints/50-dotenv.sh
@@ -28,7 +28,7 @@ set -a
 [ -f .env.defaults ] && . ./.env.defaults  || true
 [ -f .env ] && . ./.env  || true
 # Provide a file that adds variables to all Lagoon envs, but is overridable in a specific env below
-[ -f .env ] && . ./.lagoon.env  || true
+[ -f .lagoon.env ] && . ./.lagoon.env  || true
 [ -f .lagoon.env.$LAGOON_GIT_BRANCH ] && . ./.lagoon.env.$LAGOON_GIT_BRANCH  || true
 # Branch names can have weird special chars in them which are not allowed in File names, so we also try the Branch name with special chars replaced by dashes.
 [ -f .lagoon.env.$LAGOON_GIT_SAFE_BRANCH ] && . ./.lagoon.env.$LAGOON_GIT_SAFE_BRANCH  || true

--- a/images/commons/lagoon/entrypoints/50-dotenv.sh
+++ b/images/commons/lagoon/entrypoints/50-dotenv.sh
@@ -27,6 +27,8 @@ export -p > $TMPFILE
 set -a
 [ -f .env.defaults ] && . ./.env.defaults  || true
 [ -f .env ] && . ./.env  || true
+# Provide a file that adds variables to all Lagoon envs, but is overridable in a specific env below
+[ -f .env ] && . ./.lagoon.env  || true
 [ -f .lagoon.env.$LAGOON_GIT_BRANCH ] && . ./.lagoon.env.$LAGOON_GIT_BRANCH  || true
 # Branch names can have weird special chars in them which are not allowed in File names, so we also try the Branch name with special chars replaced by dashes.
 [ -f .lagoon.env.$LAGOON_GIT_SAFE_BRANCH ] && . ./.lagoon.env.$LAGOON_GIT_SAFE_BRANCH  || true


### PR DESCRIPTION
Adding a .lagoon.env file to allow overwriting variables for all branches on Lagoon only - not affecting Local dev (customisation possible via .env file)
 
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Provides a .lagoon.env file for catch-all variables (#1107 )

# Closing issues
Closes #1107 
