### PR TITLE
Label namespaces with lagoon/project in k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,12 @@ k8s-tests: $(all-k8s-tests)
 $(all-k8s-tests): k3d kubernetes-test-services-up
 		$(MAKE) push-local-registry -j6
 		$(eval testname = $(subst k8s-tests/,,$@))
-		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) run --rm tests-kubernetes ansible-playbook --skip-tags="skip-on-kubernetes" /ansible/tests/$(testname).yaml
+		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) run --rm \
+			tests-kubernetes ansible-playbook --skip-tags="skip-on-kubernetes" \
+			/ansible/tests/$(testname).yaml \
+			--extra-vars \
+			"$$(cat $$(./local-dev/k3d get-kubeconfig --name='$(K3D_NAME)') | \
+				jq -rcsR '{kubeconfig: .}')"
 
 # push command of our base images into minishift
 push-local-registry-images = $(foreach image,$(base-images) $(base-images-with-versions),[push-local-registry]-$(image))

--- a/services/kubernetesbuilddeploy/src/index.js
+++ b/services/kubernetesbuilddeploy/src/index.js
@@ -307,7 +307,19 @@ const messageConsumer = async msg => {
   let namespaceStatus = {}
   try {
     const namespacePost = promisify(kubernetes.namespace.post)
-    namespaceStatus = await namespacePost({ body: {"apiVersion":"v1","kind":"Namespace","metadata":{"name":openshiftProject}} })
+    namespaceStatus = await namespacePost({
+      body: {
+        "apiVersion":"v1",
+        "kind":"Namespace",
+        "metadata": {
+          "name":openshiftProject,
+          "labels": {
+            "lagoon.sh/project": projectName,
+            "lagoon.sh/environment": environmentName
+          }
+        }
+      }
+    })
     logger.info(`${openshiftProject}: Namespace ${openshiftProject} created`)
   } catch (err) {
     console.log(err.code)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,11 +4,21 @@ FROM alpine:3.10
 RUN apk add --no-cache \
       ansible \
       bash \
+      curl \
       git \
+      jq \
       openssh-client \
       py2-jwt \
       py2-requests \
       rsync
+
+# download, extract and install kubectl binary
+# https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#downloads-for-v1182
+ARG KUBECTL_URL=https://dl.k8s.io/v1.18.2/kubernetes-client-linux-amd64.tar.gz
+ARG KUBECTL_SHA512=ed36f49e19d8e0a98add7f10f981feda8e59d32a8cb41a3ac6abdfb2491b3b5b3b6e0b00087525aa8473ed07c0e8a171ad43f311ab041dcc40f72b36fa78af95
+# curl -> tee -> sha512sum -> grep
+#            `-> tar
+RUN { { curl -sSL $KUBECTL_URL | tee /dev/fd/3 | sha512sum >&4; } 3>&1 | tar -xz --strip-components=3 -C /usr/local/bin kubernetes/client/bin/kubectl; } 4>&1 | grep -q $KUBECTL_SHA512
 
 RUN git config --global user.email "deploytest@amazee.io" && git config --global user.name deploytest
 

--- a/tests/checks/check-namespace-labels.yaml
+++ b/tests/checks/check-namespace-labels.yaml
@@ -1,0 +1,19 @@
+---
+- name: "{{ testname }} - Check if {{project}} namespace is labelled"
+  shell: |
+    set -e
+    export KUBECONFIG=$(mktemp)
+    echo "{{ kubeconfig }}" > $KUBECONFIG
+    # replace with the IP of host from within container
+    sed -i "s/localhost/$(ip -4 route list match 0/0 | cut -d' ' -f3)/" $KUBECONFIG
+    # create the $label and $value variables from item
+    eval $(echo "{{ item }}" | awk -F= '{sep=index($0,"="); print "label=\"" $1 "\" value=\"" substr($0,sep+1) "\""}')
+    [ $(kubectl --insecure-skip-tls-verify=true get namespace {{ project }}-{{ branch }} -o json |
+    jq -er ".metadata.labels | .\"$label\"") = "$value" ]
+  loop: "{{ expected_labels }}"
+  register: result
+  retries: 20
+  delay: 10
+  until: result.rc == 0
+- name: "{{ testname }} - Check if {{project}} namespace is labelled"
+  debug: msg="Success!!!"

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -4,6 +4,13 @@
   vars:
     testname: "API TOKEN"
 
+- include: features/namespace-labels.yaml
+  vars:
+    testname: "NAMESPACE LABELS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    git_repo_name: features.git
+    project: ci-features-{{ lookup('env','CLUSTER_TYPE') }}
+    branch: namespace-labels
+
 - include: features/remote-shell.yaml
   vars:
     testname: "REMOTE SHELL {{ lookup('env','CLUSTER_TYPE')|upper }}"

--- a/tests/tests/features/namespace-labels.yaml
+++ b/tests/tests/features/namespace-labels.yaml
@@ -1,0 +1,39 @@
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "features/"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml
+
+- name: >
+    {{ testname }} - check that the namespace is labelled correctly
+  hosts: localhost
+  serial: 1
+  vars:
+    expected_labels:
+    - "lagoon.sh/project={{ project }}"
+    - "lagoon.sh/environment={{ branch }}"
+  tasks:
+  - include: ../../checks/check-namespace-labels.yaml
+
+- name: >
+    {{ testname }} - api deleteEnvironment on {{ project }}, which should remove
+    all resources
+  hosts: localhost
+  serial: 1
+  vars:
+    project: "{{ project }}"
+    branch: "{{ branch }}"
+  tasks:
+  - include: ../../tasks/api/remove.yaml


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change adds a label to namespaces created by lagoon to indicate the lagoon project that they belong to. Currently k8s only, not openshift.

This is in support of a larger logging overhaul. Partially adresses #1364.

# Closing issues
n/a
