### PR TITLE
SAFE_BRANCH and SAFE_PROJECT args build-deploy

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -252,7 +252,9 @@ if [[ ( "$TYPE" == "pullrequest"  ||  "$TYPE" == "branch" ) && ! $THIS_IS_TUG ==
   BUILD_ARGS+=(--build-arg IMAGE_REPO="${CI_OVERRIDE_IMAGE_REPO}")
   BUILD_ARGS+=(--build-arg LAGOON_GIT_SHA="${LAGOON_GIT_SHA}")
   BUILD_ARGS+=(--build-arg LAGOON_GIT_BRANCH="${BRANCH}")
+  BUILD_ARGS+=(--build-arg LAGOON_GIT_SAFE_BRANCH="${SAFE_BRANCH}")
   BUILD_ARGS+=(--build-arg LAGOON_PROJECT="${PROJECT}")
+  BUILD_ARGS+=(--build-arg LAGOON_SAFE_PROJECT="${SAFE_PROJECT}")
   BUILD_ARGS+=(--build-arg LAGOON_BUILD_TYPE="${TYPE}")
   set +x
   BUILD_ARGS+=(--build-arg LAGOON_SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY}")


### PR DESCRIPTION
Currently `LAGOON_GIT_BRANCH` and `LAGOON_PROJECT` are passed as build args when building images, it would be good to have `LAGOON_GIT_SAFE_BRANCH` and `LAGOON_SAFE_PROJECT` versions of these too.

## specific usecase
If images are pre-built elsewhere prior and pushed to a private container registry, being able to tag the image built in branch `feature/xyz` with the safe_branch like `myproject/cli:feature-xyz`.
This would allow using the `LAGOON_GIT_SAFE_BRANCH` build arg so that tagged images are used in the lagoon build step with a dockerfile like below.

```
ARG LAGOON_GIT_SAFE_BRANCH
FROM myregistry.com/myrepo/myproject/cli:${LAGOON_GIT_SAFE_BRANCH:-latest}
```
