### PR TITLE
Patch keycloak Dockerfile and entrypoint for new base image

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,10 +1,10 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM jboss/keycloak
+FROM jboss/keycloak:7.0.1
 
 USER root
 
-RUN microdnf install -y nc \
+RUN microdnf install -y nc python2 \
     && microdnf clean all \
     && rm -rf /var/cache/yum
 

--- a/services/keycloak/start.sh
+++ b/services/keycloak/start.sh
@@ -1335,6 +1335,10 @@ if echo "$@" | egrep -v -- '-c |-c=|--server-config |--server-config='; then
     SYS_PROPS+=" -c=standalone-ha.xml"
 fi
 
+# in 7.0.1+ script uploads are disabled by default. Enable them here.
+# https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-7-0-1-final
+SYS_PROPS+=" -Dkeycloak.profile.feature.upload_scripts=enabled"
+
 ##################
 # Start Keycloak #
 ##################


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

The base image our keycloak is `jboss/keycloak`. This had a new release tagged, and as we don't currently pin base images against a tag we get `latest` when building from scratch. This new version has an incompatibility with our entrypoint scripts.

Therefore this PR implements the following:

* install python2, as it is no longer part of the base image
* enable script upload, as this is disabled by default in 7.0.1
* pin base image version to 7.0.1 (current latest version)

# Changelog Entry
Bugfix - Fix incompatibility and pin new upstream keycloak version

# Closing issues
Supersedes #1352
