### PR TITLE
Update makefile dependency for yarn-workspace-builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ build/node__6-builder: build/node__6 images/node/builder/Dockerfile
 # Yarn Workspace Image which builds the Yarn Workspace within a single image. This image will be
 # used by all microservices based on Node.js to not build similar node packages again
 build-images += yarn-workspace-builder
-build/yarn-workspace-builder: build/node__8-builder images/yarn-workspace-builder/Dockerfile
+build/yarn-workspace-builder: build/node__10-builder images/yarn-workspace-builder/Dockerfile
 	$(eval image = $(subst build/,,$@))
 	$(call docker_build,$(image),images/$(image)/Dockerfile,.)
 	touch $@


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

Follow up to #1240. I reset my docker and ran `make build/api` but it failed because the Makefile was still referencing the node 8 builder but all services moved to 10.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Makefile still references node 8 deps (#1233)

# Closing issues
Follow up for #1233 
