### PR TITLE
Allow logs2logs-db to create missing lagoon-logs exchange

### DIFF
--- a/services/logs2logs-db/pipeline/lagoon-logs.conf
+++ b/services/logs2logs-db/pipeline/lagoon-logs.conf
@@ -4,6 +4,7 @@ input {
     user => "${RABBITMQ_USER}"
     password => "${RABBITMQ_PASSWORD}"
     exchange => "lagoon-logs"
+    exchange_type => "direct"
     key => ""
     durable => "true"
     queue => "lagoon-logs:logstash"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

When developing locally, it's possible to start lagoon images in an order which makes the `logs2logs-db` service constantly spit out errors:

```bash

logs2logs-db_1                   | [2020-02-28T06:56:12,995][WARN ][logstash.inputs.rabbitmq ]
Error while setting up connection for rabbitmq input! Will retry.
{:message=>"#method<channel.close>(reply-code=404, reply-text=NOT_FOUND - no exchange 'lagoon-logs' in vhost '/', class-id=50, method-id=20)",
:class=>"MarchHare::ChannelAlreadyClosed", :location=>"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/march_hare-3.1.1-java/lib/march_hare/exceptions.rb:121:in `convert_and_reraise'"}
```

This is because the `lagoon-logs` rabbitmq exchange may not exist yet (if the `api` hasn't started and declared it yet, for example). It's possible to configure the logstash pipeline in a way that will allow it to create the rabbitmq exchange if it doesn't yet exist.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
n/a
