### PR TITLE
Allow Xdebug to work with .twig templates

### DIFF
--- a/docs/using_lagoon/drupal/drupal8-composer-mariadb/web/sites/default/development.services.yml
+++ b/docs/using_lagoon/drupal/drupal8-composer-mariadb/web/sites/default/development.services.yml
@@ -8,7 +8,7 @@ parameters:
   twig.config:
     debug: true # displays twig debug messages, developers like them :)
     auto_reload: true # reloads the twig files on every request, so no drush cache clear is required
-    cache: false # No twig internal cache, important: check the example.settings.loca.php to fully fully disable the twig cache
+    cache: true # Twig cache allows Xdebug to work with .twig files
 
 services:
   cache.backend.null: # Defines a Cache Backend Factory which is just empty, it is not used by default


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] ~Documentation has been written/updated.~ Not applicable
- [x] Changelog entry has been written

The Lagoon docs say to copy this `development.services.yml` file. That file sets `twig.config.cache` to `false`. Unfortunately, disabling twig cache prevents Xdebug from working with .twig files.

See #1238 

# Changelog Entry
Documentation - Allow Xdebug to work with .twig files (#1238)

# Closing issues
Closes #1238 