### PR TITLE
Add `order` field to `allProjects` and `allEnvironments` GraphQL API endpoints

### DIFF
--- a/services/api/src/resources/environment/resolvers.js
+++ b/services/api/src/resources/environment/resolvers.js
@@ -658,8 +658,12 @@ const getAllEnvironments = async (
     'deleted = "0000-00-00 00:00:00"',
   ]);
 
-  const prep = prepare(sqlClient, `SELECT * FROM environment ${where}`);
+  const order = args.order ? ` ORDER BY ${R.toLower(args.order)} ASC` : ''
+
+  const prep = prepare(sqlClient, `SELECT * FROM environment ${where}${order}`);
   const rows = await query(sqlClient, prep(args));
+
+  console.warn(rows)
   return rows;
 };
 

--- a/services/api/src/resources/environment/resolvers.js
+++ b/services/api/src/resources/environment/resolvers.js
@@ -663,7 +663,6 @@ const getAllEnvironments = async (
   const prep = prepare(sqlClient, `SELECT * FROM environment ${where}${order}`);
   const rows = await query(sqlClient, prep(args));
 
-  console.warn(rows)
   return rows;
 };
 

--- a/services/api/src/resources/project/resolvers.js
+++ b/services/api/src/resources/project/resolvers.js
@@ -46,7 +46,9 @@ const getAllProjects = async (
     ),
   ]);
 
-  const prep = prepare(sqlClient, `SELECT * FROM project ${where}`);
+  const order = args.order ? ` ORDER BY ${R.toLower(args.order)} ASC` : ''
+
+  const prep = prepare(sqlClient, `SELECT * FROM project ${where}${order}`);
   const rows = await query(sqlClient, prep(args));
 
   return rows;

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -66,6 +66,16 @@ const typeDefs = gql`
     FAILED
   }
 
+  enum EnvOrderType {
+    NAME
+    UPDATED
+  }
+
+  enum ProjectOrderType {
+    NAME
+    CREATED
+  }
+
   type File {
     id: Int
     filename: String
@@ -472,7 +482,7 @@ const typeDefs = gql`
     """
     Returns all Project Objects matching given filters (all if no filter defined)
     """
-    allProjects(createdAfter: String, gitUrl: String): [Project]
+    allProjects(createdAfter: String, gitUrl: String, order: ProjectOrderType): [Project]
     """
     Returns all Customer Objects matching given filter (all if no filter defined)
     """
@@ -484,7 +494,7 @@ const typeDefs = gql`
     """
     Returns all Environments matching given filter (all if no filter defined)
     """
-    allEnvironments(createdAfter: String, type: EnvType): [Environment]
+    allEnvironments(createdAfter: String, type: EnvType, order: EnvOrderType): [Environment]
   }
 
   # Must provide id OR name


### PR DESCRIPTION
# Description
This PR adds the ability for:
*  The output from the `allProjects` endpoint to be ordered by name or creation date
*  The output from the `allEnvironments` endpoint to be ordered by name or last updated date

# Changelog Entry
Improvement - Add `order` field to `allProjects` and `allEnvironments` GraphQL API endpoints (#1038)

# Closing Notes
Closes #1038 
