### PR TITLE
Cache keycloak authz requests

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -52,6 +52,7 @@
     "mariasql": "^0.2.6",
     "moment": "^2.22.2",
     "morgan": "^1.9.0",
+    "node-cache": "^4.2.1",
     "ramda": "^0.25.0",
     "snakecase-keys": "^1.2.0",
     "sshpk": "^1.14.2",

--- a/services/api/src/lib/keycloak-grant-manager.js
+++ b/services/api/src/lib/keycloak-grant-manager.js
@@ -512,11 +512,10 @@ const fetch = (manager, handler, options, params) => {
     const req = getProtocol(options).request(options, (response) => {
       let json = '';
       response.on('data', (d) => (json += d.toString()));
-      response.on('data', (d) => console.log('grant-manager-data', d.toString()));
-      if (response.statusCode < 200 || response.statusCode > 299) {
-        return reject(new Error(response.statusCode + ':' + http.STATUS_CODES[ response.statusCode ]));
-      }
       response.on('end', () => {
+        if (response.statusCode < 200 || response.statusCode > 299) {
+          return reject(new Error(response.statusCode + ':' + http.STATUS_CODES[ response.statusCode ] + ':' + json));
+        }
         handler(resolve, reject, json);
       });
     });

--- a/services/api/src/util/auth.js
+++ b/services/api/src/util/auth.js
@@ -223,6 +223,7 @@ const keycloakHasPermission = (grant, requestCache) => {
     } catch (err) {
       // Keycloak library doesn't distinguish between a request error or access
       // denied conditions.
+      logger.debug(`keycloakHasPermission denied for "${scope}" on "${resource}": ${err.message}`);
     }
 
     requestCache.set(cacheKey, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,6 +3095,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 cloudant-follow@~0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/cloudant-follow/-/cloudant-follow-0.17.0.tgz#842513a74e72c440e61dc2b6fd96eedbd9cef38a"
@@ -7058,6 +7063,11 @@ lodash@^4.15.0, lodash@^4.16.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loglevel-colored-level-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz#6a40218fdc7ae15fc76c3d0f3e676c465388603e"
@@ -7751,6 +7761,14 @@ node-addon-api@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.2.tgz#d8aad9781a5cfc4132cc2fecdbdd982534265217"
   integrity sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==
+
+node-cache@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
+  integrity sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==
+  dependencies:
+    clone "2.x"
+    lodash "^4.17.15"
 
 node-fetch@^1.0.1, node-fetch@^1.5.2:
   version "1.7.3"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
The new RBAC system means the API queries keycloak for permissions. In cases where the API returns a lot of data, it can hammer keycloak with a lot of permission check requests. Since it's unlikely that a users permissions will change in the middle of an API request, we can cache the results per request.

Also added some better logging when keycloak auth requests fail.
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

Explain the **details** for making this change. What existing problem does the pull request solve?

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Fix API slowness by caching keycloak authz response per API request

# Closing issues
N/A
