### PR TITLE
#1363: tell elasticsearch which format we're sending data

### DIFF
--- a/services/api/src/resources/environment/resolvers.js
+++ b/services/api/src/resources/environment/resolvers.js
@@ -366,6 +366,7 @@ const getEnvironmentHitsMonthByEnvironmentId = async (
                   '@timestamp': {
                     gte: `${interested_year_month}||/M`,
                     lte: `${interested_year_month}||/M`,
+                    format: "strict_year_month"
                   },
                 },
               },


### PR DESCRIPTION
this is another fix for #1363 which does not require to let the API do the time calculation, but instead let's Elasticsearch calculate it (like it currently is)
 
Bugfix - Define the Date Format for loading of Hits 

# Closing issues
closes #1363
