### PR TITLE
Bucket names should use SAFE_PROJECT to be more DNS compliant

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
@@ -51,7 +51,7 @@ objects:
         key: repo-pw
         name: baas-repo-pw
       s3:
-        bucket: 'baas-${PROJECT}'
+        bucket: 'baas-${SAFE_PROJECT}'
     backup:
       schedule: '${BACKUP_SCHEDULE}'
     check:


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Backup bucket names should use `SAFE_PROJECT` to be more DNS compliant. This also matches the restore job using safeProjectName [here](https://github.com/amazeeio/lagoon/blob/master/services/openshiftmisc/src/handlers/resticRestore.js#L57)

# Changelog Entry
Bugfix - Use `SAFE_PROJECT` for bucket names in backup schedule
