### PR TITLE
Use labels on kubernetes jobs to not block builds on cron/backups/tasks

### DIFF
--- a/services/kubernetesbuilddeploy/src/index.js
+++ b/services/kubernetesbuilddeploy/src/index.js
@@ -134,6 +134,9 @@ const messageConsumer = async msg => {
       "metadata": {
           "creationTimestamp": null,
           "name": buildName,
+          "labels": {
+            "lagoon.job.type": "build",
+          }
       },
       "spec": {
         "backoffLimit": 0,

--- a/services/kubernetesbuilddeploy/src/index.js
+++ b/services/kubernetesbuilddeploy/src/index.js
@@ -135,7 +135,7 @@ const messageConsumer = async msg => {
           "creationTimestamp": null,
           "name": buildName,
           "labels": {
-            "lagoon.job.type": "build",
+            "lagoon.sh/jobType": "build",
           }
       },
       "spec": {

--- a/services/kubernetesdeployqueue/src/index.js
+++ b/services/kubernetesdeployqueue/src/index.js
@@ -89,7 +89,7 @@ const messageConsumer = async msg => {
     new Promise(async (resolve, reject) => {
       const namespaceJobs = await jobsGet({
         qs: {
-          labelSelector: 'lagoon.job.type=build'
+          labelSelector: 'lagoon.sh/jobType=build'
         }
       });
       const activeBuilds = R.pipe(

--- a/services/kubernetesdeployqueue/src/index.js
+++ b/services/kubernetesdeployqueue/src/index.js
@@ -87,7 +87,11 @@ const messageConsumer = async msg => {
 
   const hasNoActiveBuilds = () =>
     new Promise(async (resolve, reject) => {
-      const namespaceJobs = await jobsGet();
+      const namespaceJobs = await jobsGet({
+        qs: {
+          labelSelector: 'lagoon.job.type=build'
+        }
+      });
       const activeBuilds = R.pipe(
         R.propOr([], 'items'),
         R.filter(R.pathSatisfies(R.lt(0), ['status', 'active']))

--- a/services/kubernetesjobs/src/index.ts
+++ b/services/kubernetesjobs/src/index.ts
@@ -51,7 +51,10 @@ const jobConfig = (name, spec) => {
     apiVersion: 'batch/v1',
     kind: 'Job',
     metadata: {
-      name
+      name,
+      labels: {
+        "lagoon.job.type": "task",
+      }
     },
     spec: {
       parallelism: 1,
@@ -59,7 +62,7 @@ const jobConfig = (name, spec) => {
       backoffLimit: 0,
       template: {
         metadata: {
-          name: 'pi'
+          name
         },
         spec: {
           ...spec,

--- a/services/kubernetesjobs/src/index.ts
+++ b/services/kubernetesjobs/src/index.ts
@@ -53,7 +53,7 @@ const jobConfig = (name, spec) => {
     metadata: {
       name,
       labels: {
-        "lagoon.job.type": "task",
+        "lagoon.sh/jobType": "task",
       }
     },
     spec: {

--- a/services/openshiftjobs/src/index.js
+++ b/services/openshiftjobs/src/index.js
@@ -86,7 +86,7 @@ const messageConsumer = async msg => {
       metadata: {
         name,
         labels: {
-          "lagoon.job.type": "task",
+          "lagoon.sh/jobType": "task",
         }
       },
       spec: {

--- a/services/openshiftjobs/src/index.js
+++ b/services/openshiftjobs/src/index.js
@@ -84,7 +84,10 @@ const messageConsumer = async msg => {
       apiVersion: 'batch/v1',
       kind: 'Job',
       metadata: {
-        name
+        name,
+        labels: {
+          "lagoon.job.type": "task",
+        }
       },
       spec: {
         parallelism: 1,
@@ -92,7 +95,7 @@ const messageConsumer = async msg => {
         backoffLimit: 0,
         template: {
           metadata: {
-            name: 'pi'
+            name
           },
           spec: {
             ...spec,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Adds a `lagoon.job.type` label for builds and tasks so that the kubernetes deploy queue service can block only on other builds for that namespace.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1652 