### PR TITLE
Improve shared-to-shared-migrate script

### DIFF
--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -144,16 +144,16 @@ fi
 SECRETS=/tmp/${NAMESPACE}-migration.yaml
 oc -n ${NAMESPACE} get secret mariadb-servicebroker-credentials -o yaml > $SECRETS
 
-DB_NETWORK_SERVICE=$(cat $SECRETS | shyaml get-value data.DB_HOST | base64 -D)
+DB_NETWORK_SERVICE=$(cat $SECRETS | shyaml get-value data.DB_HOST | base64 -d)
 if cat ${SECRETS} | grep DB_READREPLICA_HOSTS > /dev/null ; then
-  DB_READREPLICA_HOSTS=$(cat $SECRETS | shyaml get-value data.DB_READREPLICA_HOSTS | base64 -D)
+  DB_READREPLICA_HOSTS=$(cat $SECRETS | shyaml get-value data.DB_READREPLICA_HOSTS | base64 -d)
 else
   DB_READREPLICA_HOSTS=""
 fi
-DB_USER=$(cat $SECRETS | shyaml get-value data.DB_USER | base64 -D)
-DB_PASSWORD=$(cat $SECRETS | shyaml get-value data.DB_PASSWORD | base64 -D)
-DB_NAME=$(cat $SECRETS | shyaml get-value data.DB_NAME | base64 -D)
-DB_PORT=$(cat $SECRETS | shyaml get-value data.DB_PORT | base64 -D)
+DB_USER=$(cat $SECRETS | shyaml get-value data.DB_USER | base64 -d)
+DB_PASSWORD=$(cat $SECRETS | shyaml get-value data.DB_PASSWORD | base64 -d)
+DB_NAME=$(cat $SECRETS | shyaml get-value data.DB_NAME | base64 -d)
+DB_PORT=$(cat $SECRETS | shyaml get-value data.DB_PORT | base64 -d)
 
 shw_grey "================================================"
 shw_grey " DB_NETWORK_SERVICE=$DB_NETWORK_SERVICE"
@@ -238,7 +238,7 @@ shw_info "> Testing the route https://${ROUTE}/?${TIMESTAMP}"
 shw_info "================================================"
 curl -skLIXGET "https://${ROUTE}/?${TIMESTAMP}" \
   -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36" \
-  --cookie "NO_CACHE=1" | grep -E "HTTP|Cache|Location|LAGOON" || TRUE
+  --cookie "NO_CACHE=1" | grep -E "HTTP|Cache|Location|LAGOON" || true
 
 shw_grey "================================================"
 shw_grey ""

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -63,19 +63,34 @@ TIMESTAMP=$(date +%s)
 
 # Colours.
 shw_grey () {
-  echo $(tput bold)$(tput setaf 0) $@ $(tput sgr 0)
+  tput bold
+	tput setaf 0
+	echo "$@"
+	tput sgr0
 }
 shw_norm () {
-  echo $(tput bold)$(tput setaf 9) $@ $(tput sgr 0)
+  tput bold
+	tput setaf 9
+	echo "$@"
+	tput sgr0
 }
 shw_info () {
-  echo $(tput bold)$(tput setaf 4) $@ $(tput sgr 0)
+  tput bold
+	tput setaf 4
+	echo "$@"
+	tput sgr0
 }
 shw_warn () {
-  echo $(tput bold)$(tput setaf 2) $@ $(tput sgr 0)
+  tput bold
+	tput setaf 2
+	echo "$@"
+	tput sgr0
 }
 shw_err ()  {
-  echo $(tput bold)$(tput setaf 1) $@ $(tput sgr 0)
+  tput bold
+	tput setaf 1
+	echo "$@"
+	tput sgr0
 }
 
 # Parse input arguments.

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -254,5 +254,5 @@ echo ""
 shw_grey "================================================"
 shw_grey " END_TIMESTAMP='$(date +%Y-%m-%dT%H:%M:%S%z)'"
 shw_grey "================================================"
