### PR TITLE
Docker host improvements

### DIFF
--- a/lagoon-remote/docker-compose.yaml
+++ b/lagoon-remote/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       lagoon.rollout: daemonset
       lagoon.template: logs-collector/.lagoon.yml
   docker-host:
-    image: amazeeiolagoon/master-docker-host
+    image: amazeeio/docker-host:latest
     labels:
       lagoon.type: custom
       lagoon.template: docker-host/docker-host.yaml

--- a/services/docker-host/docker-host.yaml
+++ b/services/docker-host/docker-host.yaml
@@ -83,7 +83,7 @@ objects:
             - name: CRONJOBS
               value: |
                 22 1 * * * /lagoon/cronjob.sh "/prune-images.sh"
-                22 0 * * * /lagoon/cronjob.sh "/remove-exited.sh"
+                22 */4 * * * /lagoon/cronjob.sh "/remove-exited.sh"
                 */15 * * * * /lagoon/cronjob.sh "/update-push-images.sh"
           ports:
           - containerPort: 2375

--- a/services/docker-host/docker-host.yaml
+++ b/services/docker-host/docker-host.yaml
@@ -39,7 +39,7 @@ parameters:
     value: "Recreate"
   - name: SERVICE_IMAGE
     description: Pullable image of service
-    value: amazeeiolagoon/master-docker-host
+    value: amazeeio/docker-host:latest
 objects:
 - apiVersion: v1
   kind: DeploymentConfig


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

We used the `amazeeiolagoon/master-docker-host ` for the docker-hosts - as we have versioned images we switch over to `amazeeio/docker-host:latest ` which gets updated with every lagoon release.

Exited containers get now removed every 4 hours instead of 1 day to reduce build container buildup and make cleanups more efficient.

# Changelog Entry
Change - docker-host iamges now use the versioned amazeeio/docker-host:latest which is updated on every lagoon release and not on merges to master
Improvement - exited containers are removed every 4 hours

# Closing issues
No open issues - as this came up while operating lagoon