### PR TITLE
Redeploy pods if only the configmap is changed

### DIFF
--- a/docs/using_lagoon/lagoon_yml.md
+++ b/docs/using_lagoon/lagoon_yml.md
@@ -111,6 +111,11 @@ Common uses for post-rollout tasks include running `drush updb`, `drush cim`, or
 * `shell`
   * Which shell should be used to run the task in. By default `sh` is used, but if the container also has other shells \(like `bash`, you can define it here\). This is useful if you want to run some small if/else bash scripts within the post-rollouts. \(see the example above how to write a script with multiple lines\).
 
+Note: If you would like to temporarily disable pre/post-rollout tasks during a deployment, you can set either of the following environment variables in the API at the project or environment level \(see how on [Environment Variables](environment_variables.md)\).
+
+* `LAGOON_PREROLLOUT_DISABLED=true`
+* `LAGOON_POSTROLLOUT_DISABLED=true`
+
 ## Routes
 
 ### `routes.autogenerate.enabled`

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -842,7 +842,7 @@ fi
 ## once we have set everything up, check if we modified the configmap in any way, we may need to redeploy
 ADJUSTED_CONFIG_MAP_SHA=$(kubectl --insecure-skip-tls-verify -n ${NAMESPACE} get configmap lagoon-env -o yaml | shyaml get-value data | sha256sum | awk '{print $1}')
 REDEPLOY_IF_CONFIG_CHANGED=false
