### PR TITLE
Improve storage-calculator script add update to support oc 3.9.

### DIFF
--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -61,19 +61,31 @@ do
       fi
 
       OC="oc --insecure-skip-tls-verify --token=$OPENSHIFT_TOKEN --server=$OPENSHIFT_URL -n $ENVIRONMENT_OPENSHIFT_PROJECTNAME"
+
+      # Skip if namespace doesn't exist.
+      if ! ${OC} get ns ${ENVIRONMENT_OPENSHIFT_PROJECTNAME} >/dev/null 2>&1 ; then
+        echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: no valid namespace found"
+        continue
+      fi
+
       echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: creating storage-calc pod"
 
-      ${OC} run --image amazeeio/alpine-mysql-client storage-calc -- sh -c "while sleep 3600; do :; done"
+      # Cleanup any existing storage-calc deployments
+      ${OC} delete deploymentconfig/storage-calc >/dev/null 2>&1
+
+      # Start storage-calc deployment
+      ${OC} run --generator=deploymentconfig/v1 --image amazeeio/alpine-mysql-client storage-calc -- sh -c "while sleep 3600; do :; done"
       ${OC} rollout pause deploymentconfig/storage-calc
 
-      ${OC} env --from=configmap/lagoon-env deploymentconfig/storage-calc
+      # Copy environment variable from lagoon-env configmap.
+      ${OC} set env --from=configmap/lagoon-env deploymentconfig/storage-calc
 
       PVCS=($(${OC} get pvc -o name | sed 's/persistentvolumeclaims\///'))
 
       for PVC in "${PVCS[@]}"
       do
         echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: mounting ${PVC} into storage-calc"
-        ${OC} volume deploymentconfig/storage-calc --add --name=${PVC} --type=persistentVolumeClaim --claim-name=${PVC} --mount-path=/storage/${PVC}
+        ${OC} set volume deploymentconfig/storage-calc --add --name=${PVC} --type=persistentVolumeClaim --claim-name=${PVC} --mount-path=/storage/${PVC}
       done
 
       ${OC} rollout resume deploymentconfig/storage-calc
@@ -84,6 +96,8 @@ do
 
       if [[ ! $POD ]]; then
         echo "No running pod found for storage-calc"
+        # Clean up any failed deployments.
+        ${OC} delete deploymentconfig/storage-calc >/dev/null 2>&1
         exit 1
       fi
 

--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -133,6 +133,11 @@ do
             query=$(echo $MUTATION | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
             curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}"
 
+            # Update namespace labels
+            if [ ! -z "$LAGOON_STORAGE_LABEL_NAMESPACE"]; then
+              ${OC} label namespace $ENVIRONMENT_OPENSHIFT_PROJECTNAME lagoon/storage-${PVC}=${STORAGE_BYTES} --overwrite
+            fi
+
         done
       fi
 

--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -80,7 +80,7 @@ do
       # Copy environment variable from lagoon-env configmap.
       ${OC} set env --from=configmap/lagoon-env deploymentconfig/storage-calc
 
-      PVCS=($(${OC} get pvc -o name | sed 's/persistentvolumeclaims\///'))
+      PVCS=($(${OC} get pvc -o name | sed 's/persistentvolumeclaim\///'))
 
       for PVC in "${PVCS[@]}"
       do


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Adds a check for a valid namespace before deploying `storage-calc` to avoid script failures when an environment doesn't exist.

Updates references to `oc volume` as this has changes to `oc set volume` in `oc 3.9`

**Includes PR 1158 - Update version of oc used in oc image

# Changelog Entry
Improvement - Improve storage-calculator script add update to support for `oc 3.9`. (#1290)

# Closing issues
closes #1290
