### PR TITLE
Solr 7.5 - setting $solr.lock.type to none

### DIFF
--- a/images/solr-drupal/solr7.5/conf/solrconfig.xml
+++ b/images/solr-drupal/solr7.5/conf/solrconfig.xml
@@ -224,7 +224,7 @@
          More details on the nuances of each LockFactory...
          http://wiki.apache.org/lucene-java/AvailableLockFactories
     -->
-    <lockType>${solr.lock.type:native}</lockType>
+    <lockType>${solr.lock.type:none}</lockType>
 
     <!-- Commit Deletion Policy
          Custom deletion policies can be specified here. The class must


### PR DESCRIPTION
The $solr.lock.type was not set to none - which lead to crash-looping containers becasue the config-fix startup script was exiting the container due to this configuration. This PR fixes this issue.
 
# Changelog Entry
Bugfix - Setting $solr.lock.type to none for Solr 7.5 configuration
