### PR TITLE
Use DBaaS operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,9 @@ service-images += ssh
 
 # Images for local helpers that exist in another folder than the service images
 localdevimages := local-git \
-									local-api-data-watcher-pusher
+									local-api-data-watcher-pusher \
+									local-dbaas-provider
+
 service-images += $(localdevimages)
 build-localdevimages = $(foreach image,$(localdevimages),build/$(image))
 
@@ -563,7 +565,7 @@ tests-list:
 #### Definition of tests
 
 # Define a list of which Lagoon Services are needed for running any deployment testing
-deployment-test-services-main = broker openshiftremove openshiftbuilddeploy openshiftbuilddeploymonitor logs2email logs2slack logs2rocketchat logs2microsoftteams api api-db keycloak keycloak-db ssh auth-server local-git local-api-data-watcher-pusher tests
+deployment-test-services-main = broker openshiftremove openshiftbuilddeploy openshiftbuilddeploymonitor logs2email logs2slack logs2rocketchat logs2microsoftteams api api-db keycloak keycloak-db ssh auth-server local-git local-api-data-watcher-pusher tests local-dbaas-provider
 
 # These targets are used as dependencies to bring up containers in the right order.
 .PHONY: test-services-main
@@ -845,6 +847,9 @@ openshift-lagoon-setup:
 	oc -n lagoon create -f openshift-setup/clusterrole-daemonset-admin.yaml; \
 	oc -n lagoon adm policy add-cluster-role-to-user daemonset-admin -z lagoon-deployer; \
 	bash -c "oc process -n lagoon -f services/docker-host/docker-host.yaml | oc -n lagoon apply -f -"; \
+	oc -n lagoon create -f openshift-setup/dbaas-roles.yaml; \
+	oc -n dbaas-operator-system create -f openshift-setup/dbaas-operator.yaml; \
+	oc -n lagoon create -f openshift-setup/dbaas-providers.yaml; \
 	echo -e "\n\nAll Setup, use this token as described in the Lagoon Install Documentation:" \
 	oc -n lagoon serviceaccounts get-token openshiftbuilddeploy
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       - ./services/api-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - ./services/api-db/rerun_initdb.sh:/rerun_initdb.sh
     ports:
-      - '3306:3306'
+      - '3366:3306'
     labels:
       lagoon.type: mariadb-single
       lagoon.image: amazeeiolagoon/api-db:v1-2-0
@@ -323,6 +323,18 @@ services:
       - ./local-dev/api-data-watcher-pusher:/home
     labels:
       lagoon.type: none
+  local-dbaas-provider:
+    image: ${IMAGE_REPO:-lagoon}/local-dbaas-provider
+    restart: always
+    labels:
+      lagoon.type: none
+    environment:
+      MYSQL_DATABASE: 'db'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'password'
+      MYSQL_ROOT_PASSWORD: 'password'
+    ports:
+      - '3306:3306'
   local-minio:
     image: minio/minio
     entrypoint: sh

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -87,6 +87,9 @@ do
     # mariadb-single deployed (probably from the past where there was no mariadb-shared yet) and use that one
     if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get service "$SERVICE_NAME" &> /dev/null; then
       SERVICE_TYPE="mariadb-single"
+    # check if we can use the dbaas operator
+    elif oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} auth can-i create mariadbconsumer.v1.mariadb.amazee.io > /dev/null; then
+      SERVICE_TYPE="dbaas-shared"
     # heck if this cluster supports the default one, if not we assume that this cluster is not capable of shared mariadbs and we use a mariadb-single
     elif svcat --scope cluster get class $MARIADB_SHARED_DEFAULT_CLASS > /dev/null; then
       SERVICE_TYPE="mariadb-shared"
@@ -94,6 +97,38 @@ do
       SERVICE_TYPE="mariadb-single"
     fi
 
