### PR TITLE
Add a bitbucket project permissions sync script

### DIFF
--- a/node-packages/commons/src/api.js
+++ b/node-packages/commons/src/api.js
@@ -1075,6 +1075,21 @@ const updateTask = (id: number, patch: TaskPatch): Promise<Object> =>
 const sanitizeGroupName = R.pipe(R.replace(/[^a-zA-Z0-9-]/g, '-'), R.toLower);
 const sanitizeProjectName = R.pipe(R.replace(/[^a-zA-Z0-9-]/g, '-'), R.toLower);
 
+const getProjectsByGroupName = groupName => graphqlapi.query(
+  `query groupByName($name: String!) {
+    groupByName(name: $name) {
+      id
+      name
+      projects {
+        id
+        name
+        gitUrl
+      }
+    }
+  }`,
+  { name: groupName }
+);
+
 module.exports = {
   addGroup,
   addGroupWithParent,
@@ -1120,4 +1135,5 @@ module.exports = {
   removeGroupFromProject,
   sanitizeGroupName,
   sanitizeProjectName,
+  getProjectsByGroupName,
 };

--- a/node-packages/commons/src/api.js
+++ b/node-packages/commons/src/api.js
@@ -1090,6 +1090,23 @@ const getProjectsByGroupName = groupName => graphqlapi.query(
   { name: groupName }
 );
 
+const getGroupMembersByGroupName = groupName => graphqlapi.query(
+  `query groupByName($name: String!) {
+    groupByName(name: $name) {
+      id
+      name
+      members {
+        user {
+          id
+          email
+        }
+        role
+      }
+    }
+  }`,
+  { name: groupName }
+);
+
 module.exports = {
   addGroup,
   addGroupWithParent,
@@ -1136,4 +1153,5 @@ module.exports = {
   sanitizeGroupName,
   sanitizeProjectName,
   getProjectsByGroupName,
+  getGroupMembersByGroupName,
 };

--- a/node-packages/commons/src/api.js
+++ b/node-packages/commons/src/api.js
@@ -321,7 +321,7 @@ const getUserBySshKey = (sshKey: string): Promise<Object> =>
 
 const addUser = (
   email: string,
-  firstName: string,
+  firstName: ?string = null,
   lastName: ?string = null,
   comment: ?string = null,
   gitlabId: ?number = null,

--- a/node-packages/commons/src/bitbucketApi.js
+++ b/node-packages/commons/src/bitbucketApi.js
@@ -1,0 +1,127 @@
+const axios = require('axios');
+const R = require('ramda');
+
+const API_HOST = R.propOr(
+  'https://bitbucket.org',
+  'BITBUCKET_API_HOST',
+  process.env
+);
+
+const API_TOKEN = R.propOr(
+  'personal access token',
+  'BITBUCKET_API_TOKEN',
+  process.env
+);
+
+const options = {
+  baseURL: `${API_HOST}/rest/api/1.0/`,
+  timeout: 30000,
+  headers: {
+    Authorization: `Bearer ${API_TOKEN}`
+  }
+};
+
+const bitbucketapi = axios.create(options);
+
+class NetworkError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NetworkError';
+  }
+}
+
+class APIError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BitbucketAPIError';
+  }
+}
+
+const getRequest = async url => {
+  try {
+    const response = await bitbucketapi.get(url);
+    return response.data;
+  } catch (error) {
+    if (error.response) {
+      const errorMessage = R.pathOr(
+        error.message,
+        ['data', 'errors'],
+        error.response
+      );
+      const errorString =
+        typeof errorMessage === 'string'
+          ? errorMessage
+          : JSON.stringify(errorMessage);
+
+      throw new APIError(errorString);
+    } else if (error.request) {
+      throw new NetworkError(error.message);
+    } else {
+      throw error;
+    }
+  }
+};
+
+const getAllPagesRequest = async url => {
+  let start = 0;
+  let moreResults = true;
+  let results = [];
+
+  do {
+    try {
+      const response = await bitbucketapi.get(url, {
+        params: {
+          limit: 100,
+          start
+        }
+      });
+
+      if (response.data.isLastPage) {
+        moreResults = false;
+      } else {
+        start = response.data.nextPageStart;
+      }
+
+      results = [...results, ...response.data.values];
+    } catch (error) {
+      if (error.response) {
+        const errorMessage = R.pathOr(
+          error.message,
+          ['data', 'errors'],
+          error.response
+        );
+        const errorString =
+          typeof errorMessage === 'string'
+            ? errorMessage
+            : JSON.stringify(errorMessage);
+
+        throw new APIError(errorString);
+      } else if (error.request) {
+        throw new NetworkError(error.message);
+      } else {
+        throw error;
+      }
+    }
+  } while (moreResults);
+
+  return results;
+};
+
+searchReposByName = async name => {
+  try {
+    const repos = await getAllPagesRequest(
+      `repos?name=${name}&permission=REPO_READ`
+    );
+    return R.find(R.propEq('slug', name), repos);
+  } catch (e) {
+    throw e;
+  }
+};
+
+getRepoUsers = async (project, repo) =>
+  getAllPagesRequest(`projects/${project}/repos/${repo}/permissions/users`);
+
+module.exports = {
+  searchReposByName,
+  getRepoUsers
+};

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -18,7 +18,8 @@
     "sync:gitlab:groups": "flow-node dist/gitlab-sync/groups",
     "sync:gitlab:projects": "flow-node dist/gitlab-sync/projects",
     "sync:gitlab:all": "yarn run sync:gitlab:users && yarn run sync:gitlab:groups && yarn run sync:gitlab:projects",