-if [ "${ADJUSTED_CONFIG_MAP_SHA}" -ne "${CONFIG_MAP_SHA}"]; then
+if [ "${ADJUSTED_CONFIG_MAP_SHA}" -ne "${CONFIG_MAP_SHA}" ]; then
   REDEPLOY_IF_CONFIG_CHANGED=true
 fi
 

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -188,6 +188,18 @@ if [[ ( "$BUILD_TYPE" == "pullrequest"  ||  "$BUILD_TYPE" == "branch" ) && ! $TH
   BUILD_ARGS=()
 
   set +x # reduce noise in build logs
+  # Get the pre-rollout and post-rollout vars
+    if [ ! -z "$LAGOON_PROJECT_VARIABLES" ]; then
+      LAGOON_PREROLLOUT_DISABLED=($(echo $LAGOON_PROJECT_VARIABLES | jq -r '.[] | select(.name == "LAGOON_PREROLLOUT_DISABLED") | "\(.value)"'))
+      LAGOON_POSTROLLOUT_DISABLED=($(echo $LAGOON_PROJECT_VARIABLES | jq -r '.[] | select(.name == "LAGOON_POSTROLLOUT_DISABLED") | "\(.value)"'))
+    fi
+    if [ ! -z "$LAGOON_ENVIRONMENT_VARIABLES" ]; then
+      LAGOON_PREROLLOUT_DISABLED=($(echo $LAGOON_PROJECT_VARIABLES | jq -r '.[] | select(.name == "LAGOON_PREROLLOUT_DISABLED") | "\(.value)"'))
+      LAGOON_POSTROLLOUT_DISABLED=($(echo $LAGOON_PROJECT_VARIABLES | jq -r '.[] | select(.name == "LAGOON_POSTROLLOUT_DISABLED") | "\(.value)"'))
+    fi
+  set -x
+
+  set +x # reduce noise in build logs
   # Add environment variables from lagoon API as build args
   if [ ! -z "$LAGOON_PROJECT_VARIABLES" ]; then
     echo "LAGOON_PROJECT_VARIABLES are available from the API"
@@ -305,7 +317,6 @@ fi
 # create a new list with the current version / generation / revision so we can force a roll out
 # @TODO: could probably do this in the initial `COMPOSE_SERVICES` generation section, but for initial work its here
 SERVICE_TYPES_CURRENT_VERSION=()
-COUNT_VERSIONS=0
 for SERVICE_LATEST_VERSION_ENTRY in "${SERVICE_TYPES[@]}"
 do
   IFS=':' read -ra SERVICE_LATEST_VERSION_ENTRY_SPLIT <<< "$SERVICE_LATEST_VERSION_ENTRY"
@@ -346,24 +357,14 @@ do
   fi
   # set the values in the new map, but default `CURRENT_VERSION` to 0 if nothing has been deployed yet
   SERVICE_TYPES_CURRENT_VERSION+=("${SERVICE_NAME}:${SERVICE_TYPE}:${CURRENT_VERSION:-0}")
-  if [ ${CURRENT_VERSION:-0} == 0 ]; then
-    let "COUNT_VERSIONS=COUNT_VERSIONS+1"
-  fi
 done
-
-# if all our versions are 0 and the number of versions equalling 0 match the number of service_types we have
-# then this is likely the first deployment
-FIRST_DEPLOYMENT=false
-if [ ${COUNT_VERSIONS} == ${#SERVICE_TYPES[@]} ]; then
-  FIRST_DEPLOYMENT=true
-fi
 
 ##############################################
 ### RUN PRE-ROLLOUT tasks defined in .lagoon.yml
 ##############################################
 
-# if this is the first deployment, don't try to run any pre-rollout tasks
-if [ "${FIRST_DEPLOYMENT}" != "true" ]; then
+# if we have LAGOON_PREROLLOUT_DISABLED set, don't try to run any pre-rollout tasks
+if [ "${LAGOON_PREROLLOUT_DISABLED}" != "true" ]; then
   COUNTER=0
   while [ -n "$(cat .lagoon.yml | shyaml keys tasks.pre-rollout.$COUNTER 2> /dev/null)" ]
   do
@@ -384,6 +385,8 @@ if [ "${FIRST_DEPLOYMENT}" != "true" ]; then
 
     let COUNTER=COUNTER+1
   done
+else
+  echo "pre-rollout tasks are currently disabled LAGOON_PREROLLOUT_DISABLED is set to true"
 fi
 
 ##############################################
@@ -1089,23 +1092,28 @@ done
 ### RUN POST-ROLLOUT tasks defined in .lagoon.yml
 ##############################################
 
-COUNTER=0
-while [ -n "$(cat .lagoon.yml | shyaml keys tasks.post-rollout.$COUNTER 2> /dev/null)" ]
-do
-  TASK_TYPE=$(cat .lagoon.yml | shyaml keys tasks.post-rollout.$COUNTER)
-  echo $TASK_TYPE
-  case "$TASK_TYPE" in
-    run)
-        COMMAND=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.command)
-        SERVICE_NAME=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.service)
-        CONTAINER=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.container false)
-        SHELL=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.shell sh)
-        . /kubectl-build-deploy/scripts/exec-tasks-run.sh
-        ;;
-    *)
-        echo "Task Type ${TASK_TYPE} not implemented"; exit 1;
+# if we have LAGOON_POSTROLLOUT_DISABLED set, don't try to run any pre-rollout tasks
+if [ "${LAGOON_POSTROLLOUT_DISABLED}" != "true" ]; then
+  COUNTER=0
+  while [ -n "$(cat .lagoon.yml | shyaml keys tasks.post-rollout.$COUNTER 2> /dev/null)" ]
+  do
+    TASK_TYPE=$(cat .lagoon.yml | shyaml keys tasks.post-rollout.$COUNTER)
+    echo $TASK_TYPE
+    case "$TASK_TYPE" in
+      run)
+          COMMAND=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.command)
+          SERVICE_NAME=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.service)
+          CONTAINER=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.container false)
+          SHELL=$(cat .lagoon.yml | shyaml get-value tasks.post-rollout.$COUNTER.$TASK_TYPE.shell sh)
+          . /kubectl-build-deploy/scripts/exec-tasks-run.sh
+          ;;
+      *)
+          echo "Task Type ${TASK_TYPE} not implemented"; exit 1;
 
-  esac
+    esac
 
-  let COUNTER=COUNTER+1
-done
+    let COUNTER=COUNTER+1
+  done
+else
+  echo "post-rollout tasks are currently disabled LAGOON_POSTROLLOUT_DISABLED is set to true"
+fi

