### PR TITLE
Expose Lagoon tag/version in UI and API

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -4,6 +4,10 @@ const GraphQLDate = require('graphql-iso-date');
 const GraphQLJSON = require('graphql-type-json');
 
 const {
+  getLagoonVersion,
+} = require('./resources/lagoon/resolvers');
+
+const {
   getDeploymentsByEnvironmentId,
   getDeploymentByRemoteId,
   addDeployment,
@@ -263,6 +267,7 @@ const resolvers /* : { [string]: ResolversObj | typeof GraphQLDate } */ = {
   },
   Query: {
     me: getMe,
+    lagoonVersion: getLagoonVersion,
     userBySshKey: getUserBySshKey,
     projectByGitUrl: getProjectByGitUrl,
     projectByName: getProjectByName,

--- a/services/api/src/resources/lagoon/resolvers.ts
+++ b/services/api/src/resources/lagoon/resolvers.ts
@@ -1,0 +1,5 @@
+
+export const getLagoonVersion = async (_root, args, { models, keycloakGrant: grant }) => {
+  let lagoonVersion = process.env.LAGOON_VERSION
+  return lagoonVersion;
+}

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -618,6 +618,10 @@ const typeDefs = gql`
     Returns the Billing Group Modifiers for a given Billing Group (all modifiers for the Billing Group will be returned if the month is not provided)
     """
     allBillingModifiers(input: GroupInput!, month: String): [BillingModifier]
+    """
+    Returns LAGOON_VERSION
+    """
+    lagoonVersion: JSON
   }
 
   # Must provide id OR name

--- a/services/ui/src/components/Footer/index.js
+++ b/services/ui/src/components/Footer/index.js
@@ -1,16 +1,46 @@
 import React from 'react';
 import { color } from 'lib/variables';
+import getConfig from 'next/config';
+const { publicRuntimeConfig } = getConfig();
 
-/**
- * This component appears to be unused.
- */
 const Footer = () => (
   <footer>
-    Placeholder footer
+  <span className="version">Lagoon {`${publicRuntimeConfig.LAGOON_VERSION}`}</span>
     <style jsx>{`
       footer {
-        background: ${color.grey};
-        padding: 10px 20px;
+        background: ${color.brightBlue} ${color.lightBlue};
+        background: ${color.lightBlue};
+        background: -moz-linear-gradient(left, ${color.brightBlue} 0%, ${color.lightBlue} 25%);
+        background: -webkit-linear-gradient(left, ${color.brightBlue} 0%,${color.lightBlue} 25%);
+        background: linear-gradient(to right, ${color.brightBlue} 0%,${color.lightBlue} 25%);
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='${color.brightBlue}', endColorstr='${color.lightBlue}',GradientType=1 );
+        display: flex;
+        justify-content: space-between;
+
+        span {
+          color: ${color.almostWhite};
+          padding: 10px 20px;
+          &.version {
+            background: ${color.blue};
+            position: relative;
+            img {
+              display: block;
+              height: 28px;
+              width: auto;
+            }
+            &::after {
+              background: ${color.blue};
+              clip-path: polygon(0 0,100% 0,0 105%,0 100%);
+              content: '';
+              display: block;
+              height: 100%;
+              position: absolute;
+              right: -13px;
+              top: 0;
+              width: 14px;
+            }
+          }
+        }
       }
   `}</style>
   </footer>

--- a/services/ui/src/layouts/MainLayout/index.js
+++ b/services/ui/src/layouts/MainLayout/index.js
@@ -1,5 +1,6 @@
 import GlobalStyles from 'layouts/GlobalStyles';
 import Header from 'components/Header';
+import Footer from 'components/Footer';
 
 /**
  * The main layout includes the Lagoon UI header.
@@ -8,6 +9,7 @@ const MainLayout = ({ children }) => (
   <GlobalStyles>
     <Header />
     { children }
+    <Footer />
   </GlobalStyles>
 );
 

--- a/services/ui/src/layouts/StatusLayout/index.js
+++ b/services/ui/src/layouts/StatusLayout/index.js
@@ -1,5 +1,6 @@
 import GlobalStlyes from 'layouts/GlobalStyles';
 import Header from 'components/Header';
+import Footer from 'components/Footer';
 import { bp } from 'lib/variables';
 
 /**
@@ -27,6 +28,7 @@ const StatusLayout = ({ children }) => (
         }
       }
     `}</style>
+    <Footer />
   </GlobalStlyes>
 );
 

--- a/services/ui/src/next.config.js
+++ b/services/ui/src/next.config.js
@@ -14,6 +14,8 @@ const lagoonKeycloakRoute = lagoonRoutes.find(routes =>
 );
 const envKeycloakRoute = process.env.KEYCLOAK_API;
 
+const lagoonVersion = process.env.LAGOON_VERSION;
+
 const taskBlacklist =
   (process.env.LAGOON_UI_TASK_BLACKLIST &&
     process.env.LAGOON_UI_TASK_BLACKLIST.split(',')) ||
@@ -27,7 +29,8 @@ module.exports = withCSS({
       ? `${lagoonKeycloakRoute}/auth`
       : envKeycloakRoute,
     LAGOON_UI_ICON: process.env.LAGOON_UI_ICON,
-    LAGOON_UI_TASK_BLACKLIST: taskBlacklist
+    LAGOON_UI_TASK_BLACKLIST: taskBlacklist,
+    LAGOON_VERSION: lagoonVersion
   },
   distDir: '../build',
   webpack(config, options) {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Being able to know which version of Lagoon is currently running via the UI or API is handy when knowing which mutations/queries are supported, or quickly checking which version is running to know what feature set is available.

This PR adds the following query, which just exposes the `LAGOON_VERSION` environment variable.
```
query lagoonVersion {
  lagoonVersion
}
```
With the response:
```
{
  "data": {
    "lagoonVersion": "v1.4.0"
  }
}
```

And adds the footer to pages like so
![image](https://user-images.githubusercontent.com/9973880/78524780-5ba04600-7818-11ea-9951-77c05f575bd3.png)

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1384 
