### PR TITLE
initial K8s charts tidyup

### DIFF
--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -782,18 +782,18 @@ do
 
   PERSISTENT_STORAGE_SIZE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.persistent\\.size false)
   if [ ! $PERSISTENT_STORAGE_SIZE == "false" ]; then
-    HELM_SET_VALUES+=(--set "persistentStorageSize=${PERSISTENT_STORAGE_SIZE}")
+    HELM_SET_VALUES+=(--set "persistentStorage.size=${PERSISTENT_STORAGE_SIZE}")
   fi
 
   PERSISTENT_STORAGE_PATH=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.persistent false)
   if [ ! $PERSISTENT_STORAGE_PATH == "false" ]; then
-    HELM_SET_VALUES+=(--set "persistentStoragePath=${PERSISTENT_STORAGE_PATH}")
+    HELM_SET_VALUES+=(--set "persistentStorage.path=${PERSISTENT_STORAGE_PATH}")
 
     PERSISTENT_STORAGE_NAME=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.persistent\\.name false)
     if [ ! $PERSISTENT_STORAGE_NAME == "false" ]; then
-      HELM_SET_VALUES+=(--set "persistentStorageName=${PERSISTENT_STORAGE_NAME}")
+      HELM_SET_VALUES+=(--set "persistentStorage.name=${PERSISTENT_STORAGE_NAME}")
     else
-      HELM_SET_VALUES+=(--set "persistentStorageName=${SERVICE_NAME}")
+      HELM_SET_VALUES+=(--set "persistentStorage.name=${SERVICE_NAME}")
     fi
   fi
 

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image:  {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
@@ -18,29 +18,28 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      priorityClassName: {{ include "cli-persistent.lagoon-priority" . }}
-      enableServiceLinks: false
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: lagoon-sshkey
           secret:
             defaultMode: 420
             secretName: lagoon-sshkey
-        - name: {{ .Values.persistentStorageName }}
+        - name: {{ .Values.persistentStorage.name }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentStorageName }}
+            claimName: {{ .Values.persistentStorage.name }}
+      priorityClassName: {{ include "cli-persistent.lagoon-priority" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+	        name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
               value: {{ .Values.cronjobs | quote }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli-persistent.to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: SERVICE_NAME
@@ -48,14 +47,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: lagoon-env
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /var/run/secrets/lagoon/sshkey/
               name: lagoon-sshkey
               readOnly: true
-            - name: {{ .Values.persistentStorageName }}
-              mountPath: {{ .Values.persistentStoragePath | quote }}
+            - name: {{ .Values.persistentStorage.name }}
+              mountPath: {{ .Values.persistentStorage.path | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "cli-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/values.yaml
@@ -16,7 +16,6 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "cli.lagoon-priority" . }}
-      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
@@ -28,16 +27,16 @@ spec:
             defaultMode: 420
             secretName: lagoon-sshkey
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
               value: {{ .Values.cronjobs | quote }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: SERVICE_NAME

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "cli.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-shared/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-shared/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "mariadb-shared.labels" -}}
 helm.sh/chart: {{ include "mariadb-shared.chart" . }}
 {{ include "mariadb-shared.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "nginx-php-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -19,11 +19,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-        - name: {{ .Values.persistentStorageName }}
+        - name: {{ .Values.persistentStorage.name }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentStorageName }}
+            claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "nginx-php-persistent.lagoon-priority" . }}
-      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -49,7 +48,7 @@ spec:
             failureThreshold: 5
           env:
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: NGINX_FASTCGI_PASS
@@ -60,12 +59,10 @@ spec:
             - configMapRef:
                 name: lagoon-env
           volumeMounts:
-            - name: {{ .Values.persistentStorageName }}
-              mountPath: {{ .Values.persistentStoragePath | quote }}
+            - name: {{ .Values.persistentStorage.name }}
+              mountPath: {{ .Values.persistentStorage.path | quote }}
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources.nginx | nindent 12 }}
 
         - image: {{ .Values.images.php | quote }}
           name: "php"
@@ -88,15 +85,25 @@ spec:
                 name: lagoon-env
           env:
             # LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            # This will cause the cli to redeploy on every deployment, even the files have not changed
+            # This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: NGINX_FASTCGI_PASS
               value: '127.0.0.1'
           volumeMounts:
-            - name: {{ .Values.persistentStorageName }}
-              mountPath: {{ .Values.persistentStoragePath | quote }}
+            - name: {{ .Values.persistentStorage.name }}
+              mountPath: {{ .Values.persistentStorage.path | quote }}
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources.php | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/pvc.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/pvc.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.persistentStorageName | quote }}
+  name: {{ .Values.persistentStorage.name | quote }}
   annotations:
     appuio.ch/backup: "true"
 spec:
   accessModes:
     - ReadWriteOnce
-    # storageClassName: {{ .Values.persistentStorageClass | quote }}
+    # storageClassName: {{ .Values.persistentStorage.class | quote }}
   resources:
     requests:
