### PR TITLE
Avoid piping to head where possible

### DIFF
--- a/helpers/migrate-resize-pv.sh
+++ b/helpers/migrate-resize-pv.sh
@@ -149,7 +149,7 @@ EOF
   ${OC} -n ${NS} rollout status deploymentconfig/pv-migrator --watch
 
   #
-  MIGRATOR=$(${OC} -n ${NS} get pods -l run=pv-migrator -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+  MIGRATOR=$(${OC} -n ${NS} get pods -l run=pv-migrator -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
   if [[ ! $MIGRATOR ]]; then
     echo "No running pod found for migrator"
     exit 1
@@ -178,7 +178,7 @@ EOF
   ${OC} -n ${NS} rollout resume deploymentconfig/pv-migrator
   ${OC} -n ${NS} rollout status deploymentconfig/pv-migrator --watch
 
-  MIGRATOR=$(${OC} -n ${NS} get pods -l run=pv-migrator -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+  MIGRATOR=$(${OC} -n ${NS} get pods -l run=pv-migrator -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
   ${OC} -n ${NS} exec $MIGRATOR -- cp -Rpav /migrator/${PVC} /storage/
   ${OC} -n ${NS} exec $MIGRATOR -- ls -la  /storage/${PVC}

--- a/helpers/reclaim-pv.sh
+++ b/helpers/reclaim-pv.sh
@@ -70,7 +70,7 @@ EOF
   ${OC} rollout status deploymentconfig/pv-migrator --watch
 
   #
-  MIGRATOR=$(${OC} get pods -l run=pv-migrator -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+  MIGRATOR=$(${OC} get pods -l run=pv-migrator -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
   #MIGRATOR=$(${OC} get pod -o custom-columns=NAME:.metadata.name --no-headers -l run=pv-migrator)
   if [[ ! $MIGRATOR ]]; then
     echo "No running pod found for migrator"
@@ -99,7 +99,7 @@ EOF
     ${OC} rollout status deploymentconfig/pv-migrator --watch
 
 
-    MIGRATOR=$(${OC} get pods -l run=pv-migrator -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+    MIGRATOR=$(${OC} get pods -l run=pv-migrator -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
     ${OC} exec $MIGRATOR -- cp -Rpav /migrator/${PVC} /storage/
     ${OC} exec $MIGRATOR -- ls -la  /storage/${PVC}

--- a/images/oc-build-deploy-dind/scripts/exec-pre-tasks-run.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-pre-tasks-run.sh
@@ -12,7 +12,7 @@ if [[ $(oc -n ${OPENSHIFT_PROJECT} get deploymentconfigs --no-headers=true -o na
   done
 fi
 
-POD=$(oc -n ${OPENSHIFT_PROJECT} get pods -l service=${SERVICE_NAME} -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+POD=$(oc -n ${OPENSHIFT_PROJECT} get pods -l service=${SERVICE_NAME} -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
 if [[ ! $POD ]]; then
   echo "No running pod found for ${SERVICE_NAME}, skipping"

--- a/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-tasks-run.sh
@@ -12,7 +12,7 @@ if [[ $(oc -n ${OPENSHIFT_PROJECT} get deploymentconfigs --no-headers=true -o na
   done
 fi
 
-POD=$(oc -n ${OPENSHIFT_PROJECT} get pods -l service=${SERVICE_NAME} -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+POD=$(oc -n ${OPENSHIFT_PROJECT} get pods -l service=${SERVICE_NAME} -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
 if [[ ! $POD ]]; then
   echo "No running pod found for ${SERVICE_NAME}"

--- a/services/ssh/home/rsh.sh
+++ b/services/ssh/home/rsh.sh
@@ -115,7 +115,7 @@ if [[ $($OC get deploymentconfigs -l service=${SERVICE}) ]]; then
   fi
 fi
 
-POD=$($OC get pods -l service=${SERVICE} -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+POD=$($OC get pods -l service=${SERVICE} -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
 if [[ ! $POD ]]; then
   echo "No running pod found for service ${SERVICE}"

--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -92,7 +92,7 @@ do
       echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: redeploying storage-calc to mount volumes"
       ${OC} rollout status deploymentconfig/storage-calc --watch
 
-      POD=$(${OC} get pods -l run=storage-calc -o json | jq -r '.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running") | .metadata.name' | head -n 1)
+      POD=$(${OC} get pods -l run=storage-calc -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name')
 
       if [[ ! $POD ]]; then
         echo "No running pod found for storage-calc"


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Piping to `head` may cause the preceding command to receive a SIGPIPE if it sends lines too slowly. Where that preceding command is `jq`, we can use built-in functionality instead.

See #1528 for details.

# Changelog Entry
Bugfix - race condition in deployment script (#1528)

# Closing issues
Closes #1528 
