### PR TITLE
Configure Lagoon project for "release-drafter" Github Action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,24 +4,22 @@
 
 Please provide enough information so that others can review your pull request:
  -->
- 
+
 <!-- You can skip this if you're fixing a typo. -->
 # Checklist
 - [ ] Affected Issues have been mentioned in the Closing issues section
-- [ ] Documentation has been written/updated.
-- [ ] Changelog entry has been written
+- [ ] Documentation has been written/updated
+- [ ] PR title is ready for changelog and subsystem label(s) applied
 
 Explain the **details** for making this change. What existing problem does the pull request solve?
 
-# Changelog Entry
 <!--
-Describe the change in order to make it visible in the changelog
-If the change breaks anything document this - how was the functionality before - how does it work after the change
+# Changelog Entry
+Lagoon is using "Release Drafter" to create changelogs using PR titles and labels
 
-Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation
-
-Use following format:
-Improvement - Description (#ISSUENUMBER)
+Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
+Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
+To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
 -->
 
 # Closing issues

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+categories:
+  - title: 'Vanilla kubernetes support'
+    labels:
+      - '0-kubernetes'
+  - title: 'API & Authentication subsystem'
+    label: '1-api-auth'
+  - title: 'Build & Deploy subsystem'
+    label: '2-build-deploy'
+  - title: 'Logging & Reporting subsystem'
+    label: '3-logging-reporting'
+  - title: 'Metrics & Alerting subsytem'
+    label: '4-metrics-alerting'
+  - title: 'Operators & Provisioning subsystem'
+    label: '5-operators-provision'
+  - title: 'Base Images & Testing subsystem'
+    label: '6-images-testing'
+  - title: 'Documentation & Examples / DX subsystem'
+    label: '7-documentation-examples'
+  - title: 'Automation, Services & Helpers subsystem'
+    label: '8-automation-helpers'
+  - title: 'Security subsystem'
+    label: '9-security'
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes in this release
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+      - develop
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enables the use of the release-drafter [GitHub action](https://github.com/marketplace/actions/release-drafter) to auto-create release notes ahead of the next release of Lagoon.

This uses two pieces of information:
* The PR title - very important to keep this concise and to-the-point (it's now a proxy changelog entry)
* The subsystem label(s) assigned for use - named `[0-9]-subsystem`.

It'll auto-generate a draft of the next minor release of Lagoon for us, and keep track of all the PRs merged into `master` and `develop` branches between releases.  This also allows us to go back and reword a PR title, or re-assign a label as necessary, and the release notes will be modified on the next run.  I've reworded the PR template accordingly.

We should trial this for a release or two - I've proposed a PR title-based system to allow more freedom in commit message titling.  There is the ability to use a `skip-changelog` label to not include a PR in the list, but these will be reviewed prior to the next release being produced.

