### PR TITLE
Ensure that cron jobs that are every 15 minutes do not create a kuber…

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -31,7 +31,7 @@ function cronScheduleMoreOftenThan15Minutes() {
     # We are running every minute.
     return 0
   else
-    # All other cases are less often than 15 minutes.
+    # All other cases are more often than 15 minutes.
     return 1
   fi
 }


### PR DESCRIPTION
…netes native cronjob, and instead just fire in the CLI pod.

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Bugfix - Cron will now use the CLI pod instead of kubernetes native cronjobs when run at least every 15 minutes. This will help clusters with high amounts of 15 minute crons to not create a lot of cronjobs. (#1371)

# Closing issues
Closes #1371
