### PR TITLE
Pin Python Alpine to 3.10 instead of latest

### DIFF
--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}-alpine3.10
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=python
@@ -23,11 +23,20 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache python-dev \
-    py2-pip \
-    py2-virtualenv
+    && case ${PYTHON_VERSION} in \
+      2*) \
+        apk add --no-cache python-dev \
+        py2-pip \
+        py2-virtualenv; \
+        ;; \
+      3*) \
+        apk add --no-cache python3-dev \
+        py3-virtualenv; \
+        ;; \
+      esac
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/


### PR DESCRIPTION
As per #1514 - Python2 is no longer supported in Alpine 3.10

This PR pins the Alpine version for Python (2 and 3) to 3.10.  It also adds a case switch into the dockerfile to handle the differing package dependencies for the two versions.  This prevents Python 2.7 from also being installed into the Python3 version as a dependency of the python2 packages

```
python:/$ python -V
Python 3.7.5
python:/$ python2 -V
Python 2.7.16
python:/$ printenv | grep PYTHON_VERSION
PYTHON_VERSION=3.7.5
```

This change is ahead of a wider one to allow builds to continue.  I will continue to look at alpine version pinning to avoid unwanted version upgrades/backward-compatibility issues

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

# Changelog Entry
Bugfix: Pin Python Alpine to 3.10 instead of latest

# Closing issues
closes #1514
