### PR TITLE
Slack notifications to match Rocketchat

### DIFF
--- a/services/logs2slack/src/readFromRabbitMQ.js
+++ b/services/logs2slack/src/readFromRabbitMQ.js
@@ -55,16 +55,29 @@ async function readFromRabbitMQ (msg: RabbitMQMsg, channelWrapperLogs: ChannelWr
     case "bitbucket:pullrequest:updated:handled":
     case "bitbucket:pullrequest:fulfilled:handled":
     case "bitbucket:pullrequest:rejected:handled":
+    case "bitbucket:pullrequest:created:opened:handled":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "gitlab:push:handled":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "gitlab:merge_request:opened:handled":
     case "gitlab:merge_request:updated:handled":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "gitlab:merge_request:closed:handled":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "rest:deploy:receive":
     case "rest:remove:receive":
     case "rest:promote:receive":
     case "api:deployEnvironmentLatest":
     case "api:deployEnvironmentBranch":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "api:deleteEnvironment":
+      sendToSlack(project, message, '#E8E8E8', ':information_source:', channelWrapperLogs, msg, appId)
+      break;
     case "github:push:skipped":
     case "gitlab:push:skipped":
     case "bitbucket:push:skipped":
@@ -73,6 +86,8 @@ async function readFromRabbitMQ (msg: RabbitMQMsg, channelWrapperLogs: ChannelWr
 
     case "task:deploy-openshift:finished":
     case "task:remove-openshift:finished":
+      sendToSlack(project, message, 'good', ':white_check_mark:', channelWrapperLogs, msg, appId)
+      break;
     case "task:remove-openshift-resources:finished":
     case "task:builddeploy-openshift:complete":
       sendToSlack(project, message, 'good', ':white_check_mark:', channelWrapperLogs, msg, appId)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The Slack notifications were missing quite a few that were present in Rocketchat.
I've added the missing ones, but I have excluded the `rest:` notifications as rest2tasks is being deprecated.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
Closes #1637 
