### PR TITLE
Switch to Node10 for Lagoon internal services

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 RUN apk add --no-cache bash \
     && mkdir -p /home/.ssh \

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "prepublish": "in-publish && yarn run build || not-in-publish",

--- a/images/yarn-workspace-builder/Dockerfile
+++ b/images/yarn-workspace-builder/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/node:8-builder
+FROM ${IMAGE_REPO:-lagoon}/node:10-builder
 
 RUN apk add --no-cache \
         libexecinfo-dev \

--- a/node-packages/commons/package.json
+++ b/node-packages/commons/package.json
@@ -5,7 +5,7 @@
   "author": "amazee.io <hello@amazee.io> (http://www.amazee.io)",
   "license": "MIT",
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "format": "prettier-eslint --write '**/*.js'",

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -4,7 +4,7 @@
   "description": "Lagoon GraphQL API",
   "main": "index.js",
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "format": "prettier-eslint --write '**/*.js'",

--- a/services/auth-server/Dockerfile
+++ b/services/auth-server/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest}  as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/auth-server/package.json
+++ b/services/auth-server/package.json
@@ -8,7 +8,7 @@
     "Michael Schmid <michael@amazee.io> (https://amazee.io)"
   ],
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "clean": "rimraf dist && rimraf logs",

--- a/services/logs2rocketchat/.babelrc
+++ b/services/logs2rocketchat/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "node8-es6"
+    "presets": [["latest-node", { "target": "10" }]]
   ],
   "plugins": [
     "transform-flow-strip-types",

--- a/services/logs2rocketchat/Dockerfile
+++ b/services/logs2rocketchat/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/logs2slack/Dockerfile
+++ b/services/logs2slack/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftbuilddeploy/Dockerfile
+++ b/services/openshiftbuilddeploy/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftbuilddeploymonitor/Dockerfile
+++ b/services/openshiftbuilddeploymonitor/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftjobs/Dockerfile
+++ b/services/openshiftjobs/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftjobsmonitor/Dockerfile
+++ b/services/openshiftjobsmonitor/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftmisc/Dockerfile
+++ b/services/openshiftmisc/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftremove/Dockerfile
+++ b/services/openshiftremove/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/openshiftremove/README.md
+++ b/services/openshiftremove/README.md
@@ -20,7 +20,7 @@ It uses https://github.com/benbria/node-amqp-connection-manager for connecting t
 
 Fully developed in Docker and hosted on amazee.io Openshift, see the `.openshift` folder. Deployed via Jenkinsfile.
 
-Uses `lagoon/node:8` as base image.
+Uses `lagoon/node:10` as base image.
 
 ## Development
 

--- a/services/rest2tasks/Dockerfile
+++ b/services/rest2tasks/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/webhook-handler/Dockerfile
+++ b/services/webhook-handler/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/webhook-handler/README.md
+++ b/services/webhook-handler/README.md
@@ -15,7 +15,7 @@ Logs each received webhook to the lagoon-logs queue.
 
 Fully developed in Docker and hosted on amazee.io Openshift, see the `.openshift` folder. Deployed via Jenkinsfile.
 
-Uses `lagoon/node:8` as base image.
+Uses `lagoon/node:10` as base image.
 
 ## Development
 

--- a/services/webhooks2tasks/Dockerfile
+++ b/services/webhooks2tasks/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-amazeeiolagoon}/yarn-workspace-builder:${LAGOON_GIT_BRANCH:-latest} as yarn-workspace-builder
 
 # STAGE 2: specific service Image
-FROM ${IMAGE_REPO:-amazeeiolagoon}/node:8
+FROM ${IMAGE_REPO:-amazeeiolagoon}/node:10
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/webhooks2tasks/README.md
+++ b/services/webhooks2tasks/README.md
@@ -15,7 +15,7 @@ It uses https://github.com/benbria/node-amqp-connection-manager for connecting t
 
 Fully developed in Docker and hosted on amazee.io Openshift, see the `.openshift` folder. Deployed via Jenkinsfile.
 
-Uses `lagoon/node:8` as base image.
+Uses `lagoon/node:10` as base image.
 
 ## Development
 

--- a/services/webhooks2tasks/package.json
+++ b/services/webhooks2tasks/package.json
@@ -5,7 +5,7 @@
   "author": "amazee.io <hello@amazee.io> (http://www.amazee.io)",
   "main": "build/index.js",
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "start": "flow-node build/index.js",

--- a/tests/files/features-autogenerated-routes-disabled/Dockerfile
+++ b/tests/files/features-autogenerated-routes-disabled/Dockerfile
@@ -1,9 +1,9 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-amazeeio}/node:8-builder as builder
+FROM ${IMAGE_REPO:-amazeeio}/node:10-builder as builder
 COPY package.json yarn.lock /app/
 RUN yarn install
 
-FROM ${IMAGE_REPO:-amazeeio}/node:8
+FROM ${IMAGE_REPO:-amazeeio}/node:10
 COPY --from=builder /app/node_modules /app/node_modules
 COPY . /app/
 

--- a/tests/files/features-disable-inject-git-sha/Dockerfile
+++ b/tests/files/features-disable-inject-git-sha/Dockerfile
@@ -1,9 +1,9 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-amazeeio}/node:8-builder as builder
+FROM ${IMAGE_REPO:-amazeeio}/node:10-builder as builder
 COPY package.json yarn.lock /app/
 RUN yarn install
 
-FROM ${IMAGE_REPO:-amazeeio}/node:8
+FROM ${IMAGE_REPO:-amazeeio}/node:10
 COPY --from=builder /app/node_modules /app/node_modules
 COPY . /app/
 

--- a/tests/files/features-subfolder/subfolder1/subfolder2/Dockerfile
+++ b/tests/files/features-subfolder/subfolder1/subfolder2/Dockerfile
@@ -1,9 +1,9 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-amazeeio}/node:8-builder as builder
+FROM ${IMAGE_REPO:-amazeeio}/node:10-builder as builder
 COPY package.json yarn.lock /app/
 RUN yarn install
 
-FROM ${IMAGE_REPO:-amazeeio}/node:8
+FROM ${IMAGE_REPO:-amazeeio}/node:10
 COPY --from=builder /app/node_modules /app/node_modules
 COPY . /app/
 

--- a/tests/files/features/Dockerfile
+++ b/tests/files/features/Dockerfile
@@ -1,9 +1,9 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-amazeeio}/node:8-builder as builder
+FROM ${IMAGE_REPO:-amazeeio}/node:10-builder as builder
 COPY package.json yarn.lock /app/
 RUN yarn install
 
-FROM ${IMAGE_REPO:-amazeeio}/node:8
+FROM ${IMAGE_REPO:-amazeeio}/node:10
 COPY --from=builder /app/node_modules /app/node_modules
 COPY . /app/
 


### PR DESCRIPTION
This commit moves our internal Node.js services from Node 8 to Node 10.

# Changelog Entry
Change - Update Lagoon internal Node services to Node 10 (#1233)

# Closing issues
Closes #1233 