-      storage: {{ .Values.persistentStorageSize | quote }}
+      storage: {{ .Values.persistentStorage.size | quote }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/values.yaml
@@ -9,7 +9,9 @@ images:
   php: ""
 
 environmentType: production
-persistentStorageSize: 5Gi
+
+persistentStorage:
+  size: 5Gi
 
 imagePullPolicy: Always
 
@@ -32,7 +34,9 @@ service:
   type: ClusterIP
   port: 8080
 
-resources: {}
+resources:
+  nginx: {}
+  php: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "nginx-php.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "nginx-php.lagoon-priority" . }}
-      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -45,7 +44,7 @@ spec:
             failureThreshold: 5
           env:
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: NGINX_FASTCGI_PASS
@@ -56,9 +55,7 @@ spec:
             - configMapRef:
                 name: lagoon-env
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources.nginx | nindent 12 }}
 
         - image: {{ .Values.images.php | quote }}
           name: "php"
@@ -81,12 +78,22 @@ spec:
                 name: lagoon-env
           env:
             # LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            # This will cause the cli to redeploy on every deployment, even the files have not changed
+            # This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: NGINX_FASTCGI_PASS
               value: '127.0.0.1'
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources.php | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/values.yaml
@@ -31,7 +31,9 @@ service:
   type: ClusterIP
   port: 8080
 
-resources: {}
+resources:
+  nginx: {}
+  php: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/Chart.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/Chart.yaml
@@ -15,7 +15,3 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "nginx.labels" -}}
 helm.sh/chart: {{ include "nginx.chart" . }}
 {{ include "nginx.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
@@ -52,6 +49,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create a PriorityClassName.
 (this is based on the Lagoon Environment Type)).
 */}}
-{{- define "nginx-php.lagoon-priority" -}}
+{{- define "nginx.lagoon-priority" -}}
 {{- printf "lagoon-priority-%s" .Values.environmentType }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/deployment.yaml
@@ -21,19 +21,11 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+	        name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          env:
-            - name: CRONJOBS
-              value: {{ .Values.cronjobs | quote }}
-            - name: LAGOON_GIT_SHA
-              value: {{ .Values.gitSha | quote }}
-          envFrom:
-            - configMapRef:
-                name: lagoon-env
           ports:
             - name: http
               containerPort: 8080
@@ -44,6 +36,16 @@ spec:
           readinessProbe:
             tcpSocket:
               port: http
+          env:
+            ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
+            - name: LAGOON_GIT_SHA
+              value: {{ .Values.gitSha | quote }}
+            - name: CRONJOBS
+              value: {{ .Values.cronjobs | quote }}
+          envFrom:
+            - configMapRef:
+                name: lagoon-env
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 image: ""
+
 environmentType: production
 
 imagePullPolicy: Always

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/deployment.yaml
@@ -23,12 +23,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "node-persistent.lagoon-priority" . }}
-      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - image: {{ .Values.images | quote }}
-          name: "node-persistent"
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
@@ -46,7 +45,7 @@ spec:
             periodSeconds: 10
           env:
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
@@ -58,9 +57,7 @@ spec:
             - name: {{ .Values.persistentStorage.name }}
               mountPath: {{ .Values.persistentStorage.path | quote }}
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "node-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/pvc.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-    # storageClassName: {{ .Values.persistentStorageClass | quote }}
+    # storageClassName: {{ .Values.persistentStorage.class | quote }}
   resources:
     requests:
       storage: {{ .Values.persistentStorage.size | quote }}

--- a/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               key: lagoon/build
               operator: Exists
           containers:
-            - image: "{{ $.Values.image }}"
+            - image: {{ $.Values.image | quote }}
               command:
                 - /lagoon/cronjob.sh
                 - "{{ $cronjobConfig.command }}"

--- a/images/kubectl-build-deploy-dind/helmcharts/node/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "node.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/node/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node/templates/deployment.yaml
@@ -19,12 +19,13 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "node.lagoon-priority" . }}
-      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - image: {{ .Values.images | quote }}
-          name: "node"
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
@@ -42,7 +43,7 @@ spec:
             periodSeconds: 10
           env:
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
-            ## This will cause the cli to redeploy on every deployment, even the files have not changed
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
@@ -51,9 +52,7 @@ spec:
             - configMapRef:
                 name: lagoon-env
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "redis-persistent.labels" -}}
 helm.sh/chart: {{ include "redis-persistent.chart" . }}
 {{ include "redis-persistent.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
@@ -52,6 +49,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create a PriorityClassName.
 (this is based on the Lagoon Environment Type)).
 */}}
