### PR TITLE
#1722 Pin curl to Version 7.69.1-r0

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -42,6 +42,11 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
 ENV NEWRELIC_VERSION=9.6.0.255
 
+# Pin curl to Version 7.69.1-r0 as the current shipped one 7.67.0 has a bug, see
+# https://github.com/curl/curl/issues/4624
+# TODO: Remove as soon as Alpine 3.11 is shipped with a version higher than 7.67.0
+RUN apk add --no-cache curl=7.69.1-r0 libcurl=7.69.1-r0 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
+
 RUN apk add --no-cache fcgi \
         ssmtp \
         libzip libzip-dev \


### PR DESCRIPTION
Pin curl to Version 7.69.1-r0 as the current shipped one 7.67.0 has a bug, see
https://github.com/curl/curl/issues/4624

# Closing issues
Put `closes #1722` in your comment to auto-close the issue that your PR fixes (if such).
