### PR TITLE
Fluentd prometheus plugin fix

### DIFF
--- a/services/logs-forwarder/Dockerfile
+++ b/services/logs-forwarder/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache tini \
         fluent-plugin-elasticsearch \
         fluent-plugin-secure-forward \
         fluent-plugin-record-modifier \
- && gem install fluent-plugin-prometheus --version='~0.4.0' \
+ && gem install fluent-plugin-prometheus --version='~>0.4.0' \
  && gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /var/cache/apk/* \

--- a/services/logs-forwarder/Dockerfile
+++ b/services/logs-forwarder/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache tini \
         fluent-plugin-elasticsearch \
         fluent-plugin-secure-forward \
         fluent-plugin-record-modifier \
- && gem install fluent-plugin-prometheus --version='~>1.0.0' \
+ && gem install fluent-plugin-prometheus --version='~0.4.0' \
  && gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
Downgrading the prometheus exporter plugin for fluentd so that it will work with the version of fluentd we are running (`0.12`).

# Changelog Entry
BugFix - Resolve fluentd prometheus exporter plugin startup issue.
