### PR TITLE
correctly escape nginx regex in redirects

### DIFF
--- a/docs/using_lagoon/docker_images/nginx.md
+++ b/docs/using_lagoon/docker_images/nginx.md
@@ -25,7 +25,7 @@ If you just have a few redirects there's a handy trick to create the redirects w
 Example for redirecting `www.example.com` to `example.com` and preserving the request.
 
 ```
-RUN echo "~^www.example.com           http://example.com\$request_uri;" >> /etc/nginx/redirects-map.conf
+RUN echo "~^www\.example\.com\/           http://example.com\$request_uri;" >> /etc/nginx/redirects-map.conf
 
 ```
 

--- a/images/nginx/redirects-map.conf
+++ b/images/nginx/redirects-map.conf
@@ -6,21 +6,21 @@
 ## A couple of examples:
 
 ## Simple www to non www redirect, with preserving the URL string and arguments
-# ~^www.example.com   http://example.com$request_uri;
+# ~^www\.example\.com\/   http://example.com$request_uri;
 
 ## Simple non-www to www redirect, with preserving the URL string and arguments
-#~^example.com   http://www.example.com$request_uri;
+#~^example\.com\/   http://www.example.com$request_uri;
 
 ## Redirect every request to example.com to example.net with preserving the URL string and arguments, eg: example.com/bla -> example.net/bla, example.com/bla?test -> example.net/bla?test
 ##
-# ~^example.com   http://example.net$request_uri;
+# ~^example\.com\/   http://example.net$request_uri;
 
 ## Redirect request only to example.com/test (no regex matching) to example.net without preserving the URL string, eg: example.com/test -> example.net
 ## Requestes to example.com/test/bla or example.com/bla are not matched
 ##
-# example.com/test   http://example.net;
+# example\.com\/test   http://example.net;
 
 ## Redirect request only to example.com/test to example.net with preserving the rest of the URL string and arguments, eg: example.com/test/bla -> example.net/bla, example.com/test/bla?test -> example.net/bla?test
 ## Requestes to example.com/bla are not matched
 ##
-# ~^example.com/test/(.*)   http://example.net/$1$is_args$args;
+# ~^example\.com\/test\/(.*)   http://example.net/$1$is_args$args;


### PR DESCRIPTION
# Changelog Entry
Documentation - Correctly escape regex in nginx redirects
