### PR TITLE
Fix alignment for SSH key fields in UI

### DIFF
--- a/services/ui/src/components/SshKeys/index.js
+++ b/services/ui/src/components/SshKeys/index.js
@@ -134,10 +134,12 @@ const SshKeys = ({me: { id, email, sshKeys: keys }}) => {
               }
               @media ${bp.wideUp} {
                 &.name {
+                  align-self: center;
                   width: 40%;
                 }
 
                 &.type {
+                  align-self: center;
                   width: 20%;
                 }
 


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change fixes the alignment of fields when viewing my ssh keys in the lagoon UI.

Before:
![Screenshot_2020-02-05 Settings(1)](https://user-images.githubusercontent.com/861778/73820301-6cd6d180-482c-11ea-9a54-cdf88d0f6f03.png)

After:
![Screenshot_2020-02-05 Settings](https://user-images.githubusercontent.com/861778/73820321-752f0c80-482c-11ea-8b64-1e977523dd0b.png)

# Closing issues
n/a
