### PR TITLE
add broker-single as a build dependency of broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ build/auto-idler: build/oc
 build/storage-calculator: build/oc
 build/api-db build/keycloak-db: build/mariadb
 build/api-db-galera build/keycloak-db-galera: build/mariadb-galera
-build/broker: build/rabbitmq-cluster
+build/broker: build/rabbitmq-cluster build/broker-single
 build/broker-single: build/rabbitmq
 build/drush-alias: build/nginx
 build/keycloak: build/commons


### PR DESCRIPTION
When running `make k8s-tests` locally without a full built image cache, you hit an issue with the lagoon/broker-single image being missing - run locally, lagoon/broker is built from lagoon/broker-single (https://github.com/amazeeio/lagoon/blob/master/docker-compose.yaml#L41-L42), but the dependencies don't reflect this.

```
Pulling broker (lagoon/broker-single:)...
ERROR: The image for the service you're trying to recreate has been removed. If you continue, volume data could be lost. Consider backing up your data before continuing.

Continue with the new image? [yN]n
ERROR: pull access denied for lagoon/broker-single, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
make: *** [main-test-services-up] Error 1
```

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied
