### PR TITLE
Sync output of parallel make tasks in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,15 @@ node {
       try {
         env.CI_BUILD_TAG = env.BUILD_TAG.replaceAll('%2f','').replaceAll("[^A-Za-z0-9]+", "").toLowerCase()
         env.SAFEBRANCH_NAME = env.BRANCH_NAME.replaceAll('%2f','-').replaceAll("[^A-Za-z0-9]+", "-").toLowerCase()
+        env.SYNC_MAKE_OUTPUT = 'target'
+        // make/tests will synchronise (buffer) output by default to avoid interspersed
+        // lines from multiple jobs run in parallel. However this means that output for
+        // each make target is not written until the command completes.
+        //
+        // See `man -P 'less +/-O' make` for more information about this option.
+        //
+        // Uncomment the line below to disable output synchronisation.
+        //env.SYNC_MAKE_OUTPUT = 'none'
 
         stage ('env') {
           sh "env"
@@ -23,7 +32,7 @@ node {
         }
 
         stage ('build images') {
-          sh "make -O -j6 build"
+          sh "make -O${SYNC_MAKE_OUTPUT} -j6 build"
         }
 
         openshift_versions.each { openshift_version ->
@@ -51,7 +60,7 @@ node {
                 stage ('push images to amazeeiolagoon/*') {
                   withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
                     sh 'docker login -u amazeeiojenkins -p $PASSWORD'
-                    sh "make -O -j4 publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages BRANCH_NAME=${SAFEBRANCH_NAME}"
+                    sh "make -O${SYNC_MAKE_OUTPUT} -j4 publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages BRANCH_NAME=${SAFEBRANCH_NAME}"
                   }
                 }
               }
@@ -66,9 +75,9 @@ node {
             "_tests_${openshift_version}": {
                 stage ('run tests') {
                   try {
-                    sh "make -O -j5 push-minishift"
+                    sh "make -O${SYNC_MAKE_OUTPUT} -j5 push-minishift"
                     sh "make up"
-                    sh "make -O -j2 tests"
+                    sh "make -O${SYNC_MAKE_OUTPUT} -j2 tests"
                   } catch (e) {
                     echo "Something went wrong, trying to cleanup"
                     cleanup()
@@ -89,14 +98,14 @@ node {
           stage ('publish-amazeeio') {
             withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
               sh 'docker login -u amazeeiojenkins -p $PASSWORD'
-              sh "make -O -j4 publish-amazeeio-baseimages"
+              sh "make -O${SYNC_MAKE_OUTPUT} -j4 publish-amazeeio-baseimages"
             }
           }
         }
 
         if (env.BRANCH_NAME == 'master') {
           stage ('save-images-s3') {
-            sh "make -O -j8 s3-save"
+            sh "make -O${SYNC_MAKE_OUTPUT} -j8 s3-save"
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node {
         }
 
         stage ('build images') {
-          sh "make build -j6"
+          sh "make -O -j6 build"
         }
 
         openshift_versions.each { openshift_version ->
@@ -51,7 +51,7 @@ node {
                 stage ('push images to amazeeiolagoon/*') {
                   withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
                     sh 'docker login -u amazeeiojenkins -p $PASSWORD'
-                    sh "make publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages BRANCH_NAME=${SAFEBRANCH_NAME} -j4"
+                    sh "make -O -j4 publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages BRANCH_NAME=${SAFEBRANCH_NAME}"
                   }
                 }
               }
@@ -66,9 +66,9 @@ node {
             "_tests_${openshift_version}": {
                 stage ('run tests') {
                   try {
-                    sh "make push-minishift -j5"
+                    sh "make -O -j5 push-minishift"
                     sh "make up"
-                    sh "make tests -j2"
+                    sh "make -O -j2 tests"
                   } catch (e) {
                     echo "Something went wrong, trying to cleanup"
                     cleanup()
@@ -89,14 +89,14 @@ node {
           stage ('publish-amazeeio') {
             withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
               sh 'docker login -u amazeeiojenkins -p $PASSWORD'
-              sh "make publish-amazeeio-baseimages -j4"
+              sh "make -O -j4 publish-amazeeio-baseimages"
             }
           }
         }
 
         if (env.BRANCH_NAME == 'master') {
           stage ('save-images-s3') {
-            sh "make s3-save -j8"
+            sh "make -O -j8 s3-save"
           }
         }
 


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

The parallel tasks in CI (`-jN`) all write to STDOUT at once and the output is garbled. This change syncs the output to avoid the interspersed messages from parallel make tasks.

# Changelog Entry
Improvement - Sync output of parallel CI tasks

# Closing issues
n/a