### PR TITLE
Increase test concurrency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node {
                   try {
                     sh "make -O${SYNC_MAKE_OUTPUT} -j5 push-minishift"
                     sh "make up"
-                    sh "make -O${SYNC_MAKE_OUTPUT} -j2 tests"
+                    sh "make -O${SYNC_MAKE_OUTPUT} -j8 tests"
                   } catch (e) {
                     echo "Something went wrong, trying to cleanup"
                     cleanup()

--- a/tests/checks/check-url-redirect.yaml
+++ b/tests/checks/check-url-redirect.yaml
@@ -7,7 +7,7 @@
     validate_certs: no
   register: result
   until: result.location | default('') | regex_search(expected_redirect_location)
-  retries: 5
+  retries: 10
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} redirects to the location {{expected_redirect_location}}"
   debug: msg="Success!!!"


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change increases the concurrency of the test suite and brings a test run down from 50-55 min to 25-30 min.

# Closing issues
n/a
