### PR TITLE
Router logs overhaul

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -411,3 +411,11 @@ services:
       - RABBITMQ_USER=guest
       - RABBITMQ_PASS=guest
       - CLUSTER_NAME=local_development_cluster
+  logs-dispatcher:
+    image: ${IMAGE_REPO:-lagoon}/logs-dispatcher
+    user: '111111111'
+    environment:
+      - RABBITMQ_USER=guest
+      - RABBITMQ_PASS=guest
+      - ELASTICSEARCH_USER=admin
+      - ELASTICSEARCH_PASS=admin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -362,7 +362,6 @@ services:
       - '--config.reload.interval'
       - '1s'
     ports:
-      - '5140:5140/udp'
       - '5141:5141/udp'
     volumes:
       - './services/logs2logs-db/pipeline:/usr/share/logstash/pipeline'
@@ -396,3 +395,19 @@ services:
       lagoon.type: custom
       lagoon.template: services/logs-collector/.lagoon.yml
       lagoon.rollout: daemonset
+  logs-tee:
+    image: ${IMAGE_REPO:-lagoon}/logs-tee
+    user: '111111111'
+    ports:
+      - '5140:5140/udp'
+    command:
+      # logs will be copied to these endpoints
+      - 'logs2logs-db:5140'
+      - 'router-logs-collector:5140'
+  router-logs-collector:
+    image: ${IMAGE_REPO:-lagoon}/router-logs-collector
+    user: '111111111'
+    environment:
+      - RABBITMQ_USER=guest
+      - RABBITMQ_PASS=guest
+      - CLUSTER_NAME=local_development_cluster

--- a/services/logs-dispatcher/Dockerfile
+++ b/services/logs-dispatcher/Dockerfile
@@ -1,0 +1,19 @@
+FROM fluent/fluentd:v1.7-1
+LABEL maintainer="support@amazee.io"
+
+USER root
+
+RUN apk add --no-cache --update --virtual .build-deps \
+      build-base ruby-dev \
+      && gem install fluent-plugin-rabbitmq \
+      && gem install fluent-plugin-elasticsearch \
+      && gem sources --clear-all \
+      && apk del .build-deps \
+      && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem
+
+COPY fluent.conf /fluentd/etc/
+COPY entrypoint.sh /bin/
+
+EXPOSE 5140/udp
+
+USER fluent

--- a/services/logs-dispatcher/entrypoint.sh
+++ b/services/logs-dispatcher/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#source vars if file exists
+DEFAULT=/etc/default/fluentd
+
+if [ -r $DEFAULT ]; then
+    set -o allexport
+    . $DEFAULT
+    set +o allexport
+fi
+
+# If the user has supplied only arguments append them to `fluentd` command
+if [ "${1#-}" != "$1" ]; then
+    set -- fluentd "$@"
+fi
+
+# If user does not supply config file or plugins, use the default
+if [ "$1" = "fluentd" ]; then
+    if ! echo "$@" | grep ' \-c' ; then
+       set -- "$@" -c "/fluentd/etc/${FLUENTD_CONF}"
+    fi
+
+    if ! echo "$@" | grep ' \-p' ; then
+       set -- "$@" -p /fluentd/plugins
+    fi
+fi
+
+exec "$@"

