### PR TITLE
Fix up build dependencies to enable parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ build/nginx: build/commons images/nginx/Dockerfile
 build/nginx-drupal: build/nginx images/nginx-drupal/Dockerfile
 build/varnish: build/commons images/varnish/Dockerfile
 build/varnish-drupal: build/varnish images/varnish-drupal/Dockerfile
-build/varnish-persistent: build/commons images/varnish/Dockerfile
+build/varnish-persistent: build/varnish images/varnish/Dockerfile
 build/varnish-persistent-drupal: build/varnish images/varnish-drupal/Dockerfile
 build/redis: build/commons images/redis/Dockerfile
 build/redis-persistent: build/redis images/redis-persistent/Dockerfile
@@ -181,7 +181,7 @@ build/docker-host: build/commons images/docker-host/Dockerfile
 build/oc: build/commons images/oc/Dockerfile
 build/curator: build/commons images/curator/Dockerfile
 build/oc-build-deploy-dind: build/oc images/oc-build-deploy-dind
-build/athenapdf-service: images/athenapdf-service/Dockerfile
+build/athenapdf-service: build/commons images/athenapdf-service/Dockerfile
 
 
 #######
@@ -460,6 +460,8 @@ build/api-db build/keycloak-db: build/mariadb
 build/api-db-galera build/keycloak-db-galera: build/mariadb-galera
 build/broker: build/rabbitmq-cluster
 build/broker-single: build/rabbitmq
+build/drush-alias: build/commons
+build/keycloak: build/commons
 
 # Auth SSH needs the context of the root folder, so we have it individually
 build/ssh: build/commons

--- a/docs/developing_lagoon/index.md
+++ b/docs/developing_lagoon/index.md
@@ -30,7 +30,7 @@ If you would still like to build and start all services, go ahead:
 2\. Build images
 
 ```sh
-make build
+make build -j$(getconf _NPROCESSORS_ONLN)
 ```
 
 3\. start Lagoon Services


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

The existing image build dependencies were not entirely accurate so that parallel builds failed.
This change improves the situation by allowing you to build images in parallel, dramatically shortening overall image build time.

# Changelog Entry
Improvement - enable parallel image builds

# Closing issues
n/a
