### PR TITLE
Throttling Clair container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,7 @@ logs:
 
 # Start all Lagoon Services
 up:
-	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) up -d
+	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility up -d
 	grep -m 1 ".opendistro_security index does not exist yet" <(docker-compose -p $(CI_BUILD_TAG) logs -f logs-db 2>&1)
 	while ! docker exec "$$(docker-compose -p $(CI_BUILD_TAG) ps -q logs-db)" ./securityadmin_demo.sh; do sleep 5; done
 	$(MAKE) wait-for-keycloak

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -573,6 +573,10 @@ services:
       - SCANNER_STORE_REDIS_URL=redis://harbor-redis:6379/4
       - SCANNER_LOG_LEVEL=error
     restart: on-failure
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
     labels:
       lagoon.type: custom
       lagoon.template: services/harborclair/harborclair.yml


### PR DESCRIPTION
# Checklist
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR prevents CPU resource starvation when Lagoon is first started by throttling the Clair container to only half a CPU core.