### PR TITLE
Adjust cron task button to use standard style

### DIFF
--- a/services/ui/src/components/AddTask/components/DrushCron.js
+++ b/services/ui/src/components/AddTask/components/DrushCron.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Mutation } from 'react-apollo';
 import gql from 'graphql-tag';
 import ReactSelect from 'react-select';
+import Button from 'components/Button';
 import { bp, color, fontSize } from 'lib/variables';
 
 const taskDrushCron = gql`
@@ -44,48 +45,22 @@ const DrushCron = ({
               name="dest-environment"
               value={{
                 label: pageEnvironment.name,
-                value: pageEnvironment.id,
+                value: pageEnvironment.id
               }}
               options={[
                 {
                   label: pageEnvironment.name,
-                  value: pageEnvironment.id,
+                  value: pageEnvironment.id
                 }
               ]}
               isDisabled
               required
             />
           </div>
-          <button
-            onClick={() =>
-              taskDrushCron({
-                variables: {
-                  environment: pageEnvironment.id
-                }
-              })
-            }
-            disabled={called}
-          >
-            Add task
-          </button>
+          <Button action={taskDrushCron}>Add task</Button>
           <style jsx>{`
             .envSelect {
-              margin-top: 10px;
-            }
-            button {
-              align-self: flex-end;
-              background-color: ${color.lightestGrey};
-              border: none;
-              border-radius: 20px;
-              color: ${color.darkGrey};
-              font-family: 'source-code-pro', sans-serif;
-              ${fontSize(13)};
-              margin-top: 10px;
-              padding: 3px 20px 2px;
-              text-transform: uppercase;
-              @media ${bp.tinyUp} {
-                align-self: auto;
-              }
+              margin: 10px 0;
             }
           `}</style>
         </React.Fragment>


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

At the time of making the drush core-cron task there was separate work going on to consolidate the look and feel of task buttons into a new component called `button`, this PR will bring that button in-line with the other buttons as raised in #1556.

# Changelog Entry
Adjust cron task button to use standard style

# Closing issues
Resolves #1556 
