### PR TITLE
Fix broken docs logo image by adding missing "!". Fixes #1307

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-[The Lagoon logo is a blue hexagon split in two pieces with an L-shaped cut](/images/lagoon-logo.png)
+![The Lagoon logo is a blue hexagon split in two pieces with an L-shaped cut](/images/lagoon-logo.png)
 <br />
 
 # Lagoon - Docker Build and Deploy System for OpenShift & Kubernetes


### PR DESCRIPTION
Hotfix for #1307 