### PR TITLE
Add DB_READREPLICA_HOSTS to lagoon-env

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -670,6 +670,15 @@ do
           -n ${OPENSHIFT_PROJECT} \
           configmap lagoon-env \
           -p "{\"data\":{\"${SERVICE_NAME_UPPERCASE}_HOST\":\"${DB_HOST}\", \"${SERVICE_NAME_UPPERCASE}_USERNAME\":\"${DB_USER}\", \"${SERVICE_NAME_UPPERCASE}_PASSWORD\":\"${DB_PASSWORD}\", \"${SERVICE_NAME_UPPERCASE}_DATABASE\":\"${DB_NAME}\", \"${SERVICE_NAME_UPPERCASE}_PORT\":\"${DB_PORT}\"}}"
+
+        # only add the DB_READREPLICA_HOSTS variable if it exists in the servicebroker credentials yaml
+        if DB_READREPLICA_HOSTS=$(shyaml get-value data.DB_READREPLICA_HOSTS < "/oc-build-deploy/lagoon/${SERVICE_NAME}-servicebroker-credentials.yml" | base64 -d); then
+          oc patch --insecure-skip-tls-verify \
+            -n "$OPENSHIFT_PROJECT" \
+            configmap lagoon-env \
+            -p "{\"data\":{\"${SERVICE_NAME_UPPERCASE}_READREPLICA_HOSTS\":\"${DB_READREPLICA_HOSTS}\"}}"
+        fi
+
         set -x
         ;;
 


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Expose the database read-replica service (if available) to the web app via the `lagoon-env` configmap. This will allow the web application to make use of a read-replica endpoint.

# Changelog Entry
Feature - Database read-replica support

# Closing issues
n/a
