### PR TITLE
Show timezone offset in hours since name is not supported

### DIFF
--- a/services/ui/src/components/Backups/index.js
+++ b/services/ui/src/components/Backups/index.js
@@ -20,7 +20,7 @@ const Backups = ({ backups }) => (
             {moment
               .utc(backup.created)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
 
           <div className="backupid">{backup.backupId}</div>

--- a/services/ui/src/components/Deployment/index.js
+++ b/services/ui/src/components/Deployment/index.js
@@ -32,7 +32,7 @@ const Deployment = ({ deployment }) => (
             {moment
               .utc(deployment.created)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
         </div>
       </div>

--- a/services/ui/src/components/Deployments/index.js
+++ b/services/ui/src/components/Deployments/index.js
@@ -30,7 +30,7 @@ const Deployments = ({ deployments }) => (
               {moment
                 .utc(deployment.created)
                 .local()
-                .format('DD MMM YYYY, HH:mm:ss (z)')}
+                .format('DD MMM YYYY, HH:mm:ss (Z)')}
             </div>
             <div className={`status ${deployment.status}`}>
               {deployment.status.charAt(0).toUpperCase() +

--- a/services/ui/src/components/Environment/index.js
+++ b/services/ui/src/components/Environment/index.js
@@ -37,7 +37,7 @@ const Environment = ({ environment }) => {
             {moment
               .utc(environment.created)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
         </div>
       </div>
@@ -48,7 +48,7 @@ const Environment = ({ environment }) => {
             {moment
               .utc(environment.updated)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
         </div>
       </div>

--- a/services/ui/src/components/ProjectDetailsSidebar/index.js
+++ b/services/ui/src/components/ProjectDetailsSidebar/index.js
@@ -24,7 +24,7 @@ const Project = ({ project }) => {
             {moment
               .utc(project.created)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
         </div>
       </div>

--- a/services/ui/src/components/Task/index.js
+++ b/services/ui/src/components/Task/index.js
@@ -17,7 +17,7 @@ const Task = ({ task }) => (
             {moment
               .utc(task.created)
               .local()
-              .format('DD MMM YYYY, HH:mm:ss (z)')}
+              .format('DD MMM YYYY, HH:mm:ss (Z)')}
           </div>
         </div>
       </div>

--- a/services/ui/src/components/Tasks/index.js
+++ b/services/ui/src/components/Tasks/index.js
@@ -29,7 +29,7 @@ const Tasks = ({ tasks }) => (
               {moment
                 .utc(task.created)
                 .local()
-                .format('DD MMM YYYY, HH:mm:ss (z)')}
+                .format('DD MMM YYYY, HH:mm:ss (Z)')}
             </div>
             <div className="service">{task.service}</div>
             <div className={`status ${task.status}`}>


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Follow up for #1285. The timezone `z` (e.g., CST) isn't supported, switched to `Z` (-06:00) instead.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Display timezone information on dates in the UI (#1284)

# Closing issues
n/a
