### PR TITLE
Default Availability set to STANDARD

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS project (
   name                             varchar(100) UNIQUE,
   customer                         int REFERENCES customer (id),
   git_url                          varchar(300),
-  availability                       varchar(50),
+  availability                     varchar(50) NOT NULL DEFAULT 'STANDARD',
   subfolder                        varchar(300),
   active_systems_deploy            varchar(300),
   active_systems_promote           varchar(300),

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -109,6 +109,24 @@ CREATE OR REPLACE PROCEDURE
 $$
 
 CREATE OR REPLACE PROCEDURE
+  add_availability_to_project()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'project'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'availability'
+    ) THEN
+      ALTER TABLE `project`
+      ADD `availability` varchar(50);
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
   add_production_environment_to_project()
 
   BEGIN

--- a/services/api/src/resources/project/resolvers.js
+++ b/services/api/src/resources/project/resolvers.js
@@ -236,7 +236,7 @@ const addProject = async (
         :id,
         :name,
         :git_url,
-        :availability,
+        ${input.availability ? ':availability' : '"STANDARD"'},
         :private_key,
         ${input.subfolder ? ':subfolder' : 'NULL'},
         :openshift,


### PR DESCRIPTION

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Most projects that get added will be STANDARD availability so it makes sense to set that by default. This is better than requiring the availability field be included during the mutation. 

# Changelog Entry

Sets the availability column to "STANDARD" by default. 
Before the column was set to null by default.


# Closing issues
Closes 1459 https://github.com/amazeeio/lagoon/issues/1459
