### PR TITLE
Disabling quota sync for harbor-core

### DIFF
--- a/services/harbor-core/harbor-core.yml
+++ b/services/harbor-core/harbor-core.yml
@@ -180,6 +180,7 @@ objects:
     #CHART_REPOSITORY_URL: "http://harbor-chartmuseum"
     LOG_LEVEL: "error"
     CONFIG_PATH: "/etc/core/app.conf"
+    SYNC_QUOTA: "false"
     SYNC_REGISTRY: "false"
     CHART_CACHE_DRIVER: "redis"
     _REDIS_URL: "harbor-redis:6379,100,"


### PR DESCRIPTION
Harbor's `harbor-core` service isn't respecting the maximum number of allowed connections to Postgres, causing it to fail to launch properly when this option is enabled. Since we don't use quotas anyway, it is safe to simple disable the quota checking behavior which generates this flood of Postgres connections.

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied
