### PR TITLE
Update PHP7 versions supported and tested.

### DIFF
--- a/docs/using_lagoon/docker_images/php-fpm.md
+++ b/docs/using_lagoon/docker_images/php-fpm.md
@@ -1,9 +1,9 @@
 # php-fpm Image
 
-Lagoon `php-fpm` Docker image, based on the official PHP Alpine images at (https://hub.docker.com/_/php/).  
-The supported versions of PHP on Lagoon are 7.1, 7.2 and 7.3.  Older versions (5.6, 7.0) may also be available for compatibility.  
+Lagoon `php-fpm` Docker image, based on the official PHP Alpine images at (https://hub.docker.com/_/php/).
+The supported versions of PHP on Lagoon are 7.2 and 7.3.  Older versions (5.6, 7.0, 7.1) may also be available for compatibility, and more recent versions (7.4) wil be available for testing.
 
-This Dockerfile is intended to be used as an base for any php needs within Lagoon.  
+This Dockerfile is intended to be used as an base for any php needs within Lagoon.
 This image itself does not create a webserver, rather just an php-fpm fastcgi listener. You maybe need to adapt the php-fpm pool config.
 
 ## Lagoon & OpenShift adaptions
@@ -17,7 +17,7 @@ This image is prepared to be used on Lagoon which leverages OpenShift. There are
 
 ## Included php config
 
-The included php config contains sane values that will make the creation of php pools configs easier.  
+The included php config contains sane values that will make the creation of php pools configs easier.
 Here a list these, check `/usr/local/etc/php.ini`, `/usr/local/etc/php-fpm.conf` for all of it:
 
 - `max_execution_time = 900` (changeable via `PHP_MAX_EXECUTION_TIME`)
@@ -30,7 +30,7 @@ Here a list these, check `/usr/local/etc/php.ini`, `/usr/local/etc/php-fpm.conf`
 - `apc.shm_size = 32m` and `apc.enabled = 1` (changeable via `PHP_APC_SHM_SIZE` and `PHP_APC_ENABLED`)
 - php-fpm error logging happens in stderr
 
-Hint: If you don't like any of these configs, you have three possibilities:  
+Hint: If you don't like any of these configs, you have three possibilities:
 1. If they are changeable via environment variables, use them (preferred version, see list of environment variables below)
 2. Create your own fpm-pool config and set configs them via `php_admin_value` and `php_admin_flag` in there (learn more about them [here](http://php.net/manual/en/configuration.changes.php) - yes this refers to Apache, but it is also the case for php-fpm). _Important:_
     1. If you like to provide your own php-fpm pool, overwrite the file `/usr/local/etc/php-fpm.d/www.conf` with your own config or remove this file if you like another name. If you don't do that the provided pool will be started!
@@ -39,8 +39,8 @@ Hint: If you don't like any of these configs, you have three possibilities:
 
 ## default fpm-pool
 
-This image is shipped with an fpm-pool config ([`php-fpm.d/www.conf`](https://github.com/amazeeio/lagoon/blob/master/images/php/fpm/php-fpm.d/www.conf)) that creates a fpm-pool and listens on port 9000.  
-This is because we try to provide an image which covers already most needs for PHP and so you don't need to create your own. You are happy to do so if you like though :)  
+This image is shipped with an fpm-pool config ([`php-fpm.d/www.conf`](https://github.com/amazeeio/lagoon/blob/master/images/php/fpm/php-fpm.d/www.conf)) that creates a fpm-pool and listens on port 9000.
+This is because we try to provide an image which covers already most needs for PHP and so you don't need to create your own. You are happy to do so if you like though :)
 Here a short description of what this file does:
 
 - listens on port 9000 via ipv4 and ipv6

--- a/docs/using_lagoon/drupal/drupal7-mariadb/cli.dockerfile
+++ b/docs/using_lagoon/drupal/drupal7-mariadb/cli.dockerfile
@@ -1,3 +1,3 @@
-FROM amazeeio/php:7.1-cli-drupal
+FROM amazeeio/php:7.2-cli-drupal
 
 COPY . /app

--- a/docs/using_lagoon/drupal/drupal7-mariadb/php.dockerfile
+++ b/docs/using_lagoon/drupal/drupal7-mariadb/php.dockerfile
@@ -1,6 +1,6 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/php:7.1-fpm
+FROM amazeeio/php:7.2-fpm
 
 COPY --from=cli /app /app

--- a/docs/using_lagoon/index.md
+++ b/docs/using_lagoon/index.md
@@ -45,9 +45,9 @@ Some Docker Images and Containers need additional customizations from the provid
 | ---------------| -------------------| -------------------------------------------------------------------------------------------------------------|
 | nginx | openresty/1.15.8.2 | [nginx/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/nginx/Dockerfile) |
 | nginx-drupal | | [nginx-drupal/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/nginx-drupal/Dockerfile) |
-| [php-fpm](docker_images/php-fpm.md) | 7.1, 7.2, 7.3 | [php/fpm/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/fpm/Dockerfile) |
-| php-cli | 7.1, 7.2, 7.3 | [php/cli/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/cli/Dockerfile) |
-| php-cli-drupal | 7.1, 7.2, 7.3 | [php/cli-drupal/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/cli-drupal/Dockerfile) |
+| [php-fpm](docker_images/php-fpm.md) | 7.2, 7.3 | [php/fpm/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/fpm/Dockerfile) |
+| php-cli | 7.2, 7.3 | [php/cli/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/cli/Dockerfile) |
+| php-cli-drupal | 7.2, 7.3 | [php/cli-drupal/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/php/cli-drupal/Dockerfile) |
 | mariadb | 10 | [mariadb/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/mariadb/Dockerfile) |
 | mariadb-drupal | 10 | [mariadb-drupal/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/mariadb-drupal/Dockerfile) |
 | mongo | 3.6 | [mongo/Dockerfile](https://github.com/amazeeio/lagoon/blob/master/images/mongo/Dockerfile) |

--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -60,7 +60,7 @@ RUN echo "source /lagoon/entrypoints/61-php-xdebug-cli-env.sh" >> /home/.bashrc
 COPY 55-cli-helpers.sh /lagoon/entrypoints/
 RUN echo "source /lagoon/entrypoints/55-cli-helpers.sh" >> /home/.bashrc
 
-RUN if [ ${PHP_VERSION%.*} == "5.6" ] || [ ${PHP_VERSION%.*} == "7.0" ] ; then \
+RUN if [ ${PHP_VERSION%.*} == "5.6" ] || [ ${PHP_VERSION%.*} == "7.0" ] || [ ${PHP_VERSION%.*} == "7.1" ] ; then \
   echo echo \"PHP ${PHP_VERSION} is end of life and should no longer be used. For more information, visit https://secure.php.net/eol.php\" \> /dev/stderr >> /home/.bashrc ; fi
 
 # SSH Key and Agent Setup

--- a/tests/files/drupal8-dockerfiles/php7.4/builder.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/builder.dockerfile
@@ -1,0 +1,9 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-amazeeio}/php:7.4-cli-drupal
+
+COPY composer.json composer.lock /app/
+COPY scripts /app/scripts
+RUN composer install --no-dev
+COPY . /app
+
+ENV WEBROOT=web

--- a/tests/files/drupal8-dockerfiles/php7.4/mariadb.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/mariadb.dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-amazeeio}/mariadb-drupal

--- a/tests/files/drupal8-dockerfiles/php7.4/nginx.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/nginx.dockerfile
@@ -1,0 +1,9 @@
+ARG CLI_IMAGE
+ARG IMAGE_REPO
+FROM ${CLI_IMAGE:-builder} as builder
+
+FROM ${IMAGE_REPO:-amazeeio}/nginx-drupal
+
+COPY --from=builder /app /app
+
+ENV WEBROOT=web

--- a/tests/files/drupal8-dockerfiles/php7.4/php.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/php.dockerfile
@@ -1,0 +1,7 @@
+ARG CLI_IMAGE
+ARG IMAGE_REPO
+FROM ${CLI_IMAGE:-builder} as builder
+
+FROM ${IMAGE_REPO:-amazeeio}/php:7.4-fpm
+
+COPY --from=builder /app /app

--- a/tests/files/drupal8-dockerfiles/php7.4/postgres.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/postgres.dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-amazeeio}/postgres-drupal

--- a/tests/files/drupal8-dockerfiles/php7.4/redis.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/redis.dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-amazeeio}/redis

--- a/tests/files/drupal8-dockerfiles/php7.4/solr.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/solr.dockerfile
@@ -1,0 +1,3 @@
+ARG IMAGE_REPO
+
+FROM ${IMAGE_REPO:-amazeeio}/solr:5.5-drupal

--- a/tests/files/drupal8-dockerfiles/php7.4/varnish.dockerfile
+++ b/tests/files/drupal8-dockerfiles/php7.4/varnish.dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-amazeeio}/varnish-drupal

--- a/tests/tests/drupal.yaml
+++ b/tests/tests/drupal.yaml
@@ -44,12 +44,21 @@
     project: ci-drupal
     branch: drupal8-composer-73-mariadb
 
+- include: drupal/drupal.yaml
+  vars:
+    testname: "Drupal 8 composer PHP 7.4 - MARIADB"
+    drupal_version: 8
+    db: mariadb
+    php_version: 7.4
+    git_repo_name: drupal.git
+    project: ci-drupal
+    branch: drupal8-composer-74-mariadb
 
 - include: drupal/drush.yaml
   vars:
     testname: "DRUSH"
     drupal_version: 8
     db: mariadb
-    php_version: 7.1
+    php_version: 7.3
     git_repo_name: drupal.git
     project: ci-drupal


### PR DESCRIPTION
This PR introduces two things:
* Removal of PHP7.1 support from documentation now that it is EOL
* Adds in testing for PHP7.4 now that it is released (and initial support)

TO-DO:
* Make PHP7.4 tests optional until https://www.drupal.org/project/drupal/issues/3086374 is resolved.
* Consider removing PHP7.0 tests from our testing.
* As per #1214 we should consider a timeframe to remove/freeze image support for PHP5.6, PHP7.0 and PHP7.1

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Improvement - Remove PHP7.1 support from documentation (#1214)
Improvement - Add PHP7.4 testing to Lagoon

# Closing issues
Closes #1214 (first stage)