--- a/images/kubectl-build-deploy-dind/scripts/exec-monitor-deploy.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-monitor-deploy.sh
@@ -31,7 +31,7 @@ stream_logs_deployment() {
 # if they are, check the service version is greater than 0, 0 = new/never deployed
 # then check if we have the flag to redeploy if the configmap was updated
 LATEST_POD_TEMPLATE_HASH=$(kubectl -n ${NAMESPACE} get replicaset -l app.kubernetes.io/instance=${SERVICE_NAME} --sort-by=.metadata.creationTimestamp -o=json | jq -r '.items[-1].metadata.labels."pod-template-hash"')
-if [[ $SERVICE_VERSION == $LATEST_POD_TEMPLATE_HASH ] && [ $SERVICE_VERSION -gt 0] && [ "$REDEPLOY_IF_CONFIG_CHANGED" == "true" ]]; then
+if [[ $SERVICE_VERSION == $LATEST_POD_TEMPLATE_HASH && $SERVICE_VERSION -gt 0 && "$REDEPLOY_IF_CONFIG_CHANGED" == "true" ]]; then
   # do the redeploy
   kubectl -n ${NAMESPACE} --insecure-skip-tls-verify rollout restart deployments/${SERVICE_NAME}
 fi

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -997,7 +997,7 @@ done
 ## once we have set everything up, check if we modified the configmap in any way, we may need to redeploy
 ADJUSTED_CONFIG_MAP_SHA=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap lagoon-env -o yaml | shyaml get-value data | sha256sum | awk '{print $1}')
 REDEPLOY_IF_CONFIG_CHANGED=false
-if [ "${ADJUSTED_CONFIG_MAP_SHA}" -ne "${CONFIG_MAP_SHA}"]; then
+if [ "${ADJUSTED_CONFIG_MAP_SHA}" -ne "${CONFIG_MAP_SHA}" ]; then
   REDEPLOY_IF_CONFIG_CHANGED=true
 fi
 

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -398,25 +398,37 @@ do
     # STATEFULSET="${SERVICE_NAME}-galera"
     # SERVICE_NAME="${SERVICE_NAME}-maxscale"
     ## noone should be using `mariadb-galera`
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+    fi
   elif [ $SERVICE_TYPE == "elasticsearch-cluster" ]; then
     # STATEFULSET="${SERVICE_NAME}"\
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    fi
   elif [ $SERVICE_TYPE == "rabbitmq-cluster" ]; then
     # STATEFULSET="${SERVICE_NAME}"
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    fi
   elif [ $SERVICE_ROLLOUT_TYPE == "statefulset" ]; then
     # STATEFULSET="${SERVICE_NAME}"
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+    fi
   elif [ $SERVICE_ROLLOUT_TYPE == "deamonset" ]; then
     # DAEMONSET="${SERVICE_NAME}"
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify daemonset ${DAEMONSET} -o=go-template --template='{{.metadata.generation}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify daemonset ${DAEMONSET} -o=go-template --template='{{.metadata.generation}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify daemonset ${DAEMONSET} -o=go-template --template='{{.metadata.generation}}' 2> /dev/null)
+    fi
   elif [ $SERVICE_TYPE == "mariadb-dbaas" ]; then
     CURRENT_VERSION=0
   elif [ $SERVICE_TYPE == "mariadb-shared" ]; then
     CURRENT_VERSION=0
   elif [ ! $SERVICE_ROLLOUT_TYPE == "false" ]; then
-    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+    if oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' &> /dev/null; then
+      CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+    fi
   fi
   # set the values in the new map, but default `CURRENT_VERSION` to 0 if nothing has been deployed yet
   SERVICE_TYPES_CURRENT_VERSION+=("${SERVICE_NAME}:${SERVICE_TYPE}:${CURRENT_VERSION:-0}")
@@ -466,7 +478,7 @@ fi
 
 # get a sha sum of the config map `lagoon-env`, we will use this to check later on if the config map has changed
 # if the configmap doesn't exist, we will just get a dummy sha
