### PR TITLE
Disable PHP notices on production envs by default

### DIFF
--- a/images/php/fpm/00-lagoon-php.ini.tpl
+++ b/images/php/fpm/00-lagoon-php.ini.tpl
@@ -7,6 +7,7 @@ display_errors = ${PHP_DISPLAY_ERRORS:-Off}
 display_startup_errors = ${PHP_DISPLAY_STARTUP_ERRORS:-Off}
 auto_prepend_file = ${PHP_AUTO_PREPEND_FILE:-none}
 auto_append_file = ${PHP_AUTO_APPEND_FILE:-none}
+error_reporting = ${PHP_ERROR_REPORTING:-E_ALL & ~E_DEPRECATED & ~E_STRICT}
 
 [APC]
 apc.shm_size = ${PHP_APC_SHM_SIZE:-32m}

--- a/images/php/fpm/entrypoints/51-production-detection.sh
+++ b/images/php/fpm/entrypoints/51-production-detection.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [[ ${LAGOON_ENVIRONMENT_TYPE} == "production" ]]; then
+if [[ ${LAGOON_ENVIRONMENT_TYPE} == "production" && ( -z "${production_notices}" || $production_notices == "true" ) ]]; then
     export PHP_ERROR_REPORTING="E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE"
 else
-    export PHP_ERROR_REPORTING="E_ALL"
+    export PHP_ERROR_REPORTING="E_ALL & ~E_DEPRECATED & ~E_STRICT"
 fi

--- a/images/php/fpm/entrypoints/51-production-detection.sh
+++ b/images/php/fpm/entrypoints/51-production-detection.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [[ ${LAGOON_ENVIRONMENT_TYPE} == "production" ]]; then
+    export PHP_ERROR_REPORTING="E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE"
+else
+    export PHP_ERROR_REPORTING="E_ALL"
+fi

--- a/images/php/fpm/php.ini
+++ b/images/php/fpm/php.ini
@@ -261,8 +261,8 @@ memory_limit = 400M
 ;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
 ;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
 ; Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
-; Development Value: E_ALL
-; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+; Development Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
 ; http://php.net/error-reporting
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 


### PR DESCRIPTION
 This commit disables PHP notices by default on all production environments so as to prevent those notices from being logged to the watchdog process.

This behavior can be overridden by setting the environment variable `production_notices` to `true`.

# Changelog Entry
Change - Disable PHP notices on production environments by default
