### PR TITLE
K8s DBaaS Operator improvments

### DIFF
--- a/charts/dbaas-operator.yaml
+++ b/charts/dbaas-operator.yaml
@@ -39,25 +39,50 @@ spec:
         spec:
           description: MariaDBConsumerSpec defines the desired state of MariaDBConsumer
           properties:
+            consumer:
+              description: MariaDBConsumerData defines the provider link for this
+                consumer
+              properties:
+                database:
+                  type: string
+                password:
+                  type: string
+                services:
+                  description: MariaDBConsumerServices defines the provider link for
+                    this consumer
+                  properties:
+                    primary:
+                      type: string
+                    replicas:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                username:
+                  type: string
+              type: object
             environment:
               description: These are the spec options for consumers
               type: string
-            mariadb_database:
-              type: string
-            mariadb_hostname:
-              type: string
-            mariadb_password:
-              type: string
-            mariadb_port:
-              type: string
-            mariadb_readreplica_hostname:
-              type: string
-            mariadb_user:
-              type: string
-            service_mariadb_hostname:
-              type: string
-            service_mariadb_readreplica_hostname:
-              type: string
+            provider:
+              description: MariaDBConsumerProvider defines the provider link for this
+                consumer
+              properties:
+                hostname:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                port:
+                  type: string
+                readReplicas:
+                  items:
+                    type: string
+                  type: array
+                type:
+                  type: string
+              type: object
           type: object
         status:
           description: MariaDBConsumerStatus defines the observed state of MariaDBConsumer
@@ -112,15 +137,23 @@ spec:
             environment:
               description: These are the spec options for providers
               type: string
-            mariadb_hostname:
+            hostname:
               type: string
-            mariadb_password:
+            name:
               type: string
-            mariadb_port:
+            namespace:
               type: string
-            mariadb_readreplica_hostname:
+            password:
               type: string
-            mariadb_user:
+            port:
+              type: string
+            readReplicaHostnames:
+              items:
+                type: string
+              type: array
+            type:
+              type: string
+            user:
               type: string
           type: object
         status:
@@ -337,7 +370,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: amazeeio/dbaas-operator:testingv1
+        image: amazeeio/dbaas-operator:v0.1.0
         name: manager
         resources:
           limits:

--- a/charts/dbaas-providers.yaml
+++ b/charts/dbaas-providers.yaml
@@ -4,9 +4,9 @@ metadata:
   name: mariadbprovider-development
 spec:
   environment: development
-  hostname: 172.17.0.1.xip.io
+  hostname: 172.17.0.1.nip.io
   readreplica_hostnames:
-  - 172.17.0.1.xip.io
+  - 172.17.0.1.nip.io
   password: password
   port: '3306'
   user: root
@@ -17,9 +17,9 @@ metadata:
   name: mariadbprovider-production
 spec:
   environment: production
-  hostname: 172.17.0.1.xip.io
+  hostname: 172.17.0.1.nip.io
   readreplica_hostnames:
-  - 172.17.0.1.xip.io
+  - 172.17.0.1.nip.io
   password: password
   port: '3306'
   user: root

--- a/charts/dbaas-providers.yaml
+++ b/charts/dbaas-providers.yaml
@@ -4,9 +4,9 @@ metadata:
   name: mariadbprovider-development
 spec:
   environment: development
-  hostname: 172.17.0.1.nip.io
+  hostname: development.172.17.0.1.nip.io
   readreplica_hostnames:
-  - 172.17.0.1.nip.io
+  - development.replica.172.17.0.1.nip.io
   password: password
   port: '3306'
   user: root
@@ -17,9 +17,9 @@ metadata:
   name: mariadbprovider-production
 spec:
   environment: production
-  hostname: 172.17.0.1.nip.io
+  hostname: production.172.17.0.1.nip.io
   readreplica_hostnames:
-  - 172.17.0.1.nip.io
+  - production.replica.172.17.0.1.nip.io
   password: password
   port: '3306'
   user: root


### PR DESCRIPTION
This brings the operator installation inline with the recent `v0.1.0` release of the operator.
This includes the `type` option which currently only supports `azure` everything else is just default MariaDB/MySQL.

It also tells provider config to use `nip.io` for the dns as it is more stable than `xip.io` has been after multiple tests are run.

Or should we be looking to use https://github.com/amazeeio/dbaas-operator/pull/14 at some stage.