### PR TITLE
Availability Fix - v2

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -867,6 +867,7 @@ $$
 
 DELIMITER ;
 
+CALL add_availability_to_project();
 CALL add_production_environment_to_project();
 CALL add_ssh_to_openshift();
 CALL convert_project_pullrequest_to_varchar();


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Most projects that get added will be STANDARD availability so it makes sense to set that by default. This is better than requiring the availability field be included during the mutation. 

# Changelog Entry

Sets the availability column to "STANDARD" by default. 
Before the column was set to null by default.
Fixing a missed call. 


# Closing issues
Closes 1459 https://github.com/amazeeio/lagoon/issues/1459
