### PR TITLE
Improvements to the auto-idler

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -409,6 +409,8 @@ services:
     volumes:
       - './services/auto-idler/idle-services.sh:/idle-services.sh'
       - './services/auto-idler/idle-clis.sh:/idle-clis.sh'
+      - './services/auto-idler/openshift-services.sh:/openshift-services.sh'
+      - './services/auto-idler/openshift-clis.sh:/openshift-clis.sh'
       - './services/auto-idler/create_jwt.sh:/create_jwt.sh'
     labels:
       lagoon.type: custom

--- a/services/auto-idler/Dockerfile
+++ b/services/auto-idler/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache tini jq openssl bash curl nodejs nodejs-npm \
     && npm config set unsafe-perm true \
     && npm -g install jwtgen
 
-COPY create_jwt.sh idle-services.sh idle-clis.sh /
+COPY create_jwt.sh idle-services.sh idle-clis.sh openshift-clis.sh openshift-services.sh /
 
 ENV JWTSECRET=super-secret-string \
     JWTAUDIENCE=api.dev \

--- a/services/auto-idler/idle-clis.sh
+++ b/services/auto-idler/idle-clis.sh
@@ -2,6 +2,12 @@
 
 # set -e -o pipefail
 
+prefixwith() {
+  local prefix="$1"
+  shift
+  "$@" > >(sed "s#^#${prefix}: #") 2> >(sed "s#^#${prefix} (err): #" >&2)
+}
+
 # Create an JWT Admin Token to talk to the API
 API_ADMIN_JWT_TOKEN=$(./create_jwt.sh)
 BEARER="Authorization: bearer $API_ADMIN_JWT_TOKEN"
@@ -26,116 +32,17 @@ GRAPHQL='query environments {
 query=$(echo $GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
 ALL_ENVIRONMENTS=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}")
 
-# Filter only projects that actually have an environment
-# Loop through each found project
-echo "$ALL_ENVIRONMENTS" | jq -c '.data.environments[] | select((.environments|length)>=1)' | while read project
-  do
-    PROJECT_NAME=$(echo "$project" | jq -r '.name')
-    OPENSHIFT_URL=$(echo "$project" | jq -r '.openshift.consoleUrl')
-    AUTOIDLE=$(echo "$project" | jq -r '.autoIdle')
+# All data successfully loaded, now we don't want to fail anymore if a single idle fails
+set +eo pipefail
 