-if ! oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap &> /dev/null; then
+if ! oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap lagoon-env &> /dev/null; then
   CONFIG_MAP_SHA=0000000000000000000000000000000000000000000000000000000000000000
 else
   CONFIG_MAP_SHA=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap lagoon-env -o yaml 2> /dev/null | shyaml get-value data 2> /dev/null | sha256sum | awk '{print $1}')

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -372,30 +372,103 @@ if [[ $DEPLOY_TYPE == "tug" && ! $THIS_IS_TUG == "true" ]]; then
 fi
 
 ##############################################
+### CHECK FOR CURRENT DEPLOYMENTS
+##############################################
+
+# loop through all the SERVICE_TYPES and create a new list with the current version of any dc / statefulsets / daemonsets
+# create a new list with the current version / generation / revision so we can force a roll out
+# @TODO: could probably do this in the initial `COMPOSE_SERVICES` generation section, but for initial work its here
+SERVICE_TYPES_CURRENT_VERSION=()
+COUNT_VERSIONS=0
+for SERVICE_LATEST_VERSION_ENTRY in "${SERVICE_TYPES[@]}"
+do
+  IFS=':' read -ra SERVICE_LATEST_VERSION_ENTRY_SPLIT <<< "$SERVICE_LATEST_VERSION_ENTRY"
+  SERVICE_NAME=${SERVICE_LATEST_VERSION_ENTRY_SPLIT[0]}
+  SERVICE_TYPE=${SERVICE_LATEST_VERSION_ENTRY_SPLIT[1]}
+  # default to version 0 for unsupported/unknown types
+  CURRENT_VERSION=0
+  SERVICE_ROLLOUT_TYPE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.${SERVICE_NAME}.labels.lagoon\\.rollout deploymentconfigs)
+  # Allow the rollout type to be overriden by environment in .lagoon.yml
+  ENVIRONMENT_SERVICE_ROLLOUT_TYPE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.rollouts.${SERVICE_NAME} false)
+  if [ ! $ENVIRONMENT_SERVICE_ROLLOUT_TYPE == "false" ]; then
+    SERVICE_ROLLOUT_TYPE=$ENVIRONMENT_SERVICE_ROLLOUT_TYPE
+  fi
+  # if mariadb-galera is a statefulset check also for maxscale
+  if [ $SERVICE_TYPE == "mariadb-galera" ]; then
+    # STATEFULSET="${SERVICE_NAME}-galera"
+    # SERVICE_NAME="${SERVICE_NAME}-maxscale"
+    ## noone should be using `mariadb-galera`
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+  elif [ $SERVICE_TYPE == "elasticsearch-cluster" ]; then
+    # STATEFULSET="${SERVICE_NAME}"\
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+  elif [ $SERVICE_TYPE == "rabbitmq-cluster" ]; then
+    # STATEFULSET="${SERVICE_NAME}"
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+  elif [ $SERVICE_ROLLOUT_TYPE == "statefulset" ]; then
+    # STATEFULSET="${SERVICE_NAME}"
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify statefulset ${STATEFULSET} -o=go-template --template='{{.status.updateRevision}}' 2> /dev/null)
+  elif [ $SERVICE_ROLLOUT_TYPE == "deamonset" ]; then
+    # DAEMONSET="${SERVICE_NAME}"
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify daemonset ${DAEMONSET} -o=go-template --template='{{.metadata.generation}}' 2> /dev/null)
+  elif [ $SERVICE_TYPE == "mariadb-dbaas" ]; then
+    echo "nothing to monitor for $SERVICE_TYPE"
+    CURRENT_VERSION=0
+  elif [ $SERVICE_TYPE == "mariadb-shared" ]; then
+    echo "nothing to monitor for $SERVICE_TYPE"
+    CURRENT_VERSION=0
+  elif [ ! $SERVICE_ROLLOUT_TYPE == "false" ]; then
+    CURRENT_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}' 2> /dev/null)
+  fi
+  # set the values in the new map, but default `CURRENT_VERSION` to 0 if nothing has been deployed yet
+  SERVICE_TYPES_CURRENT_VERSION+=("${SERVICE_NAME}:${SERVICE_TYPE}:${CURRENT_VERSION:-0}")
+  if [ ${CURRENT_VERSION:-0} == 0 ]
+    let "COUNT_VERSIONS=COUNT_VERSIONS+1"
+  fi
+done
+
+# if all our versions are 0 and the number of versions equalling 0 match the number of service_types we have
+# then this is likely the first deployment
+FIRST_DEPLOYMENT=false
+if [ ${COUNT_VERSIONS} == ${#SERVICE_TYPES[@]} ]; then
+  FIRST_DEPLOYMENT=true
+fi
+
+##############################################
 ### RUN PRE-ROLLOUT tasks defined in .lagoon.yml
 ##############################################
 
+# if this is the first deployment, don't try to run any pre-rollout tasks
+if [ "${FIRST_DEPLOYMENT}" != "true" ]; then
+  COUNTER=0
+  while [ -n "$(cat .lagoon.yml | shyaml keys tasks.pre-rollout.$COUNTER 2> /dev/null)" ]
+  do
+    TASK_TYPE=$(cat .lagoon.yml | shyaml keys tasks.pre-rollout.$COUNTER)
+    echo $TASK_TYPE
+    case "$TASK_TYPE" in
+      run)
+          COMMAND=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.command)
+          SERVICE_NAME=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.service)
+          CONTAINER=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.container false)
+          SHELL=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.shell sh)
+          . /oc-build-deploy/scripts/exec-pre-tasks-run.sh
+          ;;
+      *)
+          echo "Task Type ${TASK_TYPE} not implemented"; exit 1;
 
