### PR TITLE
Ensure project and environment labels exist on OpenShift projects.

### DIFF
--- a/services/openshiftbuilddeploy/src/index.js
+++ b/services/openshiftbuilddeploy/src/index.js
@@ -326,7 +326,19 @@ const messageConsumer = async msg => {
     if (err.code == 404 || err.code == 403) {
       logger.info(`${openshiftProject}: Project ${openshiftProject}  does not exist, creating`)
       const projectrequestsPost = Promise.promisify(openshift.projectrequests.post, { context: openshift.projectrequests })
-      await projectrequestsPost({ body: {"apiVersion":"v1","kind":"ProjectRequest","metadata":{"name":openshiftProject},"displayName":`[${projectName}] ${branchName}`} });
+      await projectrequestsPost({
+        body: {
+          "apiVersion":"v1",
+          "kind":"ProjectRequest",
+          "metadata": {
+            "name":openshiftProject,
+            "labels": {
+              "lagoon.sh/project": safeProjectName,
+              "lagoon.sh/environment": safeBranchName
+            }
+          },
+          "displayName":`[${projectName}] ${branchName}`
+        } });
     } else {
       logger.error(err)
       throw new Error


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

1. Adds the following labels to openshift projects.
    * `lagoon.sh/project` - project machine name
    * `lagoon.sh/environment` - environment name

There should be consistency between kubernetes and openshift namespace labels now.

# Closing issues
Closes #1888 
