### PR TITLE
Use keycloak service name in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -321,7 +321,7 @@ services:
     image: ${IMAGE_REPO:-lagoon}/logs-db
     user: '111111111'
     environment:
-      KEYCLOAK_URL: http://docker.for.mac.localhost:8088
+      KEYCLOAK_URL: http://keycloak:8080
     ports:
       - '9200:9200'
     labels:
@@ -341,7 +341,7 @@ services:
     ports:
       - '5601:5601'
     environment:
-      KEYCLOAK_URL: http://docker.for.mac.localhost:8088
+      KEYCLOAK_URL: http://keycloak:8080
       LOGSDB_UI_URL: http://0.0.0.0:5601
     labels:
       lagoon.type: kibana


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

The localhost DNS alias doesn't exist on Linux, so instead use the docker network internal service name and port.

# Changelog Entry
Improvement - Use docker keycloak service name and port in `docker-compose.yaml` for cross-platform compatibility

# Closing issues
n/a
