### PR TITLE
Pin to a default alpine version (3.11) for _most_ images

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
 
 LABEL maintainer="amazee.io"
 

--- a/images/curator/Dockerfile
+++ b/images/curator/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM bobrik/curator
+FROM bobrik/curator:5.7.6
 
 USER root
 

--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM docker:stable-dind
+FROM docker:19.03-dind
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=docker-host

--- a/images/mongo/Dockerfile
+++ b/images/mongo/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM alpine:3.9
+FROM alpine:3.8
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=mongo

--- a/images/mongo/Dockerfile
+++ b/images/mongo/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM alpine:3.8
+FROM alpine:3.9
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=mongo

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# alpine 3.9 per https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile
+# alpine 3.11 per https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile
 FROM openresty/openresty:1.15.8.2-alpine
 
 LABEL maintainer="amazee.io"

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,6 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM openresty/openresty:alpine
+# alpine 3.9 per https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile
+FROM openresty/openresty:1.15.8.2-alpine
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=nginx

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -1,7 +1,8 @@
 ARG NODE_VERSION
+ARG ALPINE_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:${NODE_VERSION}-alpine
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=node

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -1,6 +1,7 @@
+ARG ALPINE_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM golang:alpine as golang
+FROM golang:1.13-alpine${ALPINE_VERSION} as golang
 
 RUN apk add --no-cache git
 RUN go get github.com/a8m/envsubst/cmd/envsubst

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -1,8 +1,9 @@
 ARG PHP_VERSION
 ARG PHP_IMAGE_VERSION
+ARG ALPINE_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM php:${PHP_IMAGE_VERSION}-fpm-alpine
+FROM php:${PHP_IMAGE_VERSION}-fpm-alpine${ALPINE_VERSION}
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=php

--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# alpine 3.10 from https://github.com/docker-library/postgres/blob/master/11/alpine/Dockerfile
+# alpine 3.11 from https://github.com/docker-library/postgres/blob/master/11/alpine/Dockerfile
 FROM postgres:11.6-alpine
 
 ARG LAGOON_VERSION

--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -1,6 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:11-alpine
+# alpine 3.10 from https://github.com/docker-library/postgres/blob/master/11/alpine/Dockerfile
+FROM postgres:11.6-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION

--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -1,7 +1,8 @@
 ARG PYTHON_VERSION
 ARG IMAGE_REPO
+ARG ALPINE_VERSION
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM python:${PYTHON_VERSION}-alpine3.10
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=python

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,6 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM rabbitmq:3-management
+# alpine 3.10 as per https://github.com/docker-library/rabbitmq/blob/master/3.8/alpine/Dockerfile
+FROM rabbitmq:3.8-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# alpine 3.10 as per https://github.com/docker-library/rabbitmq/blob/master/3.8/alpine/Dockerfile
+# alpine 3.11 as per https://github.com/docker-library/rabbitmq/blob/master/3.8/alpine/Dockerfile
 FROM rabbitmq:3.8-management-alpine
 
 ARG LAGOON_VERSION

--- a/images/redis/Dockerfile
+++ b/images/redis/Dockerfile
@@ -1,6 +1,7 @@
 ARG IMAGE_REPO
+ARG ALPINE_VERSION
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM redis:alpine
+FROM redis:5.0-alpine${ALPINE_VERSION}
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=redis

--- a/local-dev/api-data-watcher-pusher/Dockerfile
+++ b/local-dev/api-data-watcher-pusher/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache mysql-client tini openssl bash wget curl nodejs nodejs-npm \
     && npm config set unsafe-perm true \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,4 @@
+# Held at alpine 3.10 because of Python2 dependencies not available in 3.11
 FROM alpine:3.10
 
 RUN apk add --no-cache \

--- a/tests/checks/check-url-redirect-host.yaml
+++ b/tests/checks/check-url-redirect-host.yaml
@@ -8,7 +8,7 @@
     validate_certs: no
   register: result
   until: result.location | default('') | regex_search(expected_redirect_location)
-  retries: 5
+  retries: 20
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} with sending Host: {{ host }} redirects to the location {{expected_redirect_location}}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-redirect.yaml
+++ b/tests/checks/check-url-redirect.yaml
@@ -7,7 +7,7 @@
     validate_certs: no
   register: result
   until: result.location | default('') | regex_search(expected_redirect_location)
-  retries: 5
+  retries: 20
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} redirects to the location {{expected_redirect_location}}"
   debug: msg="Success!!!"


### PR DESCRIPTION
Initial draft of a way to pin a "default" Alpine version - currently 3.11 - for those images that currently utilise :latest.

It also pins specific older versions of alpine for specific images (php, node and python).

Sumbitting a draft to put it through testing - images build ok locally, but not tested (why use my CPU cycles!)

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

# Changelog Entry

# Closing issues
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