+  fi
+
+  ## in kubernetes, we want to use dbaas-shared as no service broker exists, but capture anyone that is hardcoding mariadb-shared in their environments
+  if [[ "$SERVICE_TYPE" == "dbaas-shared" ]]; then
+    # Load a possible defined dbaas-shared
+    DBAAS_SHARED_CLASS=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.dbaas-shared\\.class "${MARIADB_SHARED_DEFAULT_CLASS}")
+
+    # Allow the dbaas shared servicebroker to be overriden by environment in .lagoon.yml
+    ENVIRONMENT_DBAAS_SHARED_CLASS_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH}.overrides.$SERVICE_NAME.dbaas-shared\\.class false)
+    if [ ! $ENVIRONMENT_DBAAS_SHARED_CLASS_OVERRIDE == "false" ]; then
+      DBAAS_SHARED_CLASS=$ENVIRONMENT_DBAAS_SHARED_CLASS_OVERRIDE
+    fi
+
+    # check if the defined operator class exists
+    if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} auth can-i create mariadbconsumer.v1.mariadb.amazee.io > /dev/null; then
+      SERVICE_TYPE="dbaas-shared"
+      MAP_SERVICE_NAME_TO_SERVICEBROKER_CLASS["${SERVICE_NAME}"]="${DBAAS_SHARED_CLASS}"
+    else
+      echo "defined dbaas-shared operator class '$DBAAS_SHARED_CLASS' for service '$SERVICE_NAME' not found in cluster";
+      exit 1
+    fi
+
+    # Default plan is the enviroment type
+    DBAAS_SHARED_PLAN=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.dbaas-shared\\.plan "${ENVIRONMENT_TYPE}")
+
+    # Allow the dbaas shared servicebroker plan to be overriden by environment in .lagoon.yml
+    ENVIRONMENT_DBAAS_SHARED_PLAN_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH}.overrides.$SERVICE_NAME.dbaas-shared\\.plan false)
+    if [ ! $DBAAS_SHARED_PLAN_OVERRIDE == "false" ]; then
+      DBAAS_SHARED_PLAN=$ENVIRONMENT_DBAAS_SHARED_PLAN_OVERRIDE
+    fi
+
+    MAP_SERVICE_NAME_TO_SERVICEBROKER_PLAN["${SERVICE_NAME}"]="${DBAAS_SHARED_PLAN}"
   fi
 
   if [ "$SERVICE_TYPE" == "mariadb-shared" ]; then
@@ -426,6 +461,28 @@ do
     SERVICEBROKERS+=("${SERVICE_NAME}:${SERVICE_TYPE}")
   fi
 
+  # If we have a dbaas consumer, create it
+  OPENSHIFT_SERVICES_TEMPLATE="/oc-build-deploy/openshift-templates/${SERVICE_TYPE}/consumer.yml"
+  if [ -f $OPENSHIFT_SERVICES_TEMPLATE ]; then
+    OPENSHIFT_TEMPLATE=$OPENSHIFT_SERVICES_TEMPLATE
+    OPERATOR_PLAN="${MAP_SERVICE_NAME_TO_SERVICEBROKER_PLAN["${SERVICE_NAME}"]}"
+    TEMPLATE_ADDITIONAL_PARAMETERS=()
+    if [[ $(oc process --local -f ${OPENSHIFT_TEMPLATE} --parameters | grep ENVIRONMENT_TYPE) ]]; then
+      TEMPLATE_ADDITIONAL_PARAMETERS+=(-p "ENVIRONMENT_TYPE=${ENVIRONMENT_TYPE}")
+    fi
+    oc process  --local -o yaml --insecure-skip-tls-verify \
+      -n ${OPENSHIFT_PROJECT} \
+      -f ${OPENSHIFT_TEMPLATE} \
+      -p SERVICE_NAME="${SERVICE_NAME}" \
+      -p SAFE_BRANCH="${SAFE_BRANCH}" \
+      -p SAFE_PROJECT="${SAFE_PROJECT}" \
+      -p ENVIRONMENT="${OPERATOR_PLAN}" \
+      "${TEMPLATE_PARAMETERS[@]}" \
+      "${TEMPLATE_ADDITIONAL_PARAMETERS[@]}" \
+      | outputToYaml
+    SERVICEBROKERS+=("${SERVICE_NAME}:${SERVICE_TYPE}")
+  fi
+
 done
 
 TEMPLATE_PARAMETERS=()
@@ -642,6 +699,10 @@ do
   SERVICE_NAME_UPPERCASE=$(echo "$SERVICE_NAME" | tr '[:lower:]' '[:upper:]')
 
   case "$SERVICE_TYPE" in
+    # Operator can take some time to return the required information, do it here
+    dbaas-shared)
+        . /oc-build-deploy/scripts/exec-openshift-dbaas-shared.sh
+        ;;
 
     mariadb-shared)
         # ServiceBrokers take a bit, wait until the credentials secret is available
@@ -989,6 +1050,10 @@ do
 
     DAEMONSET="${SERVICE_NAME}"
     . /oc-build-deploy/scripts/exec-monitor-deamonset.sh
