### PR TITLE
Updating Python images to use latest version of Alpine.

### DIFF
--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -1,7 +1,8 @@
+  
 ARG PYTHON_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM python:${PYTHON_VERSION}-alpine3.10
+FROM python:${PYTHON_VERSION}-alpine
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=python
@@ -26,8 +27,15 @@ ENV TMPDIR=/tmp \
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache python-dev \
-    && pip install virtualenv
+    && pip install virtualenv \
+    && case ${PYTHON_VERSION} in \
+      2*) \
+        apk add --no-cache python-dev \
+        ;; \
+      3*) \
+        apk add --no-cache python3-dev \
+        ;; \
+      esac
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -1,3 +1,4 @@
+  
 ARG PYTHON_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
@@ -26,8 +27,7 @@ ENV TMPDIR=/tmp \
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache python-dev \
-    py2-pip \
-    py2-virtualenv
+    && pip install virtualenv
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/


### PR DESCRIPTION
This PR changes our Python Dockerfile such that we can continue using the latest alpine image (3.11 currently)
 
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [X] Changelog entry has been written

# Changelog Entry
Change - Update Python images to use latest version of alpine