### PR TITLE
Allow the lagoon UI to pre-select a keycloak identity provider for login

### DIFF
--- a/services/ui/src/lib/util.js
+++ b/services/ui/src/lib/util.js
@@ -1,0 +1,9 @@
+import * as R from 'ramda';
+
+export const queryStringToObject = R.pipe(
+  R.defaultTo(''),
+  R.replace(/^\?/, ''),
+  R.split('&'),
+  R.map(R.split('=')),
+  R.fromPairs
+);

--- a/services/ui/src/lib/withKeycloak.js
+++ b/services/ui/src/lib/withKeycloak.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import getConfig from 'next/config';
+import { queryStringToObject } from 'lib/util';
 
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
 
@@ -27,10 +28,16 @@ export default (App, initialAuth) => {
       };
 
       await keycloak.init({
-        onLoad: 'login-required',
         checkLoginIframe: false,
         promiseType: 'native',
       });
+
+      if (!keycloak.authenticated) {
+        const urlQuery = queryStringToObject(location.search);
+        const options = urlQuery.idpHint ? { idpHint: urlQuery.idpHint } : {};
+
+        await keycloak.login(options);
+      }
 
       this.setAuth(keycloak);
     }

--- a/services/ui/src/pages/index.js
+++ b/services/ui/src/pages/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import Router from 'next/router';
+import { queryStringToObject } from 'lib/util';
 
 export default class IndexPage extends React.Component {
-  static async getInitialProps({ res }) {
+  static async getInitialProps({ req, res }) {
     if (res) {
+      const currentUrl = new URL(req.url, `https://${req.headers.host}`);
       res.writeHead(302, {
-        Location: '/projects'
+        Location: `/projects${currentUrl.search}`
       });
       res.end();
     } else {
-      Router.push('/projects');
+      Router.push({
+        pathname: '/projects',
+        query: queryStringToObject(location.search),
+      });
     }
     return {};
   }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR allows adding `idpHint` query string parameter to any lagoon UI url. If the user is not logged in, the `idpHint` will be forwarded to keycloak where it may then auto-select the identity provider that has a matching alias to the `idpHint`.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #1789 
