### PR TITLE
elasticsearch dockerimage had yml typo

### DIFF
--- a/images/elasticsearch/docker-entrypoint.sh.7
+++ b/images/elasticsearch/docker-entrypoint.sh.7
@@ -18,7 +18,7 @@ else
   K8S_SVC_NAME=$(hostname -f | cut -d"." -f2)
   echo "Using service name: ${K8S_SVC_NAME}"
   sed -i 's/discovery.seed_hosts:.*//' /usr/share/elasticsearch/config/elasticsearch.yml
-  sed -i 's/cluster.initial_master_nodes:.*//' /usr/share/elasticsearch/config/elasticsearch.ym
+  sed -i 's/cluster.initial_master_nodes:.*//' /usr/share/elasticsearch/config/elasticsearch.yml
   echo "discovery.seed_hosts: ${K8S_SVC_NAME}" >> /usr/share/elasticsearch/config/elasticsearch.yml
   echo "cluster.initial_master_nodes: ${K8S_SVC_NAME}-0" >> /usr/share/elasticsearch/config/elasticsearch.yml
 fi


### PR DESCRIPTION
# Changelog Entry
Bugfix - elasticsearch dockerimage had yml typo
