### PR TITLE
Fixes 1101 - Comments out scripts folder from dockerfile.

### DIFF
--- a/docs/using_lagoon/drupal/drupal8-composer-mariadb/cli.dockerfile
+++ b/docs/using_lagoon/drupal/drupal8-composer-mariadb/cli.dockerfile
@@ -1,7 +1,8 @@
 FROM amazeeio/php:7.2-cli-drupal
 
 COPY composer.json composer.lock /app/
-COPY scripts /app/scripts
+# Uncomment if you have a scripts directory in your Drupal Installation
+# COPY scripts /app/scripts
 # Uncomment if you have a patches directory in your Drupal Installation
 # COPY patches /app/patches
 RUN composer install --prefer-dist --no-dev --no-suggest --optimize-autoloader --apcu-autoloader

--- a/docs/using_lagoon/drupal/drupal8-composer-postgres/cli.dockerfile
+++ b/docs/using_lagoon/drupal/drupal8-composer-postgres/cli.dockerfile
@@ -1,7 +1,8 @@
 FROM amazeeio/php:7.2-cli-drupal
 
 COPY composer.json composer.lock /app/
-COPY scripts /app/scripts
+# Uncomment if you have a scripts directory in your Drupal Installation
+# COPY scripts /app/scripts
 # Uncomment if you have a patches directory in your Drupal Installation
 # COPY patches /app/patches
 RUN composer install --no-dev


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

In the latest versions of Drupal 8, the `scripts` folder is no longer included and is not referenced in the `composer.json` file, so this is not a step needed to build the `cli` images.

# Changelog Entry
Comments out scripts folder from cli dockerfiles (#1101).

# Closing issues
Closes #1101 