-{{- define "nginx-php.lagoon-priority" -}}
+{{- define "redis-persistent.lagoon-priority" -}}
 {{- printf "lagoon-priority-%s" .Values.environmentType }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
@@ -22,39 +22,42 @@ spec:
         - name: {{ .Values.persistentStorage.name }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
+      priorityClassName: {{ include "redis-persistent.lagoon-priority" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          env:
-            - name: CRONJOBS
-              value: {{ .Values.cronjobs | quote }}
-            - name: LAGOON_GIT_SHA
-              value: {{ .Values.gitSha | quote }}
-          envFrom:
-            - configMapRef:
-                name: lagoon-env
           ports:
             - name: 6379-tcp
               containerPort: 6379
               protocol: TCP
-          volumeMounts:
-            - name: {{ .Values.persistentStorage.name }}
-              mountPath: {{ .Values.persistentStorage.path | quote }}
-          livenessProbe:
-            tcpSocket:
-              port: 6379
-            initialDelaySeconds: 15
-            timeoutSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 6379
             initialDelaySeconds: 120
-            periodSeconds: 10
+            timeoutSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 15
+            periodSeconds: 1
+	  env:
+            ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
+            - name: LAGOON_GIT_SHA
+              value: {{ .Values.gitSha | quote }}
+            - name: CRONJOBS
+              value: {{ .Values.cronjobs | quote }}
+          envFrom:
+            - configMapRef:
+                name: lagoon-env
+          volumeMounts:
+            - name: {{ .Values.persistentStorage.name }}
+              mountPath: {{ .Values.persistentStorage.path | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "redis-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/pvc.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-    # storageClassName: {{ .Values.persistentStorageClass | quote }}
+    # storageClassName: {{ .Values.persistentStorage.class | quote }}
   resources:
     requests:
       storage: {{ .Values.persistentStorage.size | quote }}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/values.yaml
@@ -5,7 +5,9 @@
 replicaCount: 1
 
 image: ""
+
 environmentType: production
+
 persistentStorage:
   name: "redis"
   size: 5Gi

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/Chart.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/Chart.yaml
@@ -15,7 +15,3 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "redis.labels" -}}
 helm.sh/chart: {{ include "redis.chart" . }}
 {{ include "redis.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
@@ -52,6 +49,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create a PriorityClassName.
 (this is based on the Lagoon Environment Type)).
 */}}
-{{- define "nginx-php.lagoon-priority" -}}
+{{- define "redis.lagoon-priority" -}}
 {{- printf "lagoon-priority-%s" .Values.environmentType }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/templates/deployment.yaml
@@ -21,10 +21,10 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 image: ""
+
 environmentType: production
 
 imagePullPolicy: Always

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/Chart.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/Chart.yaml
@@ -15,10 +15,3 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
-
-# Default icon.
-icon: https://www.amazee.io/sites/default/files/2019-06/amazee_io_logo.png

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "varnish-persistent.labels" -}}
 helm.sh/chart: {{ include "varnish-persistent.chart" . }}
 {{ include "varnish-persistent.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
@@ -52,6 +49,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create a PriorityClassName.
 (this is based on the Lagoon Environment Type)).
 */}}
-{{- define "nginx-php.lagoon-priority" -}}
+{{- define "varnish-persistent.lagoon-priority" -}}
 {{- printf "lagoon-priority-%s" .Values.environmentType }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
       priorityClassName: {{ include "varnish-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/deployment.yaml
@@ -22,19 +22,22 @@ spec:
         - name: {{ .Values.persistentStorage.name }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistentStorage.name }}
+      priorityClassName: {{ include "varnish-persistent.lagoon-priority" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
-            - name: CRONJOBS
-              value: {{ .Values.cronjobs | quote }}
+            ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
+            - name: SERVICE_NAME
+              value: {{ .Release.Name | quote }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/pvc.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-    # storageClassName: {{ .Values.persistentStorageClass | quote }}
+    # storageClassName: {{ .Values.persistentStorage.class | quote }}
   resources:
     requests:
       storage: {{ .Values.persistentStorage.size | quote }}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/values.yaml
@@ -5,7 +5,9 @@
 replicaCount: 1
 
 image: ""
+
 environmentType: production
+
 persistentStorage:
   name: "varnish"
   size: 5Gi

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/Chart.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/Chart.yaml
@@ -15,10 +15,3 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
-
-# Default icon.
-icon: https://www.amazee.io/sites/default/files/2019-06/amazee_io_logo.png

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/_helpers.tpl
@@ -34,9 +34,6 @@ Common labels
 {{- define "varnish.labels" -}}
 helm.sh/chart: {{ include "varnish.chart" . }}
 {{ include "varnish.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
@@ -52,6 +49,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create a PriorityClassName.
 (this is based on the Lagoon Environment Type)).
 */}}
-{{- define "nginx-php.lagoon-priority" -}}
+{{- define "varnish.lagoon-priority" -}}
 {{- printf "lagoon-priority-%s" .Values.environmentType }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       priorityClassName: {{ include "nginx-php-persistent.lagoon-priority" . }}
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/deployment.yaml
@@ -18,17 +18,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      priorityClassName: {{ include "nginx-php-persistent.lagoon-priority" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - image: {{ .Values.image | quote }}
+          name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
-            - name: CRONJOBS
-              value: {{ .Values.cronjobs | quote }}
+            ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
+            ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 image: ""
+
 environmentType: production
 
 imagePullPolicy: Always


### PR DESCRIPTION
This is a first cut attempt at standardising our templates around definitions (for #1593) ,  only the following have been done so far.

- cli changes
- cli-persistent
- mariadb-shared
- nginx
- nginx-php 
- nginx-php-persistent 
- node 
- node-persistent 
- redis 
- redis-persistent 
- varnish 

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied
