### PR TITLE
#1449 move cronjobs into environment variable to force in-pod cronjob

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -59,10 +59,6 @@ environments:
         schedule: '*/30 * * * *'
         command: /idle-services.sh
         service: auto-idler
-      - name: curator
-        schedule: '01 0 * * * '
-        command: /lagoon/cronjob.sh "/usr/bin/curator --config /curator/curator.yml /curator/actions.yml"
-        service: logs-db-curator
   develop:
     types:
       logs-db: elasticsearch-cluster

--- a/services/logs-db-curator/.lagoon.app.yml
+++ b/services/logs-db-curator/.lagoon.app.yml
@@ -80,6 +80,9 @@ objects:
                 secretKeyRef:
                   key: LOGSDB_ADMIN_PASSWORD
                   name: logs-db-admin-password
+            - name: CRONJOBS
+              value: |
+                01 0 * * * /lagoon/cronjob.sh "/usr/bin/curator --config /curator/curator.yml /curator/actions.yml"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION

# Changelog Entry
Bugfix - move cronjobs into environment variable to force in-pod cronjob (#1449)


# Closing issues
closes #1449
