### PR TITLE
Replace REDIS_PORT to REDIS_SERVICE_PORT

### DIFF
--- a/docs/using_lagoon/drupal/drupal8-composer-mariadb/web/sites/default/settings.php
+++ b/docs/using_lagoon/drupal/drupal8-composer-mariadb/web/sites/default/settings.php
@@ -56,7 +56,7 @@ if (getenv('LAGOON') && (file_exists($app_root . '/modules/contrib/search_api_so
 if (getenv('LAGOON') && (file_exists($app_root . '/modules/contrib/redis') || file_exists($app_root . 'modules/redis')) && extension_loaded('redis')) {
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-  $settings['redis.connection']['port'] = 6379;
+  $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: '6379';
 
   $settings['cache_prefix']['default'] = getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 

--- a/docs/using_lagoon/drupal/drupal8-composer-postgres/web/sites/default/settings.php
+++ b/docs/using_lagoon/drupal/drupal8-composer-postgres/web/sites/default/settings.php
@@ -55,7 +55,7 @@ if (getenv('LAGOON')) {
 // if (getenv('LAGOON')){
 // $settings['redis.connection']['interface'] = 'PhpRedis';
 // $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-// $settings['redis.connection']['port'] = 6379;
+// $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: '6379';
 //
 // // HINT: Uncomment in order to enable Redis
 // // # Do not set the cache during installations of Drupal

--- a/docs/using_lagoon/drupal/services/redis.md
+++ b/docs/using_lagoon/drupal/services/redis.md
@@ -40,7 +40,7 @@ The Drupal 8 config is largely stock. Notably, redis is disabled while drupal is
 if (getenv('LAGOON')){
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-  $settings['redis.connection']['port'] = 6379;
+  $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: '6379';
   $settings['cache_prefix']['default'] = getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 
   // Do not set the cache during installations of Drupal

--- a/tests/files/drupal8-mariadb/web/sites/default/settings.php
+++ b/tests/files/drupal8-mariadb/web/sites/default/settings.php
@@ -57,7 +57,7 @@ if (getenv('LAGOON')) {
 if (getenv('LAGOON')){
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-  $settings['redis.connection']['port'] = getenv('REDIS_PORT') ?: '6379';
+  $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: '6379';
 
   // # Do not set the cache during installations of Drupal
   // if (!drupal_installation_attempted()) {

--- a/tests/files/drupal8-postgres/web/sites/default/settings.php
+++ b/tests/files/drupal8-postgres/web/sites/default/settings.php
@@ -57,7 +57,7 @@ if (getenv('LAGOON')) {
 if (getenv('LAGOON')){
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-  $settings['redis.connection']['port'] = getenv('REDIS_PORT') ?: '6379';
+  $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: '6379';
 
   // # Do not set the cache during installations of Drupal
   // if (!drupal_installation_attempted()) {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

The `REDIS_PORT` environment variable is not a "port" but a TCP address.
While `REDIS_SERVICE_PORT` is a variable set by Kube service discovery, with the TCP port Redis service is listening to.

# Changelog Entry
Improvement - Use of REDIS_SERVICE_PORT instead of REDIS_PORT (#1254)

# Closing issues
closes #1254 
