### PR TITLE
Close hanging SQL connections related to API subscriptions

### DIFF
--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -61,30 +61,35 @@ const apolloServer = new ApolloServer({
         throw new AuthenticationError('Auth token missing.');
       }
 
-      const sqlClient = getSqlClient();
 
       try {
+        var sqlClientKeycloak = getSqlClient();
         credentials = await getCredentialsForKeycloakToken(
-          sqlClient,
+          sqlClientKeycloak,
           token,
         );
+        sqlClientKeycloak.end();
       } catch (e) {
+        sqlClientKeycloak.end();
         // It might be a legacy token, so continue on.
         logger.debug(`Keycloak token auth failed: ${e.message}`);
       }
 
       try {
         if (!credentials) {
+          var sqlClientLegacy = getSqlClient();
           credentials = await getCredentialsForLegacyToken(
-            sqlClient,
+            sqlClientLegacy,
             token,
           );
+          sqlClientLegacy.end();
         }
       } catch (e) {
+        sqlClientLegacy.end();
         throw new AuthenticationError(e.message);
       }
-
       // Add credentials to context.
+      const sqlClient = getSqlClient();
       return { credentials, sqlClient };
     },
     onDisconnect: (websocket, context) => {

--- a/services/api/src/clients/pubSub.js
+++ b/services/api/src/clients/pubSub.js
@@ -58,6 +58,7 @@ const createEnvironmentFilteredSubscriber = (events: string[]) => ({
       sqlClient,
       environmentSql.selectEnvironmentById(environment),
     );
+    sqlClient.end();
     const project = R.path([0, 'project'], rows);
 
     if (role !== 'admin' && !R.contains(String(project), projects)) {

--- a/services/api/src/clients/sqlClient.js
+++ b/services/api/src/clients/sqlClient.js
@@ -20,6 +20,5 @@ const getSqlClient = () => {
 };
 
 module.exports = {
-  sqlClient: getSqlClient(),
   getSqlClient,
 };


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

After deploying #1012, it was discovered that there are a lot of open/stale connections to api-db which causes errors when the limit is reached. It appears to be related to API subscriptions. This change ensures that sql connections are closed after they are not needed when clients subscript to API changes.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Close hanging SQL connections related to API subscriptions

# Closing issues
N/A
