### PR TITLE
Even more configuration for elasticsearch

### DIFF
--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -55,7 +55,8 @@ ENV ES_JAVA_OPTS="-Xms200m -Xmx200m" \
     NODE_INGEST=true \
     NODE_ML=true \
     XPACK_ML_ENABLED=true \
-    CLUSTER_REMOTE_CONNECT=true
+    CLUSTER_REMOTE_CONNECT=true \
+    EXTRA_OPTS=""
 
 
 VOLUME [ "/usr/share/elasticsearch/data" ]

--- a/images/elasticsearch/docker-entrypoint.sh
+++ b/images/elasticsearch/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if [ ! -z "$EXTRA_OPTS" ]; then
+  echo -e "${EXTRA_OPTS}" >> /usr/share/elasticsearch/config/elasticsearch.yml
+fi
+
 if [ -z "$POD_NAMESPACE" ]; then
   # Single container runs in docker
   echo "POD_NAMESPACE not set, spin up single node"


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This is additional to PR #1182 and allows even more configuration to be specified via environment variables, but allows for free options rather than specific types.

Options specified as a single variable separated with newline values
```
export EXTRA_OPTS="processors: 4\ntransport.netty.worker_count: 4\nxpack.watcher.thread_pool.size: 20\nthread_pool.fetch_shard_started.max: 8\n"
```
which results in the following being added to `config/elasticsearch.yml` during container start up
```
processors: 4
transport.netty.worker_count: 4
xpack.watcher.thread_pool.size: 20
thread_pool.fetch_shard_started.max: 8
```

# Changelog Entry
Improvement - Allow any additional configurations to be added to elasticsearch

# Closing issues
closes #1181
