### PR TITLE
Silence useless "command not found" if minishift not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,7 +883,7 @@ minishift/cleanall: minishift/stopall
 # installed, otherwise downloads it.
 local-dev/minishift/minishift:
 	@mkdir -p ./local-dev/minishift
-ifeq ($(MINISHIFT_VERSION), $(shell minishift version | sed -E 's/^minishift v([0-9.]+).*/\1/'))
+ifeq ($(MINISHIFT_VERSION), $(shell minishift version 2>/dev/null | sed -E 's/^minishift v([0-9.]+).*/\1/'))
 	$(info linking local minishift version $(MINISHIFT_VERSION))
 	ln -s $(shell command -v minishift) ./local-dev/minishift/minishift
 else


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

If minishift is not installed locally the `local-dev/minishift/minishift` make target will print "command not found" on STDERR. This changes silences this useless error message.

# Changelog Entry
Improvement - Silence useless error message in CI builds

# Closing issues
n/a