-    "sync:opendistro-security": "flow-node --max-http-header-size=80000 dist/helpers/sync-groups-opendistro-security"
+    "sync:opendistro-security": "flow-node --max-http-header-size=80000 dist/helpers/sync-groups-opendistro-security",
+    "sync:bitbucket:repo-permissions": "flow-node dist/bitbucket-sync/repo-permissions"
   },
   "keywords": [],
   "author": "amazee.io <hello@amazee.io> (http://www.amazee.io)",

--- a/services/api/src/bitbucket-sync/repo-permissions.ts
+++ b/services/api/src/bitbucket-sync/repo-permissions.ts
@@ -1,0 +1,141 @@
+import * as R from 'ramda';
+import * as bitbucketApi from '@lagoon/commons/src/bitbucketApi';
+import * as api from '@lagoon/commons/src/api';
+import { logger } from '@lagoon/commons/src/local-logging';
+
+// The lagoon group that has all of the projects needing to be synced
+const LAGOON_SYNC_GROUP = R.propOr(
+  'bitbucket-sync',
+  'BITBUCKET_SYNC_LAGOON_GROUP',
+  process.env
+);
+
+interface BitbucketUser {
+  name: string;
+  displayName: string;
+  emailAddress: string;
+  id: number;
+}
+
+const usernameExistsRegex = /Username.*?exists/;
+const userExistsTest = errorMessage =>
+  R.test(usernameExistsRegex, errorMessage);
+
+const BitbucketPermsToLagoonPerms = {
+  REPO_READ: 'REPORTER',
+  REPO_WRITE: 'DEVELOPER',
+  REPO_ADMIN: 'MAINTAINER'
+};
+
+// Returns true if user was added or already exists.
+// Returns false if adding user failed and no user exists.
+const addUser = async (email: string): Promise<boolean> => {
+  try {
+    await api.addUser(email);
+  } catch (err) {
+    if (!userExistsTest(err.message)) {
+      logger.error(
+        `Could not sync (add) bitbucket user ${email}: ${err.message}`
+      );
+      return false;
+    }
+  }
+
+  // User was added or already exists
+  return true;
+}
+
+(async () => {
+  // Keep track of users we know exist to avoid API calls
+  let existingUsers = [];
+
+  // Get all bitbucket related lagoon projects
+  const groupQuery = await api.getProjectsByGroupName(LAGOON_SYNC_GROUP);
+  const projects = R.pathOr([], ['groupByName', 'projects'], groupQuery) as [
+    object
+  ];
+
+  logger.info(`Syncing users for ${projects.length} project(s)`);
+
+  for (const project of projects) {
+    const projectName = R.prop('name', project);
+    const lagoonProjectGroup = `project-${projectName}`;
+    const repo = await bitbucketApi.searchReposByName(projectName);
+    if (!repo) {
+      logger.warn(`No bitbuket repo found for: ${projectName}`);
+      continue;
+    }
+
+    const bbProject = R.path(['project', 'key'], repo);
+    const bbRepo = R.prop('slug', repo);
+    logger.debug(`Processing ${bbRepo}`);
+
+    let userPermissions = [];
+    try {
+      userPermissions = await bitbucketApi.getRepoUsers(bbProject, bbRepo);
+    } catch (e) {
+      logger.warn(`Could not load users for repo: ${R.prop('slug', repo)}`);
+      continue;
+    }
+
+    // Sync user/permissions from bitbucket to lagoon
+    for (const userPermission of userPermissions) {
+      const bbUser = userPermission.user as BitbucketUser;
+      const bbPerm = userPermission.permission;
+
+      const email = bbUser.emailAddress.toLowerCase();
+
+      if (!R.contains(email, existingUsers)) {
+        const userAddedOrExists = await addUser(email);
+        if (!userAddedOrExists) {
+          // Errors for this case are logged in addUser
+          continue;
+        }
+
+        existingUsers.push(email);
+      }
+
+      try {
+        await api.addUserToGroup(
+          email,
+          lagoonProjectGroup,
+          BitbucketPermsToLagoonPerms[bbPerm]
+        );
+      } catch (err) {
+        logger.error(
+          `Could not add user (${email}) to group (${lagoonProjectGroup}): ${err.message}`
+        );
+      }
+    }
+
+    // Get current lagoon users
+    const currentMembersQuery = await api.getGroupMembersByGroupName(lagoonProjectGroup);
+    const lagoonUsers = R.pipe(
+      R.pathOr([], ['groupByName', 'members']),
+      // @ts-ignore
+      R.pluck('user'),
+      // @ts-ignore
+      R.pluck('email'),
+    )(currentMembersQuery) as [string];
+
+    // Get current bitbucket uers
+    const bitbucketUsers = R.pipe(
+      // @ts-ignore
+      R.pluck('user'),
+      // @ts-ignore
+      R.pluck('emailAddress'),
+    )(userPermissions) as [string];
+
+    // Remove users from lagoon project that are removed in bitbucket repo
+    const deleteUsers = R.difference(lagoonUsers, bitbucketUsers);
+    for (const user of deleteUsers) {
+      try {
+        await api.removeUserFromGroup(user, lagoonProjectGroup);
+      } catch (err) {
+        logger.error(`Could not remove user (${user}) from group (${lagoonProjectGroup}): ${err.message}`);
+      }
+    }
+  }
+
+  logger.info('Sync completed');
+})();


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR adds a script that can sync users/permissions for bitbucket repos to lagoon projects. It requires three environment variables:

`BITBUCKET_API_HOST` - The hostname (eg `https://bitbucket.org`)
`BITBUCKET_API_TOKEN` - The access token (eg a personal access token)
`BITBUCKET_SYNC_LAGOON_GROUP` - The name of the lagoon group that has all projects that should be synced

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
n/a