--- a/services/logs-dispatcher/fluent.conf
+++ b/services/logs-dispatcher/fluent.conf
@@ -1,0 +1,43 @@
+# vi: ft=fluentd
+<source>
+  # fluentd parameters
+  @type  rabbitmq
+  @id    router
+  @label @router
+  tag    "lagoon.#{ENV['CLUSTER_NAME']}.logs.router"
+  # rabbitmq parameters
+  host      broker
+  user      "#{ENV['RABBITMQ_USER']}"
+  pass      "#{ENV['RABBITMQ_PASS']}"
+  vhost     /
+  exchange  lagoon
+  queue     "lagoon.#{ENV['CLUSTER_NAME']}.logs.router"
+  durable   true
+  heartbeat server
+</source>
+
+<label @router>
+  # log to local stdout
+  <filter **>
+    @type stdout
+  </filter>
+  # send to elasticsearch
+  <match **>
+    @type               elasticsearch
+    host                logs-db
+    user                "#{ENV['ELASTICSEARCH_USER']}"
+    password            "#{ENV['ELASTICSEARCH_PASS']}"
+    logstash_format     true
+    logstash_prefix     "router-logs-#{ENV['CLUSTER_NAME']}-${k8s_namespace}"
+    logstash_dateformat %Y.%m
+    log_es_400_reason   true
+    # We have to key chunks by k8s_namespace to be able to use the placeholder
+    # in logstash_prefix.
+    # https://docs.fluentd.org/configuration/buffer-section#placeholders
+    # Tag is required by the ES output plugin.
+    <buffer tag,k8s_namespace>
+      flush_thread_count 8
+      flush_interval     5s
+    </buffer>
+  </match>
+</label>

--- a/services/logs-tee/Dockerfile
+++ b/services/logs-tee/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.10
+LABEL maintainer="support@amazee.io"
+
+RUN addgroup -g 1000 -S socat && \
+      adduser -u 1000 -S socat -G socat && \
+      apk add --no-cache socat bash
+
+COPY entrypoint.sh /bin
+
+USER socat
+
+EXPOSE 5140
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/services/logs-tee/entrypoint.sh
+++ b/services/logs-tee/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# this script:
+# - takes an arbitrary number of arguments
+# - assumes each argument is a UDP endpoint
+# - listens on UDP 0.0.0.0:5140
+# - duplicates received traffic to the UDP endpoints
+
+set -x
+
+cmd="socat - udp-recvfrom:5140,fork | tee"
+
+for endpoint in "$@"; do
+	while ! nslookup "${endpoint/:[0-9]*/}" &> /dev/null; do
+		echo "${endpoint/:[0-9]*/} doesn't resolve. retrying in 2 seconds.."
+		sleep 2
+	done
+	cmd="$cmd >(socat - udp-sendto:$endpoint)"
+done
+
+eval "$cmd"

--- a/services/router-logs-collector/Dockerfile
+++ b/services/router-logs-collector/Dockerfile
@@ -1,0 +1,19 @@
+FROM fluent/fluentd:v1.7-1
+LABEL maintainer="support@amazee.io"
+
+USER root
+
+RUN apk add --no-cache --update --virtual .build-deps \
+      build-base ruby-dev \
+      && gem install fluent-plugin-rabbitmq \
+      && gem sources --clear-all \
+      && apk del .build-deps \
+      && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem \
+      && apk add --no-cache curl
+
+COPY fluent.conf /fluentd/etc/
+COPY entrypoint.sh /bin/
+
+EXPOSE 5140/udp
+
+USER fluent

--- a/services/router-logs-collector/entrypoint.sh
+++ b/services/router-logs-collector/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#source vars if file exists
+DEFAULT=/etc/default/fluentd
+
+if [ -r $DEFAULT ]; then
+    set -o allexport
+    . $DEFAULT
+    set +o allexport
+fi
+
+# If the user has supplied only arguments append them to `fluentd` command
+if [ "${1#-}" != "$1" ]; then
+    set -- fluentd "$@"
+fi
+
+# If user does not supply config file or plugins, use the default
+if [ "$1" = "fluentd" ]; then
+    if ! echo "$@" | grep ' \-c' ; then
+       set -- "$@" -c "/fluentd/etc/${FLUENTD_CONF}"
+    fi
+
+    if ! echo "$@" | grep ' \-p' ; then
+       set -- "$@" -p /fluentd/plugins
+    fi
+fi
+
+exec "$@"