+
+  elif [ $SERVICE_TYPE == "dbaas-shared" ]; then
+
+    echo "nothing to monitor for $SERVICE_TYPE"
 
   elif [ $SERVICE_TYPE == "mariadb-shared" ]; then
 

--- a/images/oc-build-deploy-dind/openshift-templates/dbaas-shared/consumer.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/dbaas-shared/consumer.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-openshift-template-dbaas-crd
+parameters:
+  - name: SERVICE_NAME
+    description: Name of this service
+    required: true
+  - name: SAFE_BRANCH
+    description: Which branch this belongs to, special chars replaced with dashes
+    required: true
+  - name: SAFE_PROJECT
+    description: Which project this belongs to, special chars replaced with dashes
+    required: true
+  - name: ENVIRONMENT
+    description: Environment or type of dbaas to choose
+    required: true
+objects:
+- apiVersion: mariadb.amazee.io/v1
+  kind: MariaDBConsumer
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      service: ${SERVICE_NAME}
+      branch: ${SAFE_BRANCH}
+      project: ${SAFE_PROJECT}
+  spec:
+    environment: ${ENVIRONMENT}

--- a/images/oc-build-deploy-dind/openshift-templates/dbaas-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/dbaas-shared/prebackuppod.yml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: lagoon-openshift-template-prebackuppod
+parameters:
+  - name: SERVICE_NAME
+    description: Name of this service
+    required: true
+  - name: SERVICE_NAME_UPPERCASE
+    description: Name of this service in uppercase
+    required: true
+  - name: SAFE_BRANCH
+    description: Which branch this belongs to, special chars replaced with dashes
+    required: true
+  - name: SAFE_PROJECT
+    description: Which project this belongs to, special chars replaced with dashes
+    required: true
+  - name: BRANCH
+    description: Which branch this belongs to, original value
+    required: true
+  - name: PROJECT
+    description: Which project this belongs to, original value
+    required: true
+  - name: LAGOON_GIT_SHA
+    description: git hash sha of the current deployment
+    required: true
+  - name: SERVICE_ROUTER_URL
+    description: URL of the Router for this service
+    value: ""
+  - name: OPENSHIFT_PROJECT
+    description: Name of the Project that this service is in
+    required: true
+  - name: REGISTRY
+    description: Registry where Images are pushed to
+    required: true
+  - name: DEPLOYMENT_STRATEGY
+    description: Strategy of Deploymentconfig
+    value: "Recreate"
+  - name: SERVICE_IMAGE
+    description: Pullable image of service
+    required: true
+  - name: CRONJOBS
+    description: Oneliner of Cronjobs
+    value: ""
+objects:
+- apiVersion: backup.appuio.ch/v1alpha1
+  kind: PreBackupPod
+  metadata:
+    name: ${SERVICE_NAME}-prebackuppod
+    labels:
+      service: ${SERVICE_NAME}
+      branch: ${SAFE_BRANCH}
+      project: ${SAFE_PROJECT}
+  spec:
+    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $${SERVICE_NAME_UPPERCASE}_HOST -u $${SERVICE_NAME_UPPERCASE}_USERNAME -p$${SERVICE_NAME_UPPERCASE}_PASSWORD $${SERVICE_NAME_UPPERCASE}_DATABASE > $dump && cat $dump && rm $dump"
+    fileExtension: .${SERVICE_NAME}.sql
+    pod:
+      metadata:
+        labels:
+          prebackuppod: ${SERVICE_NAME}
+          branch: ${SAFE_BRANCH}
+          project: ${SAFE_PROJECT}
+          parent: ${SERVICE_NAME}
+      spec:
+        containers:
+          - args:
+              - sleep
+              - '3600'
+            envFrom:
+              - configMapRef:
+                  name: lagoon-env
+            image: amazeeio/alpine-mysql-client
+            imagePullPolicy: Always
+            name: ${SERVICE_NAME}-prebackuppod
+

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-dbaas-shared.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-dbaas-shared.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# The operator can sometimes take a bit, wait until the details are available
+# We added a timeout of 10 minutes (120 retries) before exit
+SERVICE_BROKER_COUNTER=1
+SERVICE_BROKER_TIMEOUT=180
+
+# check for the database in the consumer, once it exists it means the operator has done its job
+until oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database
+do
+if [ $SERVICE_BROKER_COUNTER -lt $SERVICE_BROKER_TIMEOUT ]; then
+    let SERVICE_BROKER_COUNTER=SERVICE_BROKER_COUNTER+1
+    echo "Service for ${SERVICE_NAME} not available yet, waiting for 5 secs"
+    sleep 5
+else
+    echo "Timeout of $SERVICE_BROKER_TIMEOUT for ${SERVICE_NAME} creation reached"
+    exit 1
+fi
+done
+set +x
+# Grab the details from the consumer spec
+DB_HOST=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.services.primary)
+DB_USER=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.username)
+DB_PASSWORD=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.password)
+DB_NAME=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database)
+DB_PORT=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.provider.port)
+
+# Add credentials to our configmap, prefixed with the name of the servicename of this servicebroker
+oc patch --insecure-skip-tls-verify \
+    -n ${OPENSHIFT_PROJECT} \
+    configmap lagoon-env \
+    -p "{\"data\":{\"${SERVICE_NAME_UPPERCASE}_HOST\":\"${DB_HOST}\", \"${SERVICE_NAME_UPPERCASE}_USERNAME\":\"${DB_USER}\", \"${SERVICE_NAME_UPPERCASE}_PASSWORD\":\"${DB_PASSWORD}\", \"${SERVICE_NAME_UPPERCASE}_DATABASE\":\"${DB_NAME}\", \"${SERVICE_NAME_UPPERCASE}_PORT\":\"${DB_PORT}\"}}"
+
+# only add the DB_READREPLICA_HOSTS variable if it exists in the consumer spec
+# since the operator can support multiple replica hosts being defined, we should comma seperate them here
+if DB_READREPLICA_HOSTS=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.services.replicas); then
+    DB_READREPLICA_HOSTS=$(echo $DB_READREPLICA_HOSTS | cut -c 3- | rev | cut -c 1- | rev | sed 's/^\|$//g' | paste -sd, -)
+    oc patch --insecure-skip-tls-verify \
+    -n "$OPENSHIFT_PROJECT" \
+    configmap lagoon-env \
+    -p "{\"data\":{\"${SERVICE_NAME_UPPERCASE}_READREPLICA_HOSTS\":\"${DB_READREPLICA_HOSTS}\"}}"
+fi
+set -x

