### PR TITLE
Deleting environment variable permission issue - Hot Fix

### DIFF
--- a/services/api/src/resources/env-variables/resolvers.js
+++ b/services/api/src/resources/env-variables/resolvers.js
@@ -156,6 +156,7 @@ const addEnvVariableToEnvironment = async (
       value,
       scope,
       environment: typeId,
+      project: environment.project,
     }),
   );
 

--- a/services/api/src/resources/env-variables/resolvers.js
+++ b/services/api/src/resources/env-variables/resolvers.js
@@ -156,7 +156,6 @@ const addEnvVariableToEnvironment = async (
       value,
       scope,
       environment: typeId,
-      project: environment.project,
     }),
   );
 

--- a/services/api/src/resources/env-variables/sql.js
+++ b/services/api/src/resources/env-variables/sql.js
@@ -50,7 +50,11 @@ const Sql /* : SqlObj */ = {
     knex('env_vars')
       .select({ pid: 'project.id' })
       .leftJoin('environment', 'env_vars.environment', '=', 'environment.id')
-      .leftJoin('project', 'environment.project', '=', 'project.id')
+      .leftJoin('project', function () {
+        this
+          .on('env_vars.project', '=', 'project.id')
+          .orOn('environment.project', '=', 'project.id')
+      })
       .where('env_vars.id', id)
       .toString(),
 };

--- a/services/api/src/resources/env-variables/sql.js
+++ b/services/api/src/resources/env-variables/sql.js
@@ -50,7 +50,7 @@ const Sql /* : SqlObj */ = {
     knex('env_vars')
       .select({ pid: 'project.id' })
       .leftJoin('environment', 'env_vars.environment', '=', 'environment.id')
-      .leftJoin('project', 'env_vars.project', '=', 'project.id')
+      .leftJoin('project', 'environment.project', '=', 'project.id')
       .where('env_vars.id', id)
       .toString(),
 };


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

The issue stemmed from trying to call the `hasPermission` function without a project id. The project ID was not being set when the environment variable was being added and the query to get the `perms` requires a project ID saved in the database otherwise it will return `NULL`

```
select `project`.`id` as `pid` from `env_vars` left join `environment` on `env_vars`.`environment` = `environment`.`id` left join `project` on `env_vars`.`project` =  `project`.`id` where `env_vars`.`id` = 8
```

https://github.com/amazeeio/lagoon/blob/205acc7c97f89f3c6955e7abfe5fa1c5fae85a55/services/api/src/resources/env-variables/resolvers.js#L175

Tested this by adding/deleting an environment variable using a JWT from a user with the same roles as the issue describes. Everything worked as expected. 


# Closing issues
closes #1740
