### PR TITLE
fix issues with nginx temp folder in wrong place

### DIFF
--- a/images/nginx/fastcgi.conf
+++ b/images/nginx/fastcgi.conf
@@ -60,3 +60,4 @@ fastcgi_hide_header 'X-Generator';
 fastcgi_buffers         ${FASTCGI_BUFFERS:-256 32k};
 fastcgi_buffer_size     ${FASTCGI_BUFFER_SIZE:-32k};
 fastcgi_read_timeout    ${FASTCGI_READ_TIMEOUT:-3600s};
+fastcgi_temp_path       /tmp/fastcgi_temp;

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -77,6 +77,7 @@ http {
     client_body_timeout      10s;
     client_header_timeout    10s;
     client_body_buffer_size  128k;
+    client_body_temp_path    /tmp/client_temp;
     proxy_redirect           off;
     proxy_max_temp_file_size 4096m;
     proxy_connect_timeout    90;
@@ -88,6 +89,10 @@ http {
     proxy_set_header         X-Real-IP $remote_addr;
     proxy_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_headers_hash_bucket_size 64;
+    proxy_temp_path          /tmp/proxy_temp;
+
+    uwsgi_temp_path          /tmp/uwsgi_temp;
+    scgi_temp_path           /tmp/scgi_temp;
 
     set_real_ip_from         10.0.0.0/8;
     set_real_ip_from         172.16.0.0/12;


### PR DESCRIPTION
Nginx (OpenResty) adds temp paths inside `/usr/local/openresty/nginx` which is not the fully correct path.
This usually works as `/usr/local/openresty/nginx` is writeable by the root group (and openresty is running as root group as well) but there is a weird bug where sometimes `/usr/local/openresty/nginx` is not owned by the root group anymore.

Therefore we're changing the path for the temp files to `/tmp` which is definitely writeable by nginx