### PR TITLE
Run mysql_upgrade on existing databases after upgrade

### DIFF
--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -39,6 +39,7 @@ RUN \
     mariadb \
     mariadb-client \
     mariadb-common \
+    mariadb-server-utils \
     net-tools \
     pwgen \
     tzdata \


### PR DESCRIPTION
This PR adds a mysql_upgrade command if there is an existing database.

Definitely open to any attempts to make it nicer!

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Closing issues
Closes #1890
