### PR TITLE
Additional check for newrelic when container starts

### DIFF
--- a/images/php/fpm/entrypoints/71-php-newrelic.sh
+++ b/images/php/fpm/entrypoints/71-php-newrelic.sh
@@ -6,4 +6,8 @@ if [ ${NEWRELIC_ENABLED+x} ]; then
   ep /usr/local/etc/php/conf.d/newrelic.disable
 
   cp /usr/local/etc/php/conf.d/newrelic.disable /usr/local/etc/php/conf.d/newrelic.ini
+
+  # check if newrelic is running before trying to do tasks as it can cause them to fail, can delay container start by a few seconds
+  # https://discuss.newrelic.com/t/php-agents-tries-to-connect-before-daemon-is-ready/48160/9
+  php -r '$count=0;while(!newrelic_set_appname(ini_get("newrelic.appname")) && $count < 10){ $count++; echo "Waiting for NewRelic Agent to be responsive. ($count)" . PHP_EOL; sleep(1); }'
 fi


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

When starting tasks using the CLI image (drush cache-clear, etc) newrelic doesn't start fast enough for the command and can cause them to fail. This adds a check to the entrypoint for newrelic to wait for newrelic to start, it adds a delay of a few seconds to container starts

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Bugfix - Check newrelic is started (if enabled) in the CLI image before doing any tasks

# Closing issues
Closes #1527 