--- a/services/router-logs-collector/fluent.conf
+++ b/services/router-logs-collector/fluent.conf
@@ -1,0 +1,58 @@
+# vi: ft=fluentd
+<source>
+  # fluentd parameters
+  @type  syslog
+  @id    router
+  @label @router
+  tag    "lagoon.#{ENV['CLUSTER_NAME']}.logs.router"
+  # syslog parameters
+  port         5140
+  severity_key severity
+  <parse>
+    @type       regexp
+    # parse HTTP logs based on the haproxy documentation
+    # As per the documentation here
+    # https://www.haproxy.com/documentation/hapee/1-8r1/onepage/#8.2.3, except
+    # we split the frontend_name into its constituent parts as used by
+    # openshift.
+    expression    /^.{,15} (?<process_name>\w+)\[(?<pid>\d+)\]: (?<client_ip>\S+):(?<client_port>\d+) \[(?<request_date>\S+)\] (?<frontend_name>\S+) (?<backend_type>\S+):(?<k8s_namespace>\S+):(?<k8s_deployment>\S+)\/(?<server_name>\S+) (?<TR>[\d-]+)\/(?<Tw>[\d-]+)\/(?<Tc>[\d-]+)\/(?<Tr>[\d-]+)\/(?<Ta>[\d-]+) (?<status_code>\d+) (?<bytes_read>\d+) (?<captured_request_cookie>\S+) (?<captured_response_cookie>\S+) (?<termination_state>\S+) (?<actconn>\d+)\/(?<feconn>\d+)\/(?<beconn>\d+)\/(?<srv_conn>\d+)\/(?<retries>\d+) (?<srv_queue>\d+)\/(?<backend_queue>\d+) "(?<http_request>.+)"/
+    time_key      request_date
+    time_format   %d/%b/%Y:%T.%L
+    types         pid:integer,client_port:integer,TR:integer,Tw:integer,Tc:integer,Tr:integer,Ta:integer,bytes_read:integer,actconn:integer,feconn:integer,beconn:integer,srv_conn:integer,retries:integer,srv_queue:integer,backend_queue:integer
+  </parse>
+</source>
+
+<label @router>
+  # Inject fluentd default "time" field, ms precision. This is used as the log
+  # timestamp when read from the queue by the logs-dispatcher.
+  <filter **>
+    @type record_transformer
+    enable_ruby
+    <record>
+      time "${Time.at(time).strftime('%s.%L')}"
+    </record>
+  </filter>
+  # log to local stdout
+  <filter **>
+    @type stdout
+  </filter>
+  # send to rabbitmq
+  <match **>
+    @type            rabbitmq
+    host             broker
+    user             "#{ENV['RABBITMQ_USER']}"
+    pass             "#{ENV['RABBITMQ_PASS']}"
+    routing_key      "lagoon.#{ENV['CLUSTER_NAME']}.logs.router"
+    exchange         lagoon
+    exchange_type    topic
+    exchange_durable true
+    content_type     application/json
+    <format>
+      @type json
+    </format>
+    <buffer>
+      flush_thread_count 8
+      flush_interval     5s
+    </buffer>
+  </match>
+</label>


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This PR is part of the logging system overhaul. I don't think it's complete, just wanted to start discussion on where I'm headed with this.

Here are the important points on this PR:
* logs are going: router -> fluentd -> rabbitmq -> fluentd -> elasticsearch
  * no more logstash, we do all the parsing in fluentd
* end-to-end latency is currently max 10s (see the `flush_interval` option in the two `fluent.conf` files
* it uses a topic exchange in rabbitmq which makes it easy to attach another queue and copy log messages off elsewhere.
  * current hierarchy is `lagoon.<cluster>.logs.<log_type>`
  * e.g. you can attach a queue to the `lagoon` exchange with a routing key like `lagoon.*.logs.router`, and get all the router logs from all clusters.

build the images using:
```
docker build -t lagoon/router-logs-collector services/router-logs-collector
docker build -t lagoon/logs-tee services/logs-tee
docker build -t lagoon/logs-dispatcher services/logs-dispatcher
```

Questions:
* does the topic queue hierarchy look okay, and extensible?
* how should we go about merging this work?
* any other comments?

# Changelog Entry
Overhaul the router logs system.

# Closing issues
n/a
