### PR TITLE
Renamed the variable to VARNISH_SET_HEADER_CACHE_TAGS

### DIFF
--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -343,8 +343,8 @@ sub vcl_deliver {
   unset resp.http.X-Url;
   unset resp.http.X-Host;
 
-  # unset Cache-Tags Header by default, can be disabled with VARNISH_UNSET_HEADER_CACHE_TAGS=true
-  if (!${VARNISH_UNSET_HEADER_CACHE_TAGS:-false}) {
+  # unset Cache-Tags Header by default, can be disabled with VARNISH_SET_HEADER_CACHE_TAGS=true
+  if (!${VARNISH_SET_HEADER_CACHE_TAGS:-false}) {
     unset resp.http.Cache-Tags;
   }
 


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

The `default.vcl` file has an `if` statement where the name of the variable (VARNISH_UNSET_HEADER_CACHE_TAGS) implies to _disable_ a feature, while if set to `true` it does the opposite.
I renamed the variable in VARNISH_SET_HEADER_CACHE_TAGS, kept the default value to `false`, so feature is NOT enabled by default.

# Changelog Entry
Bugfix - Renamed the VARNISH_UNSET_HEADER_CACHE_TAGS variable to VARNISH_SET_HEADER_CACHE_TAGS (#1049)

# Closing issues
closes #1049 
