### PR TITLE
#1287 stop using edge versions for node and friends

### DIFF
--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -24,7 +24,9 @@ RUN apk add --no-cache git \
         postgresql-client \
         openssh-sftp-server \
         findutils \
-    && apk add --no-cache nodejs-current nodejs-npm yarn --force-overwrite --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+        nodejs-current \
+        nodejs-npm \
+        yarn \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -76,7 +76,6 @@ RUN apk add --no-cache fcgi \
         docker-php-ext-install mcrypt; \
        fi \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && apk update && apk upgrade nghttp2-libs \
     && rm -rf /var/cache/apk/* /tmp/pear/ \
     && apk del .phpize-deps \
     && mkdir -p /tmp/newrelic && cd /tmp/newrelic \


### PR DESCRIPTION
it causes all kind of dependency issues, plus the versions of node coming in alpine 3:10 are the same major versions as in edge now