### PR TITLE
Fix for issue #1818. Pin ubuntu image version as 18.04 in ssh/Dockerfile

### DIFF
--- a/services/ssh/Dockerfile
+++ b/services/ssh/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 LABEL maintainer="amazee.io"
 


### PR DESCRIPTION
Please see related issue #1818 
Was able to reproduce both on MacOS and Ubuntu 18.04 VM with Docker 20.x

See attached screenshot of completed build after proposed fix was applied.

![Screenshot from 2020-04-28 11-45-45](https://user-images.githubusercontent.com/2167226/80440044-3e5c2480-894b-11ea-8219-f4b067ef062b.png)