-COUNTER=0
-while [ -n "$(cat .lagoon.yml | shyaml keys tasks.pre-rollout.$COUNTER 2> /dev/null)" ]
-do
-  TASK_TYPE=$(cat .lagoon.yml | shyaml keys tasks.pre-rollout.$COUNTER)
-  echo $TASK_TYPE
-  case "$TASK_TYPE" in
-    run)
-        COMMAND=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.command)
-        SERVICE_NAME=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.service)
-        CONTAINER=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.container false)
-        SHELL=$(cat .lagoon.yml | shyaml get-value tasks.pre-rollout.$COUNTER.$TASK_TYPE.shell sh)
-        . /oc-build-deploy/scripts/exec-pre-tasks-run.sh
-        ;;
-    *)
-        echo "Task Type ${TASK_TYPE} not implemented"; exit 1;
+    esac
 
-  esac
+    let COUNTER=COUNTER+1
+  done
+fi
 
-  let COUNTER=COUNTER+1
-done
+##############################################
+### GET CURRENT CONFIG MAP
+##############################################
+
+# get a sha sum of the config map `lagoon-env`, we will use this to check later on if the config map has changed
+# if the configmap doesn't exist, we will just get a dummy sha
+CONFIG_MAP_SHA=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap lagoon-env -o yaml 2> /dev/null | shyaml get-value data 2> /dev/null | sha256sum | awk '{print $1}')
 
 ##############################################
 ### CREATE OPENSHIFT SERVICES, ROUTES and SERVICEBROKERS
@@ -918,6 +991,17 @@ for i in $(ls /tmp/istag/1); do
 done
 
 ##############################################
+### REDEPLOY DEPLOYMENTS IF CONFIG MAP CHANGES
+##############################################
+
+## once we have set everything up, check if we modified the configmap in any way, we may need to redeploy
+ADJUSTED_CONFIG_MAP_SHA=$(oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get configmap lagoon-env -o yaml | shyaml get-value data | sha256sum | awk '{print $1}')
+REDEPLOY_IF_CONFIG_CHANGED=false
+if [ "${ADJUSTED_CONFIG_MAP_SHA}" -ne "${CONFIG_MAP_SHA}"]; then
+  REDEPLOY_IF_CONFIG_CHANGED=true
+fi
+
+##############################################
 ### CREATE PVC, DEPLOYMENTS AND CRONJOBS
 ##############################################
 
