### PR TITLE
Build Python3.7 images from Alpine 3.10 instead of 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ $(build-pythonimages): build/commons
 	$(eval clean = $(subst build/python__,,$@))
 	$(eval version = $(word 1,$(subst -, ,$(clean))))
 	$(eval type = $(word 2,$(subst -, ,$(clean))))
-	$(eval alpine_version := $(shell case $(version) in (2.7) echo "3.10" ;; (*) echo $(DEFAULT_ALPINE_VERSION) ;; esac ))
+	$(eval alpine_version := $(shell case $(version) in (2.7|3.7) echo "3.10" ;; (*) echo $(DEFAULT_ALPINE_VERSION) ;; esac ))
 # this fills variables only if $type is existing, if not they are just empty
 	$(eval type_dash = $(if $(type),-$(type)))
 # Call the docker build


### PR DESCRIPTION
This PR forces Lagoon to use Alpine 3.10 to build Python 3.7 images instead of 3.11

This is because Alpine 3.11 defaults to Python 3.8, and as such will install the 3.8 version of Python3-dev (and Python3.8 as well to match the dependency), resulting in version duality.  First discovered in testing #1887 

For a later PR should be a rework of the Python images - there is a lot of optimisation that can be done - we may not need to augment the upstream images, or may be better using a glibc-based base image (e.g. buster-slim)

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Closing issues
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
