### PR TITLE
Add `drush uli` task to API and UI

### DIFF
--- a/docs/administering_lagoon/rbac.md
+++ b/docs/administering_lagoon/rbac.md
@@ -142,6 +142,8 @@ Here is a table that lists the roles and the access they have:
 | taskDrushCacheClear | task | drushCacheClear:production | projectID | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
 | taskDrushCron | task | drushCron:development | projectID | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
 | taskDrushCron | task | drushCron:production | projectID | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
+| taskDrushUserLogin | task | drushUserLogin:destination:production | EnvironmentID | Yes | Yes | Yes | Yes | No | No | No |  |
+| taskDrushUserLogin | task | drushUserLogin:destination:development | EnvironmentID | Yes | Yes | Yes | Yes | Yes | No | No |  |
 | taskDrushSqlSync | task | drushSqlSync:source:development | ProjectID | Yes | Yes | Yes | Yes | Yes | No | No |  |
 | taskDrushSqlSync | task | drushSqlSync:source:production | ProjectID | Yes | Yes | Yes | Yes | Yes | No | No |  |
 | taskDrushSqlSync | task | drushSqlSync:destination:production | ProjectID | Yes | Yes | Yes | Yes | No | No | No |  |
@@ -164,4 +166,3 @@ Here is a table that lists the roles and the access they have:
 | getProjectByEnvironmentId | project | viewPrivateKey | projectID | Yes | Yes | Yes | No | No | No | No |  |
 | getProjectByGitUrl | project | viewPrivateKey | projectID | Yes | Yes | Yes | No | No | No | No |  |
 | getProjectByName | project | viewPrivateKey | projectID | Yes | Yes | Yes | No | No | No | No |  |
-

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -29,6 +29,7 @@ const {
   taskDrushCron,
   taskDrushSqlSync,
   taskDrushRsyncFiles,
+  taskDrushUserLogin,
   taskSubscriber,
 } = require('./resources/task/resolvers');
 
