### PR TITLE
Update New Relic PHP Agent to 9.6.0.255 and pin Xdebug to 2.6.0 for PHP 7.0

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -35,8 +35,11 @@ COPY 00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/
 COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 
-# Defining Versions - https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/ / https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.3.0.248
+# New Relic PHP Agent.
+# Support for PHP 7.4 added in 9.4.
+# @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
+# @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
+ENV NEWRELIC_VERSION=9.6.0.255
 
 RUN apk add --no-cache fcgi \
         ssmtp \

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -66,6 +66,11 @@ RUN apk add --no-cache fcgi \
         && yes '' | pecl install -f xdebug-2.7.0 \
         && yes '' | pecl install -f redis-4.3.0; \
         ;; \
+      7.0*) \
+        yes '' | pecl install -f apcu \
+        && yes '' | pecl install -f xdebug-2.6.0 \
+        && yes '' | pecl install -f redis-4.3.0; \
+        ;; \
       7*) \
         yes '' | pecl install -f apcu \
         && yes '' | pecl install -f xdebug \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Updated the version of the PHP Agent to be the latest stable release. https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes

Version 9.4 added support for PHP 7.4, and at the moment New Relic is in those images. So now it will actually work.

Had to also downgrade Xdebug to 2.6.0 on the PHP 7.0 images so that they would actually build.

# Closing issues

Closes #1543`.