-    if [[ $AUTOIDLE == "1" ]]; then
-      # Match the Project name to the Project Regex
-      if [[ $PROJECT_NAME =~ $PROJECT_REGEX ]]; then
-        OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token')
-        echo "$OPENSHIFT_URL - $PROJECT_NAME: Found "
-
-        # loop through each environment of the current lagoon project
-        echo "$project" | jq -c '.environments[]' | while read environment
-        do
-          ENVIRONMENT_OPENSHIFT_PROJECTNAME=$(echo "$environment" | jq -r '.openshiftProjectName')
-          ENVIRONMENT_NAME=$(echo "$environment" | jq -r '.name')
-
-          # First check if this openshift project exists
-          echo "$OPENSHIFT_URL - $PROJECT_NAME: handling environment $ENVIRONMENT_NAME"
-          if ! oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" get project "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" > /dev/null; then
-            echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: OpenShift Project not found"
-            continue;
-          fi
-
-          # Check for Deploymentconfigs which are clis
-          DEPLOYMENTCONFIGS=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get dc -l service=cli -o name)
-          if [ "$DEPLOYMENTCONFIGS" == "" ]; then
-            echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: No deploymentconfigs for cli found"
-            continue;
-          fi
-
-          # Loop through all found deploymentconfigs
-          printf '%s\n' "$DEPLOYMENTCONFIGS" | while IFS= read -r deploymentconfig
-          do
-            echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: handling $deploymentconfig"
-
-            # Check first if deploymentconfig has running replicas
-            HAS_RUNNING_REPLICAS=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get $deploymentconfig -o json | jq '.status.replicas | if . > 0 then true else false end')
-            if [ ! $? -eq 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking for running pods"
-                continue
-            # Has running replicas
-            elif [ "$HAS_RUNNING_REPLICAS" == "true" ]; then
-              echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has running pods, checking if they are non-busy"
-
-              # Set to false initially, if there are any processes or builds running they are adjusted then.
-              # Will also skip on any continue conditions
-              NO_PROCESSES=false
-              NO_BUILDS=false
-              NO_CRONJOBS=false
-
-              # Check for any running processes
-              RUNNING_PROCESSES=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "pgrep -P 0 | tail -n +3 | wc -l | tr -d ' '")
-              if [ ! $? -eq 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking for busy-ness of pods"
-                continue
-              elif [ "$RUNNING_PROCESSES" == "0" ]; then
-                # Now we can scale
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running processes"
-                NO_PROCESSES=true
-              else
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_PROCESSES running processes, skipping"
-                continue
-              fi
-
-              # Check for cronjobs present
-              CRONJOBS_PRESENT=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "echo \$CRONJOBS")
-              if [ ! $? -eq 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking if pod has cronjob"
-                continue
-              elif [ -z "$CRONJOBS_PRESENT" ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no cronjobs"
-                NO_CRONJOBS=true
-              else
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has cronjobs defined, skipping"
-                continue
-              fi
-
-              # Check for any running builds
-              RUNNING_BUILDS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get --no-headers=true builds | grep "Running" | wc -l | tr -d ' ')
-              if [ ! $? -eq 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking build status"
-                continue
-              elif [ "$RUNNING_BUILDS" == "0" ]; then
-                # Now we can scale
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running builds"
-                NO_BUILDS=true
-              else
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_BUILDS running builds, skipping"
-                continue
-              fi
-
-              ## If there are no builds AND no processes, then we can idle the pods
-              if [[ "$NO_BUILDS" == "true" && "$NO_PROCESSES" == "true" && "$NO_CRONJOBS" == "true" ]]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: scaling to 0"
-                oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" scale --replicas=0 $deploymentconfig
-              fi
-            else
-              echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running pods"
-            fi
-          done
-        done
-      else
-        echo "$OPENSHIFT_URL - $PROJECT_NAME: SKIP, does not match Regex: $PROJECT_REGEX"
-      fi
-    echo "" # new line for prettyness
-  else
-    echo "$OPENSHIFT_URL - $PROJECT_NAME: has autoidle set to $AUTOIDLE "
-  fi
-  done
+TMP_DATA="$(mktemp)"
+echo "$ALL_ENVIRONMENTS" > $TMP_DATA
+# loop through the data and run `openshift-services` against each openshift 1by1
+echo "$ALL_ENVIRONMENTS" | jq -r -c '.data.environments[] | select((.environments|length)>=1) | .openshift.consoleUrl' | sort | uniq  | while read openshift
+do
+  # run the idler against a particular openshift only  # run the idler against a particular openshift only
+  prefixwith $openshift ./openshift-clis.sh $openshift $TMP_DATA &
+done
+sleep 5
+# clean up the tmp file
+rm $TMP_DATA

--- a/services/auto-idler/idle-services.sh
+++ b/services/auto-idler/idle-services.sh
@@ -3,6 +3,12 @@
 # make sure we stop if we fail
 set -eo pipefail
 
+prefixwith() {
+  local prefix="$1"
+  shift
+  "$@" > >(sed "s#^#${prefix}: #") 2> >(sed "s#^#${prefix} (err): #" >&2)
+}
+
 # Create an JWT Admin Token to talk to the API
 API_ADMIN_JWT_TOKEN=$(./create_jwt.sh)
 BEARER="Authorization: bearer $API_ADMIN_JWT_TOKEN"
@@ -31,136 +37,18 @@ DEVELOPMENT_ENVIRONMENTS=$(set -e -o pipefail; curl -s -XPOST -H 'Content-Type: 
 # All data successfully loaded, now we don't want to fail anymore if a single idle fails
 set +eo pipefail
 
-# Filter only projects that actually have an environment
-# Loop through each found project
-echo "$DEVELOPMENT_ENVIRONMENTS" | jq -c '.data.developmentEnvironments[] | select((.environments|length)>=1)' | while read project
-  do
-    PROJECT_NAME=$(echo "$project" | jq -r '.name')
-    OPENSHIFT_URL=$(echo "$project" | jq -r '.openshift.consoleUrl')
-    AUTOIDLE=$(echo "$project" | jq -r '.autoIdle')
+if [ "$1" == "force" ]; then
+  FORCE=force
+fi
 
-    # Match the Project name to the Project Regex
-    if [[ $PROJECT_NAME =~ $PROJECT_REGEX ]]; then
-      OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token')
-      echo "$OPENSHIFT_URL - $PROJECT_NAME: Found with development environments"
-
-      if [[ $AUTOIDLE == "1" ]]; then
-        # loop through each environment of the current project
-        echo "$project" | jq -c '.environments[]' | while read environment
-        do
-          ENVIRONMENT_OPENSHIFT_PROJECTNAME=$(echo "$environment" | jq -r '.openshiftProjectName')
-          ENVIRONMENT_NAME=$(echo "$environment" | jq -r '.name')
-          ENVIRONMENT_AUTOIDLE=$(echo "$environment" | jq -r '.autoIdle')
-          echo "$OPENSHIFT_URL - $PROJECT_NAME: handling development environment $ENVIRONMENT_NAME"
-
-          if [ "$ENVIRONMENT_AUTOIDLE" == "0" ]; then
-            echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME idling disabled, skipping"
-            continue
-          fi
-
-          # if we need to force idling of development environments we can use flag force `./idle-services.sh force` to skip all checks and proceed to idling
-          if [ "$1" == "force" ]; then
-            echo "force idling"
-            IDLE_PODS=true
-          else
-            # else we just do normal idling checks
-            NO_BUILDS=false
-            PODS_RUNNING=false
-
-            # Check for any running builds
-            RUNNING_BUILDS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get --no-headers=true builds | grep "Running" | wc -l | tr -d ' ')
-            if [ ! $? -eq 0 ]; then
-              echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: error checking build status"
-              continue
-            elif [ "$RUNNING_BUILDS" == "0" ]; then
-              # Now we can scale
-              echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: no running builds"
-              NO_BUILDS=true
-            else
-              echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME: has $RUNNING_BUILDS running builds, skipping"
-              continue
-            fi
-
-            # check if any deploymentconfigs have any running pods, and if those pods have been running greater than the $POD_RUN_INTERVAL in seconds (4hrs = 14400seconds) since the current time
-            DEPLOYMENTCONFIGS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get dc -o name -l "service notin (mariadb,postgres,cli)" | sed 's/deploymentconfigs\///')
-            for deployment in $DEPLOYMENTCONFIGS
-            do
-              RUNNING_PODS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get pods -l deploymentconfig=${deployment} --show-labels=false -o json | jq -r '.items | .[] | .status.containerStatuses | .[] | .state.running.startedAt')
-              if [ "$RUNNING_PODS" != "0" ]; then
-                for pod in $RUNNING_PODS
-                do
-                  FIX_TIME=$(echo $pod | sed 's/T/ /g; s/Z//g') #busybox `date` doesn't like ISO 8601 passed to it, we have to strip the T and Z from it
-                  RUNTIME="$(($(date -u +%s)-$(date -u -d "$FIX_TIME" +%s)))" #get a rough runtime from the pod running time
-                  if [[ $RUNTIME -gt $POD_RUN_INTERVAL ]]; then
-                    echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME - $deployment running longer than interval, proceeding to check router-logs"
-                    PODS_RUNNING=true
-                  fi
-                done
-                if [ "$PODS_RUNNING" == false ]; then
-                  echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME - $deployment running less than interval, skipping"
-                fi
-              else
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME - $deployment no running pods, skipping"
-              fi
-            done
-
-            # if no running builds, and any deploymentconfigs notin (mariadb,postgres,cli) have been running greater than $POD_RUN_INTERVAL, then we want to check router-logs then proceed to idle
-            if [[ "$NO_BUILDS" == "true" && "$PODS_RUNNING" == "true" ]]; then
-              # Check if this environment has hits
-              HITS=$(curl -s -u "admin:$LOGSDB_ADMIN_PASSWORD" -XGET "$ELASTICSEARCH_URL/router-logs-$ENVIRONMENT_OPENSHIFT_PROJECTNAME-*/_search" -H 'Content-Type: application/json' -d"
-              {
-                \"size\": 0,
-                \"query\": {
-                  \"bool\": {
-                    \"filter\": {
-                      \"range\": {
-                        \"@timestamp\": {
-                          \"gte\": \"now-${ROUTER_LOG_INTERVAL}\"
-                        }
-                      }
-                    }
-                  }
-                }
-              }" | jq ".hits.total")
-
-              if [ ! $? -eq 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME error checking hits"
-                continue
-              elif [ "$HITS" == "null"  ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME no data found, skipping"
-                continue
-              elif [ "$HITS" -gt 0 ]; then
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME had $HITS hits in last four hours, no idling"
-              else
-                echo "$OPENSHIFT_URL - $PROJECT_NAME: $ENVIRONMENT_NAME had no hits in last four hours, starting to idle"
-                IDLE_PODS=true
-              fi
-            fi
-          fi
-          if [ "$IDLE_PODS" == "true" ]; then
-            # actually idling happens here
-            oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" idle -l "service notin (mariadb,postgres)"
-
-            ### Faster Unidling:
-            ## Instead of depending that each endpoint is unidling their own service (which means it takes a lot of time to unidle multiple services)
-            ## This update makes sure that every endpoint is unidling every service that is currently idled, which means the whole system is much much faster unidled.
-            # load all endpoints which have unidle targets, format it as a space separated
-            IDLING_ENDPOINTS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get endpoints -o json | jq  --raw-output '[ .items[] | select(.metadata.annotations | has("idling.alpha.openshift.io/unidle-targets")) | .metadata.name ] | join(" ")')
-            if [[ "${IDLING_ENDPOINTS}" ]]; then
-              # Load all unidling targets of all endpoints and generate one bit JSON array from it
-              ALL_IDLED_SERVICES_JSON=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get endpoints -o json | jq --raw-output '[ .items[] | select(.metadata.annotations | has("idling.alpha.openshift.io/unidle-targets")) | .metadata.annotations."idling.alpha.openshift.io/unidle-targets" | fromjson | .[] ] | unique_by(.name) | tojson')
-              # add this generated JSON array to all endpoints
-              if [[ "${ALL_IDLED_SERVICES_JSON}" ]]; then
-                oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" annotate --overwrite endpoints $IDLING_ENDPOINTS "idling.alpha.openshift.io/unidle-targets=${ALL_IDLED_SERVICES_JSON}"
-              fi
-            fi
-          fi
-        done # environment loop
-      else
-          echo "$OPENSHIFT_URL - $PROJECT_NAME: has autoidle set to $AUTOIDLE "
-      fi
-    else
-      echo "$OPENSHIFT_URL - $PROJECT_NAME: SKIP, does not match Regex: $PROJECT_REGEX"
-    fi
-    echo "" # new line for prettyness
-  done
+TMP_DATA="$(mktemp)"
+echo "$DEVELOPMENT_ENVIRONMENTS" > $TMP_DATA
+# loop through the data and run `openshift-services` against each openshift 1by1
+echo "$DEVELOPMENT_ENVIRONMENTS" | jq -r -c '.data.developmentEnvironments[] | select((.environments|length)>=1) | .openshift.consoleUrl' | sort | uniq | while read openshift
+do
+  # run the idler against a particular openshift only
+  prefixwith $openshift ./openshift-services.sh $openshift $TMP_DATA $FORCE &
+done
+sleep 5
+# clean up the tmp file
+rm $TMP_DATA

