### PR TITLE
Set memory resource limits for cli DeploymentConfigs

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
@@ -120,6 +120,8 @@ objects:
                 requests:
                   cpu: 10m
                   memory: 10Mi
+                limits:
+                  memory: 8Gi
       test: false
       triggers:
         - type: ConfigChange

--- a/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
@@ -101,6 +101,8 @@ objects:
                 requests:
                   cpu: 10m
                   memory: 10Mi
+                limits:
+                  memory: 8Gi
       test: false
       triggers:
         - type: ConfigChange


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

PR adds a memory limit to all cli deployments. Set to a high value of `8Gi` to ensure it doesn't impact any existing processes. With the low requests set it will still keep the Burstable QoS class.

# Changelog Entry
Improvement - Set memory resource limits for cli DeploymentConfigs (#1140)

# Closing issues
closes #1140