-shw_norm "Done"
+shw_norm "Done in $SECONDS seconds"
 exit 0

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -18,7 +18,7 @@
 # ============
 # * You are logged into OpenShift CLI and have access to the NAMESPACE you want
 #   to migrate.
-# * You have a `.my.cnf` file for the desintation database cluster.
+# * You have a `.my.cnf` file for the destination database cluster.
 # * If your destination database cluster is not directly accessible, then you
 #   have created SSH tunnels to expose them on a local port.
 #

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -230,7 +230,7 @@ shw_info "================================================"
 oc -n "$NAMESPACE" exec "$POD" -- bash -c "drush status"
 
 # Get routes, and ensure a cache bust works.
-ROUTE=$(oc -n "$NAMESPACE" get routes -o json | jq --raw-output '.items[0].spec.host')
+ROUTE=$(oc -n "$NAMESPACE" get routes -o json | jq -er '.items[0].spec.host')
 shw_info "> Testing the route https://${ROUTE}/?${TIMESTAMP}"
 shw_info "================================================"
 curl -skLIXGET "https://${ROUTE}/?${TIMESTAMP}" \

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -118,6 +118,8 @@ while [[ $# -gt 0 ]] ; do
 done
 
 shw_grey "================================================"
+shw_grey " START_TIMESTAMP='$(date +%Y-%m-%dT%H:%M:%S%z)'"
+shw_grey "================================================"
 shw_grey " DESTINATION_CLUSTER=$DESTINATION_CLUSTER"
 shw_grey " REPLICA_CLUSTER=$REPLICA_CLUSTER"
 shw_grey " NAMESPACE=$NAMESPACE"
@@ -249,5 +251,8 @@ if [ "$DB_READREPLICA_HOSTS" ]; then
 fi
 
 echo ""
+shw_grey "================================================"
+shw_grey " END_TIMESTAMP='$(date +%Y-%m-%dT%H:%M:%S%z)'"
+shw_grey "================================================"
 shw_norm "Done"
 exit 0

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -136,12 +136,6 @@ for util in oc jq mysql shyaml; do
 	fi
 done
 
-CONF_FILE=${HOME}/.my.cnf-${SOURCE_CLUSTER}
-if [ ! -f "$CONF_FILE" ]; then
-  shw_err "ERROR: please create $CONF_FILE so I can know how to connect to ${SOURCE_CLUSTER}"
-  exit 2
-fi
-
 CONF_FILE=${HOME}/.my.cnf-${DESTINATION_CLUSTER}
 if [ ! -f "$CONF_FILE" ]; then
   shw_err "ERROR: please create $CONF_FILE so I can know how to connect to ${DESTINATION_CLUSTER}"

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -194,7 +194,7 @@ shw_norm "================================================"
 shw_info "> Importing the dump into ${DESTINATION_CLUSTER}"
 shw_info "================================================"
 oc -n "$NAMESPACE" exec "$POD" -- bash -c "time mysql -h '$DESTINATION_CLUSTER' -u '$DB_USER' -p'$DB_PASSWORD' '$DB_NAME' < /tmp/migration.sql"
-oc -n "$NAMESPACE" exec "$POD" -- bash -c "rm /tmp/migration.sql"
+oc -n "$NAMESPACE" exec "$POD" -- rm /tmp/migration.sql
 
 shw_norm "> Import is done"
 shw_norm "================================================"

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -39,13 +39,29 @@
 # =======================================================================
 # ssh -L 33007:shared-cluster.cluster-banana.ap-southeast-2.rds.amazonaws.com:3306 jumpbox.aws.amazee.io
 #
-# Example commands
-# ================
+# Example command 1
+# =================
 # ./helpers/shared-to-shared-migrate.sh \
 # --destination shared-cluster.cluster-apple.ap-southeast-2.rds.amazonaws.com \
 # --replica shared-cluster.cluster-r0-apple.ap-southeast-2.rds.amazonaws.com \
 # --namespace NAMESPACE \
 # --dry-run
+#
+# Example command 2
+# =================
+# namespaces="
+# foo-example-com-production
+# bar-example-com-production
+# baz-example-com-production
+# quux-example-com-production
+# "
+# for namespace in $namespaces; do
+# 	./helpers/shared-to-shared-migrate.sh \
+# 		--dry-run \
+# 		--namespace "$namespace" \
+# 		--destination shared-mysql-production-1-cluster.cluster-plum.ap-southeast-2.rds.amazonaws.com \
+# 		--replica shared-mysql-production-1-cluster.cluster-ro-plum.ap-southeast-2.rds.amazonaws.com
+# done
 #
 set -euo pipefail
 

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -180,7 +180,7 @@ shw_info "================================================"
 mysql --defaults-file="$CONF_FILE" -e "SELECT * FROM mysql.db WHERE Db = '${DB_NAME}'\G;"
 
 # Dump the database inside the CLI pod.
-POD=$(oc -n "$NAMESPACE" get pods -o json --show-all=false -l service=cli | jq -er '.items[].metadata.name')
+POD=$(oc -n "$NAMESPACE" get pods -o json --field-selector=status.phase=Running -l service=cli | jq -er '.items[0].metadata.name')
 shw_info "> Dumping database $DB_NAME on pod $POD on host $DB_NETWORK_SERVICE"
 shw_info "================================================"
 oc -n "$NAMESPACE" exec "$POD" -- bash -c "time mysqldump -h '$DB_NETWORK_SERVICE' -u '$DB_USER' -p'$DB_PASSWORD' '$DB_NAME' > /tmp/migration.sql"

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -184,9 +184,9 @@ POD=$(oc -n "$NAMESPACE" get pods -o json --show-all=false -l service=cli | jq -
 shw_info "> Dumping database $DB_NAME on pod $POD on host $DB_NETWORK_SERVICE"
 shw_info "================================================"
 oc -n "$NAMESPACE" exec "$POD" -- bash -c "time mysqldump -h '$DB_NETWORK_SERVICE' -u '$DB_USER' -p'$DB_PASSWORD' '$DB_NAME' > /tmp/migration.sql"
-oc -n "$NAMESPACE" exec "$POD" -- ls -lath /tmp/migration.sql || exit 1
+oc -n "$NAMESPACE" exec "$POD" -- ls -lath /tmp/migration.sql
 oc -n "$NAMESPACE" exec "$POD" -- head -n 5 /tmp/migration.sql
-oc -n "$NAMESPACE" exec "$POD" -- tail -n 5 /tmp/migration.sql || exit 1
+oc -n "$NAMESPACE" exec "$POD" -- tail -n 5 /tmp/migration.sql
 shw_norm "> Dump is done"
 shw_norm "================================================"
 

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -24,7 +24,7 @@
 #
 # How to get your existing ASB root credentials
 # =============================================
-# oc -n openshift-ansible-service-broker get secret/lagoon-dbaas-db-credentials -o JSON | jq '.data'
+# oc -n openshift-ansible-service-broker get secret/lagoon-dbaas-db-credentials -o json | jq '.data | map_values(@base64d)'
 #
 # How to create a `.my.cnf` file
 # ==============================

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -191,7 +191,7 @@ fi
 shw_info "> Dumping database $DB_NAME on pod $POD on host $DB_NETWORK_SERVICE"
 shw_info "================================================"
 oc -n "$NAMESPACE" exec "$POD" -- bash -c "time mysqldump -h '$DB_NETWORK_SERVICE' -u '$DB_USER' -p'$DB_PASSWORD' '$DB_NAME' > /tmp/migration.sql"
-oc -n "$NAMESPACE" exec "$POD" -- ls -lath /tmp/migration.sql
+oc -n "$NAMESPACE" exec "$POD" -- ls -lh /tmp/migration.sql
 oc -n "$NAMESPACE" exec "$POD" -- head -n 5 /tmp/migration.sql
 oc -n "$NAMESPACE" exec "$POD" -- tail -n 5 /tmp/migration.sql
 shw_norm "> Dump is done"

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -206,7 +206,7 @@ ORIGINAL_DB_HOST=$(oc -n "$NAMESPACE" get "svc/$DB_NETWORK_SERVICE" -o json --ex
 if [ "$DRY_RUN" ] ; then
   echo "**DRY RUN**"
 else
-  oc -n "$NAMESPACE" patch "svc/$DB_NETWORK_SERVICE" -p "{\"spec\":{\"externalName\": \"${DESTINATION_CLUSTER}\"}}"
+  oc -n "$NAMESPACE" patch "svc/$DB_NETWORK_SERVICE" -p "{\"spec\":{\"externalName\": \"$DESTINATION_CLUSTER\"}}"
 fi
 if [ "$DB_READREPLICA_HOSTS" ]; then
   shw_info "> Altering the Network Service $DB_READREPLICA_HOSTS to point at $REPLICA_CLUSTER"
@@ -215,7 +215,7 @@ if [ "$DB_READREPLICA_HOSTS" ]; then
   if [ "$DRY_RUN" ] ; then
     echo "**DRY RUN**"
   else
-    oc -n "$NAMESPACE" patch "svc/$DB_READREPLICA_HOSTS" -p '{"spec":{"externalName": "'"$REPLICA_CLUSTER"'"}}'
+    oc -n "$NAMESPACE" patch "svc/$DB_READREPLICA_HOSTS" -p "{\"spec\":{\"externalName\": \"$REPLICA_CLUSTER\"}}"
   fi
 fi
 

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -241,9 +241,9 @@ shw_grey "================================================"
 shw_grey ""
 shw_grey "In order to rollback this change, edit the Network Service(s) like so:"
 shw_grey ""
-shw_grey "oc -n ${NAMESPACE} patch svc/${DB_NETWORK_SERVICE} -p \"{\\\"spec\\\":{\\\"externalName': \\\"${ORIGINAL_DB_HOST}\\\"}}\""
+shw_grey "oc -n $NAMESPACE patch svc/$DB_NETWORK_SERVICE -p '{\"spec\":{\"externalName\": \"$ORIGINAL_DB_HOST\"}}'"
 if [ "$DB_READREPLICA_HOSTS" ]; then
-  shw_grey "oc -n ${NAMESPACE} patch svc/${DB_READREPLICA_HOSTS} -p \"{\\\"spec\\\":{\\\"externalName': \\\"${ORIGINAL_DB_READREPLICA_HOSTS}\\\"}}\""
+  shw_grey "oc -n $NAMESPACE patch svc/$DB_READREPLICA_HOSTS -p '{\"spec\":{\"externalName\": \"$ORIGINAL_DB_READREPLICA_HOSTS\"}}'"
 fi
 
 echo ""

--- a/helpers/shared-to-shared-migrate.sh
+++ b/helpers/shared-to-shared-migrate.sh
@@ -90,9 +90,7 @@ shw_err ()  {
 
 # Parse input arguments.
 while [[ $# -gt 0 ]] ; do
-  key="$1"
-
-  case $key in
+  case $1 in
     -d|--destination)
     DESTINATION_CLUSTER="$2"
     shift # past argument
@@ -111,6 +109,10 @@ while [[ $# -gt 0 ]] ; do
     --dry-run)
     DRY_RUN="TRUE"
     shift # past argument
+    ;;
+    *)
+		echo "Invalid Argument: $1"
+		exit 3
     ;;
   esac
 done


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR makes a few changes to `shared-to-shared-migrate.sh`:
* remove `shyaml` dependency in favour of pure `jq`
* remove the `--source` argument, instead storing the original host from the network service
* remove `base64` dependency by using built-in `jq` functionality. This was a cross-platform issue because macOS uses `base64 -D`, while GNU uses `base64 -d`.
* auto-scale the `cli` deployment if there are no `cli` pods running
* display total runtime
* fix various minor lint and cross-platform issues

# Closing issues
n/a