--- a/local-dev/dbaas-provider/Dockerfile
+++ b/local-dev/dbaas-provider/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb

--- a/openshift-setup/dbaas-operator.yaml
+++ b/openshift-setup/dbaas-operator.yaml
@@ -1,0 +1,349 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: dbaas-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: mariadbconsumers.mariadb.amazee.io
+spec:
+  group: mariadb.amazee.io
+  names:
+    kind: MariaDBConsumer
+    listKind: MariaDBConsumerList
+    plural: mariadbconsumers
+    singular: mariadbconsumer
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MariaDBConsumer is the Schema for the mariadbconsumers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MariaDBConsumerSpec defines the desired state of MariaDBConsumer
+          properties:
+            environment:
+              description: These are the spec options for consumers
+              type: string
+            mariadb_database:
+              type: string
+            mariadb_hostname:
+              type: string
+            mariadb_password:
+              type: string
+            mariadb_port:
+              type: string
+            mariadb_readreplica_hostname:
+              type: string
+            mariadb_user:
+              type: string
+            service_mariadb_hostname:
+              type: string
+            service_mariadb_readreplica_hostname:
+              type: string
+          type: object
+        status:
+          description: MariaDBConsumerStatus defines the observed state of MariaDBConsumer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: mariadbproviders.mariadb.amazee.io
+spec:
+  group: mariadb.amazee.io
+  names:
+    kind: MariaDBProvider
+    listKind: MariaDBProviderList
+    plural: mariadbproviders
+    singular: mariadbprovider
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MariaDBProvider is the Schema for the mariadbproviders API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MariaDBProviderSpec defines the desired state of MariaDBProvider
+          properties:
+            environment:
+              description: These are the spec options for providers
+              type: string
+            mariadb_hostname:
+              type: string
+            mariadb_password:
+              type: string
+            mariadb_port:
+              type: string
+            mariadb_readreplica_hostname:
+              type: string
+            mariadb_user:
+              type: string
+          type: object
+        status:
+          description: MariaDBProviderStatus defines the observed state of MariaDBProvider
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dbaas-operator-leader-election-role
+  namespace: dbaas-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: dbaas-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbconsumers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbproviders
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbproviders/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dbaas-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dbaas-operator-leader-election-rolebinding
+  namespace: dbaas-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dbaas-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: dbaas-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dbaas-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dbaas-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: dbaas-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dbaas-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dbaas-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: dbaas-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: dbaas-operator-controller-manager-metrics-service
+  namespace: dbaas-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: dbaas-operator-controller-manager
+  namespace: dbaas-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: amazeeio/dbaas-operator:testingv1
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10

