### PR TITLE
Updating env vars from varchar(300) to text

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS backup_restore (
 CREATE TABLE IF NOT EXISTS env_vars (
   id          int NOT NULL auto_increment PRIMARY KEY,
   name        varchar(300) NOT NULL,
-  value       varchar(300) NOT NULL,
+  value       text NOT NULL,
   scope       ENUM('global', 'build', 'runtime') NOT NULL DEFAULT 'global',
   project     int NULL REFERENCES project (id),
   environment int NULL REFERENCES environent (id),

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -646,20 +646,21 @@ CREATE OR REPLACE PROCEDURE
 $$
 
 CREATE OR REPLACE PROCEDURE
-  update_env_vars_from_varchar_to_text()
+  convert_env_vars_from_varchar_to_text()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
-      WHERE
-        table_name = 'env_vars'
-        AND table_schema = 'infrastructure'
-        AND column_name = 'value'
-    ) THEN
+    DECLARE column_type varchar(50);
+
+    SELECT DATA_TYPE INTO column_type
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE
+      table_name = 'env_vars'
+      AND table_schema = 'infrastructure'
+      AND column_name = 'value';
+
+    IF (column_type = 'varchar') THEN
       ALTER TABLE `env_vars`
-      MODIFY `value` TEXT NOT NULL;
-      UPDATE env_vars
+      MODIFY `value` text NOT NULL;
     END IF;
   END;
 $$
@@ -697,7 +698,7 @@ CALL convert_task_command_to_text();
 CALL add_key_fingerprint_to_ssh_key();
 CALL add_autoidle_to_environment();
 CALL add_deploy_base_head_ref_title_to_environment();
-CALL update_env_vars_from_varchar_to_text();
+CALL convert_env_vars_from_varchar_to_text();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -649,7 +649,7 @@ CREATE OR REPLACE PROCEDURE
   convert_env_vars_from_varchar_to_text()
 
   BEGIN
-    DECLARE column_type varchar(50);
+    DECLARE column_type varchar(300);
 
     SELECT DATA_TYPE INTO column_type
     FROM INFORMATION_SCHEMA.COLUMNS

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -645,6 +645,25 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
+CREATE OR REPLACE PROCEDURE
+  update_env_vars_from_varchar_to_text()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'env_vars'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'value'
+    ) THEN
+      ALTER TABLE `env_vars`
+      MODIFY `value` TEXT NOT NULL;
+      UPDATE env_vars
+    END IF;
+  END;
+$$
+
 DELIMITER ;
 
 CALL add_production_environment_to_project();
@@ -678,6 +697,7 @@ CALL convert_task_command_to_text();
 CALL add_key_fingerprint_to_ssh_key();
 CALL add_autoidle_to_environment();
 CALL add_deploy_base_head_ref_title_to_environment();
+CALL update_env_vars_from_varchar_to_text();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;


### PR DESCRIPTION
This change converts the environment variable storing mechanism from a `varchar(300)` store to a simple `text` store. This will enable much larger environment variable to be defined when using Lagoon.

# Changelog Entry
Improvement - Enable much larger environment variable definitions
