### PR TITLE
Fixes for lagoon-tug

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -701,8 +701,8 @@ if [[ $THIS_IS_TUG == "true" ]]; then
       oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} delete secret tug-registry
     fi
 
-    oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} secrets new-dockercfg tug-registry --docker-server="${TUG_REGISTRY}" --docker-username="${TUG_REGISTRY_USERNAME}" --docker-password="${TUG_REGISTRY_PASSWORD}" --docker-email="${TUG_REGISTRY_USERNAME}"
-    oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} secrets add serviceaccount/default secrets/tug-registry --for=pull
+    oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} create secret docker-registry tug-registry --docker-server="${TUG_REGISTRY}" --docker-username="${TUG_REGISTRY_USERNAME}" --docker-password="${TUG_REGISTRY_PASSWORD}" --docker-email="${TUG_REGISTRY_USERNAME}"
+    oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} secrets link default tug-registry --for=pull
   fi
 
   # Import all remote Images into ImageStreams

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -697,10 +697,12 @@ if [[ $THIS_IS_TUG == "true" ]]; then
   # Allow to disable registry auth
   if [ ! "${TUG_SKIP_REGISTRY_AUTH}" == "true" ]; then
     # This adds the defined credentials to the serviceaccount/default so that the deployments can pull from the remote registry
-    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry; then
+    echo "debug starts here"
+    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry &> /dev/null; then
+      echo "removing existing secret"
       oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} delete secret tug-registry
     fi
-
+    echo "creating new secret"
     oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} create secret docker-registry tug-registry --docker-server="${TUG_REGISTRY}" --docker-username="${TUG_REGISTRY_USERNAME}" --docker-password="${TUG_REGISTRY_PASSWORD}" --docker-email="${TUG_REGISTRY_USERNAME}"
     oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} secrets link default tug-registry --for=pull
   fi

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -698,7 +698,8 @@ if [[ $THIS_IS_TUG == "true" ]]; then
   if [ ! "${TUG_SKIP_REGISTRY_AUTH}" == "true" ]; then
     # This adds the defined credentials to the serviceaccount/default so that the deployments can pull from the remote registry
     echo "debug starts here"
-    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry &> /dev/null; then
+    echo $OPENSHIFT_PROJECT
+    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry; then
       echo "removing existing secret"
       oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} delete secret tug-registry
     fi

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -697,7 +697,7 @@ if [[ $THIS_IS_TUG == "true" ]]; then
   # Allow to disable registry auth
   if [ ! "${TUG_SKIP_REGISTRY_AUTH}" == "true" ]; then
     # This adds the defined credentials to the serviceaccount/default so that the deployments can pull from the remote registry
-    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry 2> /dev/null; then
+    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry; then
       oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} delete secret tug-registry
     fi
 

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -697,13 +697,9 @@ if [[ $THIS_IS_TUG == "true" ]]; then
   # Allow to disable registry auth
   if [ ! "${TUG_SKIP_REGISTRY_AUTH}" == "true" ]; then
     # This adds the defined credentials to the serviceaccount/default so that the deployments can pull from the remote registry
-    echo "debug starts here"
-    echo $OPENSHIFT_PROJECT
-    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry; then
-      echo "removing existing secret"
+    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get secret tug-registry 2> /dev/null; then
       oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} delete secret tug-registry
     fi
-    echo "creating new secret"
     oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} create secret docker-registry tug-registry --docker-server="${TUG_REGISTRY}" --docker-username="${TUG_REGISTRY_USERNAME}" --docker-password="${TUG_REGISTRY_PASSWORD}" --docker-email="${TUG_REGISTRY_USERNAME}"
     oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} secrets link default tug-registry --for=pull
   fi

--- a/images/oc-build-deploy-dind/tug.sh
+++ b/images/oc-build-deploy-dind/tug.sh
@@ -47,9 +47,6 @@ if [[ $OC_VERSION_OVERRIDE == "true" ]]; then
       && install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar
 fi
 
-echo OC VERSION DEBUG:
-oc version
-
 DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
 
 oc login --insecure-skip-tls-verify --token="${DEPLOYER_TOKEN}" https://kubernetes.default.svc

