### PR TITLE
Switch tests to use docker library alpine image

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,13 @@
-FROM williamyeh/ansible:centos7
+FROM alpine:3.10
 
-RUN yum -y install git && yum clean all && pip install pyjwt requests
+RUN apk add --no-cache \
+      ansible \
+      bash \
+      git \
+      openssh-client \
+      py2-jwt \
+      py2-requests \
+      rsync
 
 RUN git config --global user.email "deploytest@amazee.io" && git config --global user.name deploytest
 

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -3,3 +3,4 @@ retry_files_enabled = False # Do not create them
 gathering = explicit
 host_key_checking = False
 deprecation_warnings = False
+interpreter_python = auto_silent


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

`williamyeh/ansible` hasn't been updated in over a year, and isn't covered by the same maintenance and security policies that [official docker library](https://docs.docker.com/docker-hub/official_images/) images are.

# Changelog Entry
Improvement - Use docker library alpine image in tests

# Closing issues
n/a