### PR TITLE
use api/deploy-branch instead of rest/branch for node tests

### DIFF
--- a/tests/tests/node.yaml
+++ b/tests/tests/node.yaml
@@ -4,7 +4,7 @@
   vars:
     testname: "API TOKEN"
 
-- include: rest/branch.yaml
+- include: api/deploy-branch.yaml
   vars:
     testname: "NODE 12"
     node_version: 12
@@ -13,7 +13,7 @@
     branch: node12
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: rest/branch.yaml
+- include: api/deploy-branch.yaml
   vars:
     testname: "NODE 10"
     node_version: 10
@@ -22,7 +22,7 @@
     branch: node10
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: rest/branch.yaml
+- include: api/deploy-branch.yaml
   vars:
     testname: "NODE 8"
     node_version: 8
@@ -31,7 +31,7 @@
     branch: node8
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','OPENSHIFT_ROUTE_SUFFIX') }}"
 
-- include: rest/branch.yaml
+- include: api/deploy-branch.yaml
   vars:
     testname: "NODE 6"
     node_version: 6_subfolder


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This is a first cut a changing from rest2tasks for the node tests.

This fixes the tests that were breaking due to a strange Rest2Tasks bug.  Given it is being deprecated, we should test using the api/graphQL.  This isn't the most elegant solution, but it works.

# Changelog Entry
Replaces Rest2Tasks for Node Testing (#1407)

# Closing issues
Closes #1407