--- a/images/oc-build-deploy-dind/tug.sh
+++ b/images/oc-build-deploy-dind/tug.sh
@@ -35,6 +35,7 @@ fi
 # Possibility to switch to legacy OC version via Environment variable OC_VERSION_OVERRIDE
 if [[ $OC_VERSION_OVERRIDE == "true" ]]; then
   echo "Switching to legacy OC"
+  # Defining Versions - this version is supposed to be v3.9.0 to be backwards compatible
   LEGACY_OC_VERSION=v3.9.0
   LEGACY_OC_HASH=191fece
   LEGACY_OC_SHA256=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e

--- a/images/oc-build-deploy-dind/tug.sh
+++ b/images/oc-build-deploy-dind/tug.sh
@@ -18,8 +18,6 @@ set +a
 # remove the tmpfile
 rm $TMPFILE
 
-
-
 OPENSHIFT_REGISTRY=docker-registry.default.svc:5000
 OPENSHIFT_PROJECT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 REGISTRY_REPOSITORY=$OPENSHIFT_PROJECT
@@ -33,6 +31,23 @@ fi
 if [ ! -f .lagoon.yml ]; then
   echo "no .lagoon.yml file found"; exit 1;
 fi
+
+# Possibility to switch to legacy OC version via Environment variable OC_VERSION_OVERRIDE
+if [[ $OC_VERSION_OVERRIDE == "true" ]]; then
+  echo "Switching to legacy OC"
+  LEGACY_OC_VERSION=v3.9.0
+  LEGACY_OC_HASH=191fece
+  LEGACY_OC_SHA256=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e
+  curl -Lo /tmp/openshift-origin-client-tools.tar https://github.com/openshift/origin/releases/download/${LEGACY_OC_VERSION}/openshift-origin-client-tools-${LEGACY_OC_VERSION}-${LEGACY_OC_HASH}-linux-64bit.tar.gz \
+      && echo "$LEGACY_OC_SHA256  /tmp/openshift-origin-client-tools.tar" | sha256sum -c - \
+      && mkdir /tmp/openshift-origin-client-tools \
+      && mkdir /usr/bin-legacy/ \
+      && tar -xzf /tmp/openshift-origin-client-tools.tar -C /tmp/openshift-origin-client-tools --strip-components=1 \
+      && install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar
+fi
+
+echo OC VERSION DEBUG:
+oc version
 
 DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
 

--- a/images/oc-build-deploy-dind/tug.sh
+++ b/images/oc-build-deploy-dind/tug.sh
@@ -35,10 +35,10 @@ fi
 # Possibility to switch to legacy OC version via Environment variable OC_VERSION_OVERRIDE
 if [[ $OC_VERSION_OVERRIDE == "true" ]]; then
   echo "Switching to legacy OC"
-  # Defining Versions - this version is supposed to be v3.9.0 to be backwards compatible
-  LEGACY_OC_VERSION=v3.9.0
-  LEGACY_OC_HASH=191fece
-  LEGACY_OC_SHA256=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e
+  # Defining Versions - this version is supposed to be v3.7.2 to be backwards compatible
+  LEGACY_OC_VERSION=v3.7.2
+  LEGACY_OC_HASH=282e43f
+  LEGACY_OC_SHA256=abc89f025524eb205e433622e59843b09d2304cc913534c4ed8af627da238624
   curl -Lo /tmp/openshift-origin-client-tools.tar https://github.com/openshift/origin/releases/download/${LEGACY_OC_VERSION}/openshift-origin-client-tools-${LEGACY_OC_VERSION}-${LEGACY_OC_HASH}-linux-64bit.tar.gz \
       && echo "$LEGACY_OC_SHA256  /tmp/openshift-origin-client-tools.tar" | sha256sum -c - \
       && mkdir /tmp/openshift-origin-client-tools \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [] Documentation has been written/updated.
- [x] Changelog entry has been written


# Changelog Entry
Improvement - Possibility to downgrade OC for `lagoon-tug` deployments via setting `OC_VERSION_OVERRIDE` on the deployment configuration on the destination Openshift (this is needed if you have an Openshift v3.7 or similar for example)
Improvement - Updated oc commands for managing the `tug-registry` secret

