### PR TITLE
Added missing pages in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,20 @@ pages:
   - Environment Variables: using_lagoon/environment_variables.md
   - Docker Images:
     - PHP-FPM: using_lagoon/docker_images/php-fpm.md
+    - PHP CLI: using_lagoon/docker_images/php-cli.md
+    - PHP CLI Drupal: using_lagoon/docker_images/php-cli-drupal.md
     - Nginx: using_lagoon/docker_images/nginx.md
+    - Nginx Drupal: using_lagoon/docker_images/nginx-drupal.md
+    - MariaDB: using_lagoon/docker_images/mariadb.md
+    - MariaDB Drupal: using_lagoon/docker_images/mariadb-drupal.md
+    - MongoDB: using_lagoon/docker_images/mongo.md
     - RabbitMQ: using_lagoon/docker_images/rabbitmq.md
+    - Redis: using_lagoon/docker_images/redis.md
+    - Redis Permanent: using_lagoon/docker_images/redis-permanent.md
+    - Solr: using_lagoon/docker_images/solr.md
+    - Solr Drupal: using_lagoon/docker_images/solr-drupal.md
+    - Varnish: using_lagoon/docker_images/varnish.md
+    - Varnish Drupal: using_lagoon/docker_images/varnish-drupal.md
   - Workflows: using_lagoon/workflows.md
   - Backups: using_lagoon/backups.md
   - Logs: 


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

Previous PR added documentation for all Lagoon base images but new pages were not visible due to missing in mkdocs.yml file. 

# Changelog Entry
Documentation - Added new base images' pages in mkdocs.yml file (#1377)


# Closing issues
closes #1377
