### PR TITLE
fixing postgres not starting issue

### DIFF
--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -24,7 +24,6 @@ RUN chmod g+w /etc/passwd \
 
 ENV LAGOON=postgres
 
-RUN cp /usr/local/bin/docker-entrypoint.sh /lagoon/entrypoints/90-postgres-entrypoint
 COPY postgres-backup.sh /lagoon/
 
 RUN echo -e "local all all md5\nhost  all  all 0.0.0.0/0 md5" >> /usr/local/share/postgresql/pg_hba.conf
@@ -37,4 +36,4 @@ ENV PGUSER=postgres \
 
 # Postgresql entrypoint file needs bash, so start the entrypoints with bash
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
-CMD ["postgres"]
+CMD ["/usr/local/bin/docker-entrypoint.sh", "postgres"]


### PR DESCRIPTION
the newest postgres alpine version has a check if it is sourced or not: https://github.com/docker-library/postgres/blob/6dfdc0eacba0ae39b837df5eef63f89f13556e50/11/alpine/docker-entrypoint.sh#L274-L276
which is the case with our lagoon entrypoints system.
Instead of running it through the lagoon entrypoint system, we now execute the original entrypoint directly

closes #1418