### PR TITLE
Fix typo in api subscription constructor

### DIFF
--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -86,7 +86,7 @@ const apolloServer = new ApolloServer({
           GroupModel: Group.Group({ keycloakAdminClient }),
           BillingModel: BillingModel.BillingModel({ keycloakAdminClient, sqlClient }),
           ProjectModel: ProjectModel.ProjectModel({ keycloakAdminClient, sqlClient }),
-          EnvironmentModel: EnvironmentModel.EnvironmentMode({ sqlClient })
+          EnvironmentModel: EnvironmentModel.EnvironmentModel({ sqlClient })
         },
       };
     },


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

API subscriptions are broken due to a typo, this fixes the typo.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
n/a
