### PR TITLE
Update lagoonize.md

### DIFF
--- a/docs/using_lagoon/drupal/lagoonize.md
+++ b/docs/using_lagoon/drupal/lagoonize.md
@@ -2,9 +2,9 @@
 
 ## 1. Lagoon Drupal Setting Files
 
-In order for Drupal to work with Lagoon we need to teach Drupal about Lagoon and Lagoon about Drupal. This happens with copying specific YAML and PHP Files into your Git Repository.
+In order for Drupal to work with Lagoon we need to teach Drupal about Lagoon and Lagoon about Drupal. This happens by copying specific YAML and PHP Files into your Git repository.
 
-You find these Files [here](https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal). The easiest way is to download them as [ZIP File](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal) and copy them into your Git Repository. For each Drupal Version and Database Type you will find an individual folder. A short overview of what they are:
+You find [these Files in our GitHub repository](https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal); the easiest way is to [download these files as a ZIP file](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/amazeeio/lagoon/tree/master/docs/using_lagoon/drupal) and copy them into your Git repository. For each Drupal version and database type you will find an individual folder. A short overview of what they are:
 
 - `.lagoon.yml` - The main file that will be used by Lagoon to understand what should be deployed and many more things. This file has some sensible Drupal defaults, if you would like to edit or modify, please check the specific [Documentation for .lagoon.yml](/using_lagoon/lagoon_yml.md)
 - `docker-compose.yml`, `.dockerignore`  and `Dockerfile.*` - These files are used to run your Local Drupal Development environment, they tell docker which services to start and how to build them. They contain sensible defaults and many commented lines, it should be pretty much self describing. If you would like to find out more, see [Documentation for docker-compose.yml]()


### PR DESCRIPTION
Don't use "here" as link text; accessibility software usually has a "read all the links to me so I can choose the appropriate one to follow" action and hearing "here" is completely useless.

Also, you are using Winnie-the-Pooh-style capitalization in A Few Places, which is Cute for a Children's Book, but looks Odd in This Context.

Lastly, I don't see anything about why you would need to ”[add `patches` directory if you choose drupal8-composer-mariadb](https://github.com/amazeeio/lagoon/pull/1163/files#diff-d301d45e1a5503b578bcb333a98d151cR14)“. Is this step still needed? If not, remove it. If it is, you would also need to update the `Dockerfile.cli` file to un-comment `COPY patches /app/patches`, right?
