### PR TITLE
Run the securityadmin demo script as part of make up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,9 +749,9 @@ logs:
 
 # Start all Lagoon Services
 up:
-	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d api-db
-	sleep 20
 	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d
+	sleep 20
+	while ! docker exec "$$(docker-compose -p $(CI_BUILD_TAG) ps -q logs-db)" ./securityadmin_demo.sh; do sleep 5; done
 
 down:
 	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) down -v


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

When running `make up`, the `logs-db` container will not be available until the `securityadmin_demo.sh` script has been executed as per https://lagoon.readthedocs.io/en/latest/administering_lagoon/install/#opendistrosecurity

This change automates that step for local development.

It also removes the initial `docker-compose up` of `api-db` which doesn't seem to be necessary.

# Changelog Entry
Improvement - Automate Elastic OpenDistro Security setup for local lagoon development

# Closing issues
n/a
