### PR TITLE
Set phpredis to 4.3.0 for all versions of php

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -58,11 +58,11 @@ RUN apk add --no-cache fcgi \
     && if [ ${PHP_VERSION%.*} == "7.3" ]; then \
         yes '' | pecl install -f apcu \
         && yes '' | pecl install -f xdebug-2.7.0 \
-        && yes '' | pecl install -f redis; \
+        && yes '' | pecl install -f redis-4.3.0; \
        elif [ ${PHP_VERSION%.*.*} == "7" ]; then \
         yes '' | pecl install -f apcu \
         && yes '' | pecl install -f xdebug \
-        && yes '' | pecl install -f redis; \
+        && yes '' | pecl install -f redis-4.3.0; \
        fi \
     && if [ ${PHP_VERSION%.*.*} == "5" ]; then \
         yes '' | pecl install -f apcu-4.0.11 \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Bugfix : Drupal8 seems not to be compatible with PHPRedis 5 - pinning the images to 4.3.0

# Closing issues
closes #1207