### PR TITLE
Remove broken docker tag override for PHP7.0 images and remove tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docker_build_elastic = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VE
 # 2. PHP version and type of image (ie 7.0-fpm, 7.0-cli etc)
 # 3. Location of Dockerfile
 # 4. Path of Docker Build Context
-docker_build_php = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg PHP_VERSION=$(1)  --build-arg PHP_IMAGE_VERSION=$(2) -t $(CI_BUILD_TAG)/php:$(3) -f $(4) $(5)
+docker_build_php = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg PHP_VERSION=$(1)  --build-arg PHP_IMAGE_VERSION=$(1) -t $(CI_BUILD_TAG)/php:$(2) -f $(3) $(4)
 
 docker_build_node = docker build $(DOCKER_BUILD_PARAMS) --build-arg LAGOON_VERSION=$(LAGOON_VERSION) --build-arg IMAGE_REPO=$(CI_BUILD_TAG) --build-arg NODE_VERSION=$(1) -t $(CI_BUILD_TAG)/node:$(2) -f $(3) $(4)
 
@@ -287,7 +287,7 @@ $(build-phpimages): build/commons
 	$(eval type_dash = $(if $(subtype),-$(type)-$(subtype),$(type_dash)))
 	$(eval type_slash = $(if $(subtype),/$(type)-$(subtype),$(type_slash)))
 # Call the docker build
-	$(call docker_build_php,$(version),$(php_ver),$(version)$(type_dash),images/php$(type_slash)/Dockerfile,images/php$(type_slash))
+	$(call docker_build_php,$(version),$(version)$(type_dash),images/php$(type_slash)/Dockerfile,images/php$(type_slash))
 # Touch an empty file which make itself is using to understand when the image has been last build
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -286,8 +286,6 @@ $(build-phpimages): build/commons
 # if there is a subtype, add it. If not, just keep what we already had
 	$(eval type_dash = $(if $(subtype),-$(type)-$(subtype),$(type_dash)))
 	$(eval type_slash = $(if $(subtype),/$(type)-$(subtype),$(type_slash)))
-# cover the edge case for php 7.0 needing php:7-fpm-alpine
-	$(eval php_ver = $(patsubst 7.0,7,$(version)))
 # Call the docker build
 	$(call docker_build_php,$(version),$(php_ver),$(version)$(type_dash),images/php$(type_slash)/Dockerfile,images/php$(type_slash))
 # Touch an empty file which make itself is using to understand when the image has been last build

--- a/tests/tests/drupal-postgres.yaml
+++ b/tests/tests/drupal-postgres.yaml
@@ -6,16 +6,6 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.0 - POSTGRES"
-    drupal_version: 8
-    db: postgres
-    php_version: 7.0
-    git_repo_name: drupal-postgres.git
-    project: ci-drupal-postgres
-    branch: drupal8-composer-70-postgres
-
-- include: drupal/drupal.yaml
-  vars:
     testname: "Drupal 8 composer PHP 7.1 - POSTGRES"
     drupal_version: 8
     db: postgres

--- a/tests/tests/drupal.yaml
+++ b/tests/tests/drupal.yaml
@@ -6,16 +6,6 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.0 - MARIADB"
-    drupal_version: 8
-    db: mariadb
-    php_version: 7.0
-    git_repo_name: drupal.git
-    project: ci-drupal
-    branch: drupal8-composer-70-mariadb
-
-- include: drupal/drupal.yaml
-  vars:
     testname: "Drupal 8 composer PHP 7.1 - MARIADB"
     drupal_version: 8
     db: mariadb


### PR DESCRIPTION
This PR is to remove a tag override in place for PHP7.0 that was causing PHP7.0 based images to install the latest PHP version

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Bugfix - build PHP7.0 images from correct tag
Change - remove deprecated PHP7.0 tests from Makefile/Jenkins
