### PR TITLE
Fix #1675 by increasing backup retention window to 6 weeks

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
@@ -59,5 +59,5 @@ objects:
     prune:
       retention:
         keepDaily: 7
-        keepWeekly: 4
+        keepWeekly: 6
       schedule: '${PRUNE_SCHEDULE}'


### PR DESCRIPTION
The weekly backup retention window is currently set to 4 weeks.
This PR will increase it to 6 weeks, to be closer to "one-month" backup data retention.

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Backup data retention is 4 weeks by default. PR increases to 6 weeks
<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1675 
