### PR TITLE
Fix some ansible warnings in test suite

### DIFF
--- a/tests/checks/check-url-header-absent.yaml
+++ b/tests/checks/check-url-header-absent.yaml
@@ -1,10 +1,16 @@
 ---
-- name: "{{ testname }} - Check if URL {{url}} returns without Header set to {{expected_header}}"
+
+- name: >-
+    {{ testname }} - Check if URL {{url}} returns without Header set to
+    {{expected_header}}
   uri:
     url: "{{ url }}"
     validate_certs: no
     HEADER_Host: "{{ host }}"
   register: result
-  failed_when: result.{{expected_header}} is defined
-- name: "{{ testname }} - Check if URL {{url}} returns without Header set to {{expected_header}}"
+  failed_when: result[expected_header] is defined
+
+- name: >-
+    {{ testname }} - Check if URL {{url}} returns without Header set to
+    {{expected_header}}
   debug: msg="Success!!!"

--- a/tests/checks/check-url-header.yaml
+++ b/tests/checks/check-url-header.yaml
@@ -1,13 +1,19 @@
 ---
-- name: "{{ testname }} - Check if URL {{url}} returns with Header set to {{expected_header}} with value of '{{expected_header_value}}'"
+
+- name: >-
+    {{testname}} - Check if URL {{url}} returns with Header set to
+    {{expected_header}} with value of '{{expected_header_value}}'
   uri:
     url: "{{ url }}"
     validate_certs: no
     HEADER_Host: "{{ host }}"
   register: result
-  until: result.{{expected_header}} is defined
-  failed_when: result.{{expected_header}} != '{{expected_header_value}}'
+  until: result[expected_header] is defined
+  failed_when: result[expected_header] != expected_header_value
   retries: 20
   delay: 10
-- name: "{{ testname }} - Check if URL {{url}} returns with Header set to {{expected_header}} with value of '{{expected_header_value}}'"
+
+- name: >-
+    {{testname}} - Check if URL {{url}} returns with Header set to
+    {{expected_header}} with value of '{{expected_header_value}}'
   debug: msg="Success!!!"

--- a/tests/tasks/git-init.yaml
+++ b/tests/tasks/git-init.yaml
@@ -1,24 +1,22 @@
-- name: "{{ testname }} - make sure repo folder {{git_repo_name}} exists"
+---
+
+- name: "{{ testname }} - ensure empty repo folder /{{git_repo_name}} exists"
   file:
+    state: "{{ item }}"
     path: /{{git_repo_name}}
-    state: directory
+  loop:
+    - absent
+    - directory
 
-- name: "{{ testname }} - cleaning repo folder {{git_repo_name}}"
-  command: rm -rf {{git_repo_name}}
-  args:
-    chdir: /
-
-- name: "{{ testname }} - make sure repo folder {{git_repo_name}} exists"
-  file:
-    path: /{{git_repo_name}}
-    state: directory
-
-- name: "{{ testname }} - init fresh git repo in {{git_repo_name}}"
-  command: git init
+- name: >-
+    {{ testname }} - init and add remote
+    {{ lookup('env','GIT_REPO_PREFIX') }}{{git_repo_name}} to git repo in
+    {{git_repo_name}}
+  command: "{{ item }}"
   args:
     chdir: /{{git_repo_name}}
-
-- name: "{{ testname }} - add remote {{ lookup('env','GIT_REPO_PREFIX') }}{{git_repo_name}} to git repo in {{git_repo_name}}"
-  command: git remote add origin {{ lookup('env','GIT_REPO_PREFIX') }}{{git_repo_name}}
-  args:
-    chdir: /{{git_repo_name}}
+  loop:
+    - git init
+    - >-
+      git remote add origin
+      {{ lookup('env','GIT_REPO_PREFIX') }}{{git_repo_name}}


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This PR updates parts of the test suite that were generating ansible warnings like this in the test output:
```
[WARNING]: when statements should not include jinja2 templating delimiters
```

# Changelog Entry
Improvement - Avoid ansible warnings in CI

# Closing issues
n/a
