### PR TITLE
Pin correct version of PHPRedis for PHP5 in Dockerfile

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -58,16 +58,18 @@ RUN apk del --no-cache curl libcurl \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && if [ ${PHP_VERSION%.*} == "7.3" ]; then \
         yes '' | pecl install -f apcu \
-        && yes '' | pecl install -f xdebug-2.7.0; \
+        && yes '' | pecl install -f xdebug-2.7.0 \
+        && yes '' | pecl install -f redis; \
        elif [ ${PHP_VERSION%.*.*} == "7" ]; then \
         yes '' | pecl install -f apcu \
-        && yes '' | pecl install -f xdebug; \
+        && yes '' | pecl install -f xdebug \
+        && yes '' | pecl install -f redis; \
        fi \
     && if [ ${PHP_VERSION%.*.*} == "5" ]; then \
         yes '' | pecl install -f apcu-4.0.11 \
-        && yes '' | pecl install -f xdebug-2.5.5; \
+        && yes '' | pecl install -f xdebug-2.5.5 \
+        && yes '' | pecl install -f redis-4.3.0; \
        fi \
-    && yes '' | pecl install -f redis \
     && docker-php-ext-enable apcu redis xdebug \
     && docker-php-ext-configure gd --with-webp-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j4 bcmath gd gettext pdo_mysql mysqli pdo_pgsql pgsql shmop soap sockets opcache xsl zip \


### PR DESCRIPTION
# Changelog Entry
Pin PHPRedis version 4.3.0 for PHP 5.6 image building process due to PHPRedis 5.0.0 dropping PHP5 support

# Closing issues
Closes #1134
