### PR TITLE
Add workaround for missing localhost dns on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,15 @@ logs:
 
 # Start all Lagoon Services
 up:
+ifeq ($(ARCH), darwin)
 	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility up -d
+else
+	# once this docker issue is fixed we may be able to do away with this
+	# linux-specific workaround: https://github.com/docker/cli/issues/2290
+	KEYCLOAK_URL=$$(docker network inspect -f '{{(index .IPAM.Config 0).Gateway}}' bridge):8088 \
+		IMAGE_REPO=$(CI_BUILD_TAG) \
+		docker-compose -p $(CI_BUILD_TAG) --compatibility up -d
+endif
 	grep -m 1 ".opendistro_security index does not exist yet" <(docker-compose -p $(CI_BUILD_TAG) logs -f logs-db 2>&1)
 	while ! docker exec "$$(docker-compose -p $(CI_BUILD_TAG) ps -q logs-db)" ./securityadmin_demo.sh; do sleep 5; done
 	$(MAKE) wait-for-keycloak

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -475,7 +475,7 @@ services:
     image: ${IMAGE_REPO:-lagoon}/logs-db
     user: '111111111'
     environment:
-      KEYCLOAK_URL: http://docker.for.mac.localhost:8088
+      KEYCLOAK_URL: http://keycloak:8080
     ports:
       - '9200:9200'
     networks:
@@ -499,7 +499,7 @@ services:
     ports:
       - '5601:5601'
     environment:
-      KEYCLOAK_URL: http://docker.for.mac.localhost:8088
+      KEYCLOAK_URL: http://${KEYCLOAK_URL:-docker.for.mac.localhost:8088}
       LOGSDB_UI_URL: http://0.0.0.0:5601
     labels:
       lagoon.type: kibana


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

The `docker.for.mac.localhost` hostname obviously is not available on linux. This PR implements the following workarounds:

* use bare keycloak service name in docker-compose.yaml where possible
* make keycloak service name configurable where necessary
* configure the keycloak service URL in the `make up` target on linux

# Changelog Entry
Improvement - implement configurable keycloak endpoint for linux lagoon development

# Closing issues
n/a
