### PR TITLE
adding rabbitmq cluster to lagoon-remote

### DIFF
--- a/lagoon-remote/broker
+++ b/lagoon-remote/broker
@@ -1,0 +1,1 @@
+../services/broker/

--- a/lagoon-remote/docker-compose.yaml
+++ b/lagoon-remote/docker-compose.yaml
@@ -29,3 +29,12 @@ services:
     labels:
       lagoon.type: custom
       lagoon.template: docker-host/docker-host.yaml
+  broker:
+    image: amazeeio/rabbitmq-cluster:v1.1.4
+    ports:
+      - '15672:15672'
+      - '5672:5672'
+    labels:
+      lagoon.type: rabbitmq-cluster
+      lagoon.template: services/broker/.lagoon.app.yml
+      lagoon.image: amazeeiolagoon/broker:v1-1-4


### PR DESCRIPTION
#788 Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

As part of #1297 we're rolling out a rabbitmq broker to all `lagoon-remote` deployments.

# Changelog Entry
Feature - Adding rabbitmq cluster to lagoon-remote deployments #1343 

