### PR TITLE
1572 upgrade elasticsearch kibana opendistro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,8 +467,8 @@ $(build-services-galera):
 # Dependencies of Service Images
 build/auth-server build/logs2email build/logs2slack build/logs2rocketchat build/logs2microsoftteams build/openshiftbuilddeploy build/openshiftbuilddeploymonitor build/openshiftjobs build/openshiftjobsmonitor build/openshiftmisc build/openshiftremove build/rest2tasks build/webhook-handler build/webhooks2tasks build/api build/cli build/ui: build/yarn-workspace-builder
 build/logs2logs-db: build/logstash__7
-build/logs-db: build/elasticsearch__7.1
-build/logs-db-ui: build/kibana__7.1
+build/logs-db: build/elasticsearch__7
+build/logs-db-ui: build/kibana__7
 build/logs-db-curator: build/curator
 build/auto-idler: build/oc
 build/storage-calculator: build/oc

--- a/images/elasticsearch/Dockerfile6
+++ b/images/elasticsearch/Dockerfile6
@@ -38,6 +38,7 @@ RUN echo $'xpack.security.enabled: false\n\
 \n\
 node.name: "${HOSTNAME}"\n\
 node.master: "${NODE_MASTER}"\n\
+cluster.routing.allocation.disk.threshold_enabled: "true"\n\
 discovery.zen.minimum_master_nodes: "${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}"' >> config/elasticsearch.yml
 
 RUN fix-permissions config

--- a/images/elasticsearch/Dockerfile7
+++ b/images/elasticsearch/Dockerfile7
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 # Defining Versions - https://www.elastic.co/guide/en/elasticsearch/reference/7.3/docker.html
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.2
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=elasticsearch
@@ -42,6 +42,7 @@ xpack.ml.enabled: "${XPACK_ML_ENABLED}"\n\
 xpack.watcher.enabled: "${XPACK_WATCHER_ENABLED}"\n\
 xpack.security.enabled: "${XPACK_SECURITY_ENABLED}"\n\
 processors: "${PROCESSORS}"\n\
+cluster.routing.allocation.disk.threshold_enabled: "true"\n\
 cluster.remote.connect: "${CLUSTER_REMOTE_CONNECT}"' >> config/elasticsearch.yml
 
 RUN fix-permissions config

--- a/images/elasticsearch/Dockerfile7.1
+++ b/images/elasticsearch/Dockerfile7.1
@@ -42,6 +42,7 @@ xpack.ml.enabled: "${XPACK_ML_ENABLED}"\n\
 xpack.watcher.enabled: "${XPACK_WATCHER_ENABLED}"\n\
 xpack.security.enabled: "${XPACK_SECURITY_ENABLED}"\n\
 processors: "${PROCESSORS}"\n\
+cluster.routing.allocation.disk.threshold_enabled: "true"\n\
 cluster.remote.connect: "${CLUSTER_REMOTE_CONNECT}"' >> config/elasticsearch.yml
 
 RUN fix-permissions config

--- a/images/kibana/Dockerfile7
+++ b/images/kibana/Dockerfile7
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM docker.elastic.co/kibana/kibana:7.3.0
+FROM docker.elastic.co/kibana/kibana:7.3.2
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=kibana

--- a/services/logs-db-ui/Dockerfile
+++ b/services/logs-db-ui/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/kibana:7.1
+FROM ${IMAGE_REPO:-lagoon}/kibana:7
 
 ENV NODE_OPTIONS="--max-old-space-size=2048" \
     LOGSDB_KIBANASERVER_PASSWORD=kibanaserver \
@@ -58,7 +58,7 @@ opendistro_security.cookie.password: "${OPENDISTRO_SECURITY_COOKIE_PASSWORD:-aaa
 \n\
 ' >> config/kibana.yml
 
-RUN bin/kibana-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/kibana-plugins/opendistro-security/opendistro_security_kibana_plugin-1.1.0.0.zip
+RUN bin/kibana-plugin --allow-root install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/kibana-plugins/opendistro-security/opendistro_security_kibana_plugin-1.3.0.0.zip
 
 COPY entrypoints/80-keycloak-url.bash /lagoon/entrypoints/
 COPY entrypoints/81-logs-db-ui-url.bash /lagoon/entrypoints/

--- a/services/logs-db/Dockerfile
+++ b/services/logs-db/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/elasticsearch:7.1
+FROM ${IMAGE_REPO:-lagoon}/elasticsearch:7
 
-RUN bin/elasticsearch-plugin install -b https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-1.1.0.0.zip \
+RUN bin/elasticsearch-plugin install -b https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-1.3.0.0.zip \
     && chmod a+x /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh \
     && /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh -y \
     && sed -i 's/opendistro_security.ssl.http.*//' config/elasticsearch.yml \


### PR DESCRIPTION
This PR fixes an Elasticsearch issue (#1571) inherited by `opendistro` default's configuration, that diverges from the elasticsearch default configuration. 
By changing the default value of the variable (`cluster.routing.allocation.disk.threshold_enabled)`, elasticsearch will have the default behavior, of balancing shards across all the nodes based on disk allocation.

Moreover, the PR updates `Elasticsearch`, `Kibana` to `7.3.2` and `opendistro_security` plugin to `1.3.0`

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

- `cluster.routing.allocation.disk.threshold_enabled` is set to false, causing ES to do not balance shards based on disk allocation which causes some nodes to be fuller than others.  
- Upgrade Elasticsearch, Kibana, and Opendistro_security to a newer version.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1571 #1572 