### PR TITLE
Remove tty creation of ssh call inside drush aliases

### DIFF
--- a/services/drush-alias/web/aliases.drushrc.php.stub
+++ b/services/drush-alias/web/aliases.drushrc.php.stub
@@ -181,7 +181,7 @@ if (isset($cache->data) && time() < $cache->expire && getenv('LAGOON_IGNORE_DRUS
 // can set an env var `LAGOON_OVERRIDE_SSH_TIMEOUT=<val>` or define `ssh_port_timeout: <val>` in `.lagoon.yml` to a time in seconds to fail sooner and let user know why
 // if there is no defined timeout further up, set a value
 if (empty($ssh_port_timeout)) {
-  $ssh_port_timeout = 10; //default timeout
+  $ssh_port_timeout = 30; //default timeout
 }
 $ssh_port_check = @fsockopen($ssh_host, $ssh_port, $errno, $errstr, $ssh_port_timeout);
 if (is_resource($ssh_port_check))

--- a/services/drush-alias/web/aliases.drushrc.php.stub
+++ b/services/drush-alias/web/aliases.drushrc.php.stub
@@ -207,7 +207,7 @@ if (getenv('LAGOON_OVERRIDE_JWT_TOKEN')) {
 } else {
   // if ssh takes too long to get a token, timeout with the same ssh port timeout used to check the port status
   // this could be because the API is unavailable
-  exec("timeout $ssh_port_timeout ssh -p $ssh_port -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t lagoon@$ssh_host token 2>&1", $token_array, $rc);
+  exec("timeout --foreground $ssh_port_timeout ssh -p $ssh_port -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t lagoon@$ssh_host token 2>&1", $token_array, $rc);
   if ($rc !== 0) {
     drush_log("Could not load API JWT Token, error was: '" . implode(",", $token_array), 'warning');
     return;

--- a/services/drush-alias/web/aliases.drushrc.php.stub
+++ b/services/drush-alias/web/aliases.drushrc.php.stub
@@ -207,7 +207,7 @@ if (getenv('LAGOON_OVERRIDE_JWT_TOKEN')) {
 } else {
   // if ssh takes too long to get a token, timeout with the same ssh port timeout used to check the port status
   // this could be because the API is unavailable
-  exec("timeout --foreground $ssh_port_timeout ssh -p $ssh_port -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t lagoon@$ssh_host token 2>&1", $token_array, $rc);
+  exec("timeout $ssh_port_timeout ssh -p $ssh_port -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no lagoon@$ssh_host token 2>&1", $token_array, $rc);
   if ($rc !== 0) {
     drush_log("Could not load API JWT Token, error was: '" . implode(",", $token_array), 'warning');
     return;


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Quick fix that solves the issue of a `tcsetattr` error that appeared when using drush aliases
```
Could not load API JWT Token, error was: 'tcsetattr: Interrupted system call
```

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->