### PR TITLE
Use UTF-8 charset in api-db connection

### DIFF
--- a/services/api/src/clients/sqlClient.ts
+++ b/services/api/src/clients/sqlClient.ts
@@ -9,12 +9,13 @@ export const getSqlClient = () => {
     user: 'api',
     password: 'api',
     db: 'infrastructure',
+    charset: 'utf8',
   });
 
   sqlClient.on('error', error => {
     logger.error(error.message);
   });
-  
+
   return sqlClient;
 };
 


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The [default character set](https://mariadb.com/kb/en/setting-character-sets-and-collations/) used by MariaDB is latin1, a single-byte encoding scheme. Lagoon currently doesn't set the charset on the DB connection, so it uses the default latin1.

This means that if a multibyte UTF-8 character was encoded and written to the DB, then read back and decoded as latin1, it would cause mojibake.

Taking the string from #1681  and reversing the encoding/decoding shows that it has likely been mis-decoded as latin1:
![moji2](https://user-images.githubusercontent.com/861778/74996173-cf1b0d80-548d-11ea-9f88-2e2ae092b263.png)

This PR sets the charset of the database connection to UTF-8 to avoid this issue.

In this example I'm listing the project from #1681 using `lagoon-cli`:

Before:
![moji3](https://user-images.githubusercontent.com/861778/74996223-f540ad80-548d-11ea-92a3-fa75a5d6ce13.png)

After this PR:
![moji4](https://user-images.githubusercontent.com/861778/74996228-f96ccb00-548d-11ea-9b53-54e2ead6e09d.png)

# Closing issues
Closes #1681 