--- a/services/auto-idler/openshift-clis.sh
+++ b/services/auto-idler/openshift-clis.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+ALL_ENVIRONMENTS=$(cat $2)
+
+# Filter only projects that actually have an environment
+# Loop through each found project
+echo "$ALL_ENVIRONMENTS" | jq -c '.data.environments[] | select((.environments|length)>=1)' | while read project
+  do
+    PROJECT_NAME=$(echo "$project" | jq -r '.name')
+    OPENSHIFT_URL=$(echo "$project" | jq -r '.openshift.consoleUrl')
+    AUTOIDLE=$(echo "$project" | jq -r '.autoIdle')
+
+    # check if the openshifturl for the environment matches the openshift we want to run the idler against
+    if [ "$1" == "${OPENSHIFT_URL}" ]; then
+      if [[ $AUTOIDLE == "1" ]]; then
+        # Match the Project name to the Project Regex
+        if [[ $PROJECT_NAME =~ $PROJECT_REGEX ]]; then
+          OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token')
+          echo "$PROJECT_NAME: Found "
+
+          # loop through each environment of the current lagoon project
+          echo "$project" | jq -c '.environments[]' | while read environment
+          do
+            ENVIRONMENT_OPENSHIFT_PROJECTNAME=$(echo "$environment" | jq -r '.openshiftProjectName')
+            ENVIRONMENT_NAME=$(echo "$environment" | jq -r '.name')
+
+            # First check if this openshift project exists
+            echo "$PROJECT_NAME: handling environment $ENVIRONMENT_NAME"
+            if ! oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" get project "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" > /dev/null; then
+              echo "$PROJECT_NAME: $ENVIRONMENT_NAME: OpenShift Project not found"
+              continue;
+            fi
+
+            # Check for Deploymentconfigs which are clis
+            DEPLOYMENTCONFIGS=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get dc -l service=cli -o name)
+            if [ "$DEPLOYMENTCONFIGS" == "" ]; then
+              echo "$PROJECT_NAME: $ENVIRONMENT_NAME: No deploymentconfigs for cli found"
+              continue;
+            fi
+
+            # Loop through all found deploymentconfigs
+            printf '%s\n' "$DEPLOYMENTCONFIGS" | while IFS= read -r deploymentconfig
+            do
+              echo "$PROJECT_NAME: $ENVIRONMENT_NAME: handling $deploymentconfig"
+
+              # Check first if deploymentconfig has running replicas
+              HAS_RUNNING_REPLICAS=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get $deploymentconfig -o json | jq '.status.replicas | if . > 0 then true else false end')
+              if [ ! $? -eq 0 ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking for running pods"
+                  continue
+              # Has running replicas
+              elif [ "$HAS_RUNNING_REPLICAS" == "true" ]; then
+                echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has running pods, checking if they are non-busy"
+
+                # Set to false initially, if there are any processes or builds running they are adjusted then.
+                # Will also skip on any continue conditions
+                NO_PROCESSES=false
+                NO_BUILDS=false
+                NO_CRONJOBS=false
+
+                # Check for any running processes
+                RUNNING_PROCESSES=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "pgrep -P 0 | tail -n +3 | wc -l | tr -d ' '")
+                if [ ! $? -eq 0 ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking for busy-ness of pods"
+                  continue
+                elif [ "$RUNNING_PROCESSES" == "0" ]; then
+                  # Now we can scale
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running processes"
+                  NO_PROCESSES=true
+                else
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_PROCESSES running processes, skipping"
+                  continue
+                fi
+
+                # Check for cronjobs present
+                CRONJOBS_PRESENT=$(set -e -o pipefail; oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" rsh $deploymentconfig sh -c "echo \$CRONJOBS")
+                if [ ! $? -eq 0 ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking if pod has cronjob"
+                  continue
+                elif [ -z "$CRONJOBS_PRESENT" ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no cronjobs"
+                  NO_CRONJOBS=true
+                else
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has cronjobs defined, skipping"
+                  continue
+                fi
+
+                # Check for any running builds
+                RUNNING_BUILDS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get --no-headers=true builds | grep "Running" | wc -l | tr -d ' ')
+                if [ ! $? -eq 0 ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: error checking build status"
+                  continue
+                elif [ "$RUNNING_BUILDS" == "0" ]; then
+                  # Now we can scale
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running builds"
+                  NO_BUILDS=true
+                else
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: has $RUNNING_BUILDS running builds, skipping"
+                  continue
+                fi
+
+                ## If there are no builds AND no processes, then we can idle the pods
+                if [[ "$NO_BUILDS" == "true" && "$NO_PROCESSES" == "true" && "$NO_CRONJOBS" == "true" ]]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: scaling to 0"
+                  oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" scale --replicas=0 $deploymentconfig
+                fi
+              else
+                echo "$PROJECT_NAME: $ENVIRONMENT_NAME: $deploymentconfig: no running pods"
+              fi
+            done
+          done
+        else
+          echo "$PROJECT_NAME: SKIP, does not match Regex: $PROJECT_REGEX"
+        fi
+    else
+      echo "$PROJECT_NAME: has autoidle set to $AUTOIDLE "
+    fi
+  fi
+  done

--- a/services/auto-idler/openshift-services.sh
+++ b/services/auto-idler/openshift-services.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-POD_RUN_INTERVAL=180
-
 DEVELOPMENT_ENVIRONMENTS=$(cat $2)
 # Filter only projects that actually have an environment
 # Loop through each found project

--- a/services/auto-idler/openshift-services.sh
+++ b/services/auto-idler/openshift-services.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+POD_RUN_INTERVAL=180
+
+DEVELOPMENT_ENVIRONMENTS=$(cat $2)
+# Filter only projects that actually have an environment
+# Loop through each found project
+echo "$DEVELOPMENT_ENVIRONMENTS" | jq -c '.data.developmentEnvironments[] | select((.environments|length)>=1)' | while read project
+  do
+    PROJECT_NAME=$(echo "$project" | jq -r '.name')
+    OPENSHIFT_URL=$(echo "$project" | jq -r '.openshift.consoleUrl')
+    AUTOIDLE=$(echo "$project" | jq -r '.autoIdle')
+
+    # check if the openshifturl for the environment matches the openshift we want to run the idler against
+    if [ "$1" == "${OPENSHIFT_URL}" ]; then
+      # Match the Project name to the Project Regex
+      if [[ $PROJECT_NAME =~ $PROJECT_REGEX ]]; then
+        OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token')
+        echo "$PROJECT_NAME: Found with development environments"
+
+        if [[ $AUTOIDLE == "1" ]]; then
+          # loop through each environment of the current project
+          echo "$project" | jq -c '.environments[]' | while read environment
+          do
+            ENVIRONMENT_OPENSHIFT_PROJECTNAME=$(echo "$environment" | jq -r '.openshiftProjectName')
+            ENVIRONMENT_NAME=$(echo "$environment" | jq -r '.name')
+            ENVIRONMENT_AUTOIDLE=$(echo "$environment" | jq -r '.autoIdle')
+            echo "$PROJECT_NAME: handling development environment $ENVIRONMENT_NAME"
+
+            if [ "$ENVIRONMENT_AUTOIDLE" == "0" ]; then
+              echo "$PROJECT_NAME: $ENVIRONMENT_NAME idling disabled, skipping"
+              continue
+            fi
+
+            # if we need to force idling of development environments we can use flag force `./idle-services.sh force` to skip all checks and proceed to idling
+            IDLE_PODS=false # set the variable to false initially, to prevent any false idling
+            if [ "$3" == "force" ]; then
+              echo "force idling"
+              IDLE_PODS=true
+            else
+              # else we just do normal idling checks
+              NO_BUILDS=false
+              PODS_RUNNING=false
+
+              # Check for any running builds
+              RUNNING_BUILDS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get --no-headers=true builds | grep "Running" | wc -l | tr -d ' ')
+              if [ ! $? -eq 0 ]; then
+                echo "$PROJECT_NAME: $ENVIRONMENT_NAME: error checking build status"
+                continue
+              elif [ "$RUNNING_BUILDS" == "0" ]; then
+                # Now we can scale
+                echo "$PROJECT_NAME: $ENVIRONMENT_NAME: no running builds"
+                NO_BUILDS=true
+              else
+                echo "$PROJECT_NAME: $ENVIRONMENT_NAME: has $RUNNING_BUILDS running builds, skipping"
+                continue
+              fi
+
+              # check if any deploymentconfigs have any running pods, and if those pods have been running greater than the $POD_RUN_INTERVAL in seconds (4hrs = 14400seconds) since the current time
+              DEPLOYMENTCONFIGS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get dc -o name -l "service notin (mariadb,postgres,cli)" | sed 's/deploymentconfig.*\///')
+              for deployment in $DEPLOYMENTCONFIGS
+              do
+                RUNNING_PODS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get pods -l deploymentconfig=${deployment} --show-labels=false -o json | jq -r '.items | .[] | .status.containerStatuses | .[] | .state.running.startedAt')
+                if [[ "$RUNNING_PODS" != "0" && "$RUNNING_PODS" != "" ]]; then
+                  for pod in $RUNNING_PODS
+                  do
+                    FIX_TIME=$(echo $pod | sed 's/T/ /g; s/Z//g') #busybox `date` doesn't like ISO 8601 passed to it, we have to strip the T and Z from it
+                    RUNTIME="$(($(date -u +%s)-$(date -u -d "$FIX_TIME" +%s)))" #get a rough runtime from the pod running time
+                    if [[ $RUNTIME -gt $POD_RUN_INTERVAL ]]; then
+                      echo "$PROJECT_NAME: $ENVIRONMENT_NAME - $deployment running longer than interval, proceeding to check router-logs"
+                      PODS_RUNNING=true
+                    fi
+                  done
+                  if [ "$PODS_RUNNING" == false ]; then
+                    echo "$PROJECT_NAME: $ENVIRONMENT_NAME - $deployment running less than interval, skipping"
+                  fi
+                else
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME - $deployment no running pods, skipping"
+                fi
+              done
+
+              # if no running builds, and any deploymentconfigs notin (mariadb,postgres,cli) have been running greater than $POD_RUN_INTERVAL, then we want to check router-logs then proceed to idle
+              if [[ "$NO_BUILDS" == "true" && "$PODS_RUNNING" == "true" ]]; then
+                # Check if this environment has hits
+                HITS=$(curl -s -u "admin:$LOGSDB_ADMIN_PASSWORD" -XGET "$ELASTICSEARCH_URL/router-logs-$ENVIRONMENT_OPENSHIFT_PROJECTNAME-*/_search" -H 'Content-Type: application/json' -d"
+                {
+                  \"size\": 0,
+                  \"query\": {
+                    \"bool\": {
+                      \"filter\": {
+                        \"range\": {
+                          \"@timestamp\": {
+                            \"gte\": \"now-${ROUTER_LOG_INTERVAL}\"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }" | jq ".hits.total.value")
+
+                if [ ! $? -eq 0 ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME error checking hits"
+                  IDLE_PODS=true
+                  # continue
+                elif [ "$HITS" == "null"  ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME no data found, skipping"
+                  IDLE_PODS=true
+                  # continue
+                elif [ "$HITS" -gt "0" ]; then
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME had $HITS hits in last four hours, no idling"
+                  IDLE_PODS=false
+                  # continue
+                else
+                  echo "$PROJECT_NAME: $ENVIRONMENT_NAME had no hits in last four hours, starting to idle"
+                  IDLE_PODS=true
+                  # continue
+                fi
+              fi
+            fi
+
+            # if we have the idlepods variable as true, then we idle pods
+            if [ "$IDLE_PODS" == "true" ]; then
+              # actually idling happens here
+              oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" idle -l "service notin (mariadb,postgres)"
+
+              ### Faster Unidling:
+              ## Instead of depending that each endpoint is unidling their own service (which means it takes a lot of time to unidle multiple services)
+              ## This update makes sure that every endpoint is unidling every service that is currently idled, which means the whole system is much much faster unidled.
+              # load all endpoints which have unidle targets, format it as a space separated
+              IDLING_ENDPOINTS=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get endpoints -o json | jq  --raw-output '[ .items[] | select(.metadata.annotations | has("idling.alpha.openshift.io/unidle-targets")) | .metadata.name ] | join(" ")')
+              if [[ "${IDLING_ENDPOINTS}" ]]; then
+                # Load all unidling targets of all endpoints and generate one bit JSON array from it
+                ALL_IDLED_SERVICES_JSON=$(oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" get endpoints -o json | jq --raw-output '[ .items[] | select(.metadata.annotations | has("idling.alpha.openshift.io/unidle-targets")) | .metadata.annotations."idling.alpha.openshift.io/unidle-targets" | fromjson | .[] ] | unique_by(.name) | tojson')
+                # add this generated JSON array to all endpoints
+                if [[ "${ALL_IDLED_SERVICES_JSON}" ]]; then
+                  oc --insecure-skip-tls-verify --token="$OPENSHIFT_TOKEN" --server="$OPENSHIFT_URL" -n "$ENVIRONMENT_OPENSHIFT_PROJECTNAME" annotate --overwrite endpoints $IDLING_ENDPOINTS "idling.alpha.openshift.io/unidle-targets=${ALL_IDLED_SERVICES_JSON}"
+                fi
+              fi
+            fi
+          done # environment loop
+        else
+            echo "$PROJECT_NAME: has autoidle set to $AUTOIDLE "
+        fi
+      else
+        echo "$PROJECT_NAME: SKIP, does not match Regex: $PROJECT_REGEX"
+      fi
+      # echo "" # new line for prettyness
+    fi
+  done


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This PR adds some improvements to the way the auto-idler runs over clusters.
It first gets a list of all clusters from lagoon, then iterates through them and triggers idling on environments on each cluster as it goes through.
This means a significant speed improvement when a lagoon has control of multiple clusters and allows the idling intervals to be more aggressive.

It also adds some additional logic when checking environments that they can be idled.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Improve the way the auto-idler runs over clusters

# Closing issues
closed #1398 
