### PR TITLE
Keycloak start.sh script needs python installed

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -4,7 +4,7 @@ FROM jboss/keycloak
 
 USER root
 
-RUN microdnf install -y nc \
+RUN microdnf install -y nc python2 \
     && microdnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

The recent switch to ubi8-minimal for the keycloak image means python is no longer installed by default. We use python for the install/upgrade scripts in `start.sh`.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Keycloak container switched to different base image that doesn't include python

# Closing issues
n/a
