### PR TITLE
Allow CronJobs to be scheduled on build nodes.

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/cli-persistent/custom-cronjob.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli-persistent/custom-cronjob.yml
@@ -94,6 +94,9 @@ objects:
                 key: appuio.ch/autoscaled
                 operator: Equal
                 value: 'true'
+              - effect: NoSchedule
+                key: lagoon/build
+                operator: Exists
             volumes:
               - name: ${PERSISTENT_STORAGE_NAME}
                 persistentVolumeClaim:

--- a/images/oc-build-deploy-dind/openshift-templates/cli/custom-cronjob.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli/custom-cronjob.yml
@@ -83,6 +83,9 @@ objects:
                 key: appuio.ch/autoscaled
                 operator: Equal
                 value: 'true'
+              - effect: NoSchedule
+                key: lagoon/build
+                operator: Exists
             volumes:
               - name: lagoon-sshkey
                 secret:

--- a/images/oc-build-deploy-dind/openshift-templates/node-persistent/custom-cronjob.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/node-persistent/custom-cronjob.yml
@@ -91,6 +91,9 @@ objects:
                 key: appuio.ch/autoscaled
                 operator: Equal
                 value: 'true'
+              - effect: NoSchedule
+                key: lagoon/build
+                operator: Exists
             volumes:
               - name: ${SERVICE_NAME}
                 persistentVolumeClaim:

--- a/images/oc-build-deploy-dind/openshift-templates/node/custom-cronjob.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/node/custom-cronjob.yml
@@ -82,6 +82,9 @@ objects:
                 key: appuio.ch/autoscaled
                 operator: Equal
                 value: 'true'
+              - effect: NoSchedule
+                key: lagoon/build
+                operator: Exists
             containers:
               - image: ${SERVICE_IMAGE}
                 command:


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This PR adds a new toleration to the cronjob objects in lagoon which will allow build nodes configured with a `lagoon/build` taint to schedule cronjob pods.

This means a cluster can leverage additional capacity in a build node for running cronjob pods.

# Changelog Entry
Improvement: Allow CronJobs to be scheduled on build nodes. #1195

# Closing issues
closes #1195
