### PR TITLE
Bug fix: Self-Service ssh key adds `_` if the ssh key has a comment

### DIFF
--- a/services/api/src/resources/sshKey/resolvers.js
+++ b/services/api/src/resources/sshKey/resolvers.js
@@ -43,7 +43,9 @@ const addSshKey = async (
   { sqlClient, hasPermission, models },
 ) => {
   const keyType = sshKeyTypeToString(unformattedKeyType);
-  const keyFormatted = formatSshKey({ keyType, keyValue });
+  // handle key being sent as "ssh-rsa SSHKEY foo@bar.baz" as well as just the SSHKEY
+  const keyValueParts = keyValue.split(' ');
+  const keyFormatted = formatSshKey({ keyType, keyValue: keyValueParts.length > 1 ? keyValueParts[1] : keyValue });
 
   if (!validateSshKey(keyFormatted)) {
     throw new Error('Invalid SSH key format! Please verify keyType + keyValue');


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

# Changelog Entry
This handles public keys that are copy/pasted directly that include `type key comment` as well as just `key`


# Closing issues
`closes #1725`