--- a/openshift-setup/dbaas-operator.yaml
+++ b/openshift-setup/dbaas-operator.yaml
@@ -39,25 +39,48 @@ spec:
         spec:
           description: MariaDBConsumerSpec defines the desired state of MariaDBConsumer
           properties:
+            consumer:
+              description: MariaDBConsumerData defines the provider link for this
+                consumer
+              properties:
+                database:
+                  type: string
+                password:
+                  type: string
+                services:
+                  description: MariaDBConsumerServices defines the provider link for
+                    this consumer
+                  properties:
+                    primary:
+                      type: string
+                    replicas:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                username:
+                  type: string
+              type: object
             environment:
               description: These are the spec options for consumers
               type: string
-            mariadb_database:
-              type: string
-            mariadb_hostname:
-              type: string
-            mariadb_password:
-              type: string
-            mariadb_port:
-              type: string
-            mariadb_readreplica_hostname:
-              type: string
-            mariadb_user:
-              type: string
-            service_mariadb_hostname:
-              type: string
-            service_mariadb_readreplica_hostname:
-              type: string
+            provider:
+              description: MariaDBConsumerProvider defines the provider link for this
+                consumer
+              properties:
+                hostname:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                port:
+                  type: string
+                readReplicas:
+                  items:
+                    type: string
+                  type: array
+              type: object
           type: object
         status:
           description: MariaDBConsumerStatus defines the observed state of MariaDBConsumer
@@ -112,15 +135,17 @@ spec:
             environment:
               description: These are the spec options for providers
               type: string
-            mariadb_hostname:
+            hostname:
               type: string
-            mariadb_password:
+            password:
               type: string
-            mariadb_port:
+            port:
               type: string
-            mariadb_readreplica_hostname:
-              type: string
-            mariadb_user:
+            readReplicaHostnames:
+              items:
+                type: string
+              type: array
+            user:
               type: string
           type: object
         status:

--- a/openshift-setup/dbaas-providers.yaml
+++ b/openshift-setup/dbaas-providers.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   environment: development
   hostname: 172.17.0.1.xip.io
-  readreplica_hostnames:
+  readReplicaHostnames:
   - 172.17.0.1.xip.io
   password: password
   port: '3306'
@@ -18,7 +18,7 @@ metadata:
 spec:
   environment: production
   hostname: 172.17.0.1.xip.io
-  readreplica_hostnames:
+  readReplicaHostnames:
   - 172.17.0.1.xip.io
   password: password
   port: '3306'

--- a/openshift-setup/dbaas-providers.yaml
+++ b/openshift-setup/dbaas-providers.yaml
@@ -1,0 +1,25 @@
+apiVersion: mariadb.amazee.io/v1
+kind: MariaDBProvider
+metadata:
+  name: mariadbprovider-development
+spec:
+  environment: development
+  hostname: 172.17.0.1.xip.io
+  readreplica_hostnames:
+  - 172.17.0.1.xip.io
+  password: password
+  port: '3306'
+  user: root
+---
+apiVersion: mariadb.amazee.io/v1
+kind: MariaDBProvider
+metadata:
+  name: mariadbprovider-production
+spec:
+  environment: production
+  hostname: 172.17.0.1.xip.io
+  readreplica_hostnames:
+  - 172.17.0.1.xip.io
+  password: password
+  port: '3306'
+  user: root

--- a/openshift-setup/dbaas-roles.yaml
+++ b/openshift-setup/dbaas-roles.yaml
@@ -1,0 +1,26 @@
+# use for lagoon-deployer to be able to create mariadbconsumer kinds
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mariadbconsumer-role
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["mariadb.amazee.io"]
+  resources: ["mariadbconsumers"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mariadbprovider-role
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["mariadb.amazee.io"]
+  resources: ["mariadbproviders"]
+  verbs: ["*"]


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR allows for lagoon to leverage the DBaaS operator instead of using the ansible service broker (ASB). It introduces a new service type called `dbaas-shared` which can be used instead of the older `mariadb-shared` which uses the ASB.

It still allows for the ASB to be used if `mariadb-shared` is defined as the lagoon.type in the `.lagoon.yml` file.

It will prefer the `dbaas-shared` type if undefined, before falling back to `mariadb-shared` then `mariadb-single` as before.


<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
none
