### PR TITLE
Added "Admin & UI subsystem" to release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,8 @@ categories:
       - '0-kubernetes'
   - title: 'API & Authentication subsystem'
     label: '1-api-auth'
+  - title: 'Admin & User Interfaces subsystem'
+    label: '10-admin-user-interfaces'
   - title: 'Build & Deploy subsystem'
     label: '2-build-deploy'
   - title: 'Logging & Reporting subsystem'
@@ -22,6 +24,7 @@ categories:
     label: '8-automation-helpers'
   - title: 'Security subsystem'
     label: '9-security'
+
 exclude-labels:
   - 'skip-changelog'
 


### PR DESCRIPTION
This PR adds a new label category to the release-drafter process, to cover Admin UI / User UI changes instead of bundling them with API & Auth

PRs should be labelled `10-admin-user-interfaces` to be collected

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Changelog Entry - N/A

# Closing issues - N/A
