### PR TITLE
Handle new gd configure options in php 7.4 image

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -57,26 +57,38 @@ RUN apk add --no-cache fcgi \
         libwebp-dev \
         postgresql-dev \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && if [ ${PHP_VERSION%.*} == "7.3" ]; then \
+    && case ${PHP_VERSION} in \
+      7.3*) \
         yes '' | pecl install -f apcu \
         && yes '' | pecl install -f xdebug-2.7.0 \
         && yes '' | pecl install -f redis-4.3.0; \
-       elif [ ${PHP_VERSION%.*.*} == "7" ]; then \
+        ;; \
+      7*) \
         yes '' | pecl install -f apcu \
         && yes '' | pecl install -f xdebug \
         && yes '' | pecl install -f redis-4.3.0; \
-       fi \
-    && if [ ${PHP_VERSION%.*.*} == "5" ]; then \
+        ;; \
+      5*) \
         yes '' | pecl install -f apcu-4.0.11 \
         && yes '' | pecl install -f xdebug-2.5.5 \
         && yes '' | pecl install -f redis-4.3.0; \
-       fi \
+        ;; \
+      esac \
     && docker-php-ext-enable apcu redis xdebug \
-    && docker-php-ext-configure gd --with-webp-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && case ${PHP_VERSION} in \
+      7.4*) \
+        docker-php-ext-configure gd --with-webp --with-jpeg \
+        ;; \
+      *) \
+        docker-php-ext-configure gd --with-webp-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+        ;; \
+      esac \
     && docker-php-ext-install -j4 bcmath gd gettext pdo_mysql mysqli pdo_pgsql pgsql shmop soap sockets opcache xsl zip \
-    && if [ ${PHP_VERSION%.*} == "7.1" ] || [ ${PHP_VERSION%.*} == "7.0" ] || [ ${PHP_VERSION%.*.*} == "5" ]; then \
+    && case ${PHP_VERSION} in \
+      7.1*|7.0*|5*) \
         docker-php-ext-install mcrypt; \
-       fi \
+        ;; \
+      esac \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && rm -rf /var/cache/apk/* /tmp/pear/ \
     && apk del .phpize-deps \


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

PHP 7.4 images are broken due to changes in the `gd` extensions configuration flags. See [here](https://github.com/docker-library/php/issues/920#issuecomment-562864296) and [here](https://github.com/php/php-src/commit/19d8a6b771a1d8d458583772703a5bb1a1276274).

The reason that this hasn't been picked up before was that the incorrect flags were only producing a `WARNING`. We build our images with `--quiet`, so it was never seen. This behaviour was [recently changed](https://github.com/docker-library/php/pull/918) to `ERROR` on incorrect configure flags.

The final result is that building from the latest `php:7.4-fpm-alpine` image will now fail without the fix in this PR.

# Changelog Entry

Bugfix - Correctly build gd extension on PHP 7.4

# Closing issues
n/a