@@ -1111,13 +1195,15 @@ fi
 ### WAIT FOR POST-ROLLOUT TO BE FINISHED
 ##############################################
 
-for SERVICE_TYPES_ENTRY in "${SERVICE_TYPES[@]}"
+# Use the `SERVICE_TYPES_CURRENT_VERSION` to pass through service_version to the rollout scripts instead of `SERVICE_TYPES`
+for SERVICE_TYPES_ENTRY in "${SERVICE_TYPES_CURRENT_VERSION[@]}"
 do
 
   IFS=':' read -ra SERVICE_TYPES_ENTRY_SPLIT <<< "$SERVICE_TYPES_ENTRY"
 
   SERVICE_NAME=${SERVICE_TYPES_ENTRY_SPLIT[0]}
   SERVICE_TYPE=${SERVICE_TYPES_ENTRY_SPLIT[1]}
+  SERVICE_VERSION=${SERVICE_TYPES_ENTRY_SPLIT[1]}
 
   SERVICE_ROLLOUT_TYPE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.${SERVICE_NAME}.labels.lagoon\\.rollout deploymentconfigs)
 

--- a/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
@@ -31,7 +31,7 @@ stream_logs_deployment() {
 # if they are, check the service version is greater than 0, 0 = new/never deployed
 # then check if we have the flag to redeploy if the configmap was updated
 LATEST_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}')
-if [[ $SERVICE_VERSION == $LATEST_VERSION ] && [ $SERVICE_VERSION -gt 0] && [ "$REDEPLOY_IF_CONFIG_CHANGED" == "true" ]]; then
+if [[ $SERVICE_VERSION == $LATEST_VERSION && $SERVICE_VERSION -gt 0 && "$REDEPLOY_IF_CONFIG_CHANGED" == "true" ]]; then
   # do the redeploy
   oc -n ${OPENSHIFT_PROJECT} --insecure-skip-tls-verify rollout latest dc/${SERVICE_NAME}
 fi

--- a/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-monitor-deploy.sh
@@ -27,6 +27,15 @@ stream_logs_deployment() {
   done
 }
 
+# Check if the latest version and the service version we got this at the start of the build are the same
+# if they are, check the service version is greater than 0, 0 = new/never deployed
+# then check if we have the flag to redeploy if the configmap was updated
+LATEST_VERSION=$(oc -n ${OPENSHIFT_PROJECT} get --insecure-skip-tls-verify dc/${SERVICE_NAME} -o=go-template --template='{{.status.latestVersion}}')
+if [[ $SERVICE_VERSION == $LATEST_VERSION ] && [ $SERVICE_VERSION -gt 0] && [ "$REDEPLOY_IF_CONFIG_CHANGED" == "true" ]]; then
+  # do the redeploy
+  oc -n ${OPENSHIFT_PROJECT} --insecure-skip-tls-verify rollout latest dc/${SERVICE_NAME}
+fi
+
 # start background logs streaming
 stream_logs_deployment &
 STREAM_LOGS_PID=$!


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Whenever an environment variable is created or updated within a project, any running pods are not redeployed. This is due to the fact that the env vars are changed in the lagoon-env configmap, which is referenced by the pod. Since this configmap is not actually a part of the pod that's changing, the pod hasn't actually changed and isn't redeployed as a result.

This PR aims to do some initial checks to see if only the configmap has changed, and redeploys any pods if it has.

Added bonus: ~It can check if this is the first time a deployment has occurred and won't try to run any `pre-rollout` tasks.~ Lagoon will now check for the existence of two new VARs during a deployment to see if it should run pre or post rollout tasks instead. These need to be defined in the API as `true`.
```
LAGOON_PREROLLOUT_DISABLED
LAGOON_POSTROLLOUT_DISABLED
```
<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1728 #1804 