@@ -336,6 +337,7 @@ const resolvers /* : { [string]: ResolversObj | typeof GraphQLDate } */ = {
     taskDrushCron,
     taskDrushSqlSync,
     taskDrushRsyncFiles,
+    taskDrushUserLogin,
     deleteTask,
     updateTask,
     setEnvironmentServices,

--- a/services/api/src/resources/task/resolvers.js
+++ b/services/api/src/resources/task/resolvers.js
@@ -460,6 +460,29 @@ const taskDrushRsyncFiles = async (
   return taskData;
 };
 
+const taskDrushUserLogin = async (
+  root,
+  { environment: environmentId },
+  { sqlClient, hasPermission },
+) => {
+  await envValidators(sqlClient).environmentExists(environmentId);
+  await envValidators(sqlClient).environmentHasService(environmentId, 'cli');
+  const envPerm = await environmentHelpers(sqlClient).getEnvironmentById(environmentId);
+  await hasPermission('task', `drushUserLogin:${envPerm.environmentType}`, {
+    project: envPerm.project,
+  });
+
+  const taskData = await Helpers(sqlClient).addTask({
+    name: 'Drush uli',
+    environment: environmentId,
+    service: 'cli',
+    command: `drush uli`,
+    execute: true,
+  });
+
+  return taskData;
+};
+
 const taskSubscriber = createEnvironmentFilteredSubscriber([
   EVENTS.TASK.ADDED,
   EVENTS.TASK.UPDATED,
@@ -477,6 +500,7 @@ const Resolvers /* : ResolversObj */ = {
   taskDrushCron,
   taskDrushSqlSync,
   taskDrushRsyncFiles,
+  taskDrushUserLogin,
   taskSubscriber,
 };
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1252,6 +1252,7 @@ const typeDefs = gql`
       sourceEnvironment: Int!
       destinationEnvironment: Int!
     ): Task
+    taskDrushUserLogin(environment: Int!): Task
     deleteTask(input: DeleteTaskInput!): String
     updateTask(input: UpdateTaskInput): Task
     setEnvironmentServices(input: SetEnvironmentServicesInput!): [EnvironmentService]

--- a/services/ui/src/components/AddTask/components/DrushUserLogin.js
+++ b/services/ui/src/components/AddTask/components/DrushUserLogin.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Mutation } from 'react-apollo';
+import gql from 'graphql-tag';
+import ReactSelect from 'react-select';
+import Button from 'components/Button';
+import { bp, color, fontSize } from 'lib/variables';
+
+const taskDrushUserLogin = gql`
+  mutation taskDrushUserLogin($environment: Int!) {
+    taskDrushUserLogin(environment: $environment) {
+      id
+      name
+      status
+      created
+      started
+      completed
+      remoteId
+      command
+      service
+    }
+  }
+`;
+
+const DrushUserLogin = ({ pageEnvironment, onCompleted, onError }) => (
+  <Mutation
+    mutation={taskDrushUserLogin}
+    onCompleted={onCompleted}
+    onError={onError}
+    variables={{
+      environment: pageEnvironment.id
+    }}
+  >
+    {(taskDrushUserLogin, { loading, called, error, data }) => {
+      return (
+        <React.Fragment>
+          <div className="envSelect">
+            <label id="dest-env">Environment:</label>
+            <ReactSelect
+              aria-labelledby="dest-env"
+              name="dest-environment"
+              value={{
+                label: pageEnvironment.name,
+                value: pageEnvironment.id
+              }}
+              options={[
+                {
+                  label: pageEnvironment.name,
+                  value: pageEnvironment.id
+                }
+              ]}
+              isDisabled
+              required
+            />
+          </div>
+          <Button action={taskDrushUserLogin}>Add task</Button>
+          <style jsx>{`
+            .envSelect {
+              margin: 10px 0;
+            }
+          `}</style>
+        </React.Fragment>
+      );
+    }}
+  </Mutation>
+);
+
+export default DrushUserLogin;

--- a/services/ui/src/components/AddTask/components/DrushUserLogin.js.ignore
+++ b/services/ui/src/components/AddTask/components/DrushUserLogin.js.ignore
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Mutation } from 'react-apollo';
+import gql from 'graphql-tag';
+import ReactSelect from 'react-select';
+import Button from 'components/Button';
+import { bp, color, fontSize } from 'lib/variables';
+
+const taskDrushUserLogin = gql`
+  mutation taskDrushUserLogin($environment: Int!) {
+    taskDrushUserLogin(environment: $environment) {
+      id
+      name
+      status
+      created
+      started
+      completed
+      remoteId
+      command
+      service
+    }
+  }
+`;
+
+const DrushUserLogin = ({
+  pageEnvironment,
+  onCompleted,
+  onError,
+}) => (
+  <Mutation
+    mutation={taskDrushUserLogin}
+    onCompleted={onCompleted}
+    onError={onError}
+  >
+    {(taskDrushUserLogin, { loading, called, error, data }) => {
+      return (
+        <React.Fragment>
+          <div className="envSelect">
+            <label id="dest-env">Environment:</label>
+            <ReactSelect
+              aria-labelledby="dest-env"
+              name="dest-environment"
+              value={{
+                label: pageEnvironment.name,
+                value: pageEnvironment.id
+              }}
+              options={[
+                {
+                  label: pageEnvironment.name,
+                  value: pageEnvironment.id
+                }
+              ]}
+              isDisabled
+              required
+            />
+          </div>
+          <Button action={taskDrushUserLogin}>Add task</Button>
+          <style jsx>{`
+            .envSelect {
+              margin: 10px 0;
+            }
+          `}</style>
+        </React.Fragment>
+      );
+    }}
+  </Mutation>
+);
+
+export default DrushUserLogin;

--- a/services/ui/src/components/AddTask/index.js
+++ b/services/ui/src/components/AddTask/index.js
@@ -7,6 +7,7 @@ import DrushCacheClear from './components/DrushCacheClear';
 import DrushCron from './components/DrushCron';
 import DrushRsyncFiles from './components/DrushRsyncFiles';
 import DrushSqlSync from './components/DrushSqlSync';
+import DrushUserLogin from './components/DrushUserLogin';
 import Empty from './components/Empty';
 import Completed from './components/Completed';
 import Error from './components/Error';
@@ -31,6 +32,7 @@ const AddTask = ({
     DrushCron,
     DrushRsyncFiles,
     DrushSqlSync,
+    DrushUserLogin,
     Empty,
     Completed,
     Error

--- a/services/ui/src/components/AddTask/logic.js
+++ b/services/ui/src/components/AddTask/logic.js
@@ -36,6 +36,10 @@ const withOptions = withProps(({ pageEnvironment }) => {
     {
       label: 'Generate database and files backup (Drush 8 only) [drush archive-dump]',
       value: 'DrushArchiveDump'
+    },
+    {
+      label: 'Generate login link [drush uli]',
+      value: 'DrushUserLogin'
     }
   ];
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Adds the ability to request a one-time login link from Drupal sites via the command `drush user-login`, available directly via the GraphQL API or the UI.

# Closing issues
closes #1705 
