### PR TITLE
Small chart template changes to fix helm linting

### DIFF
--- a/charts/lagoon-logging/linter_values.yaml
+++ b/charts/lagoon-logging/linter_values.yaml
@@ -1,0 +1,7 @@
+# Linter-specific values for lagoon-logging.
+# This is a YAML-formatted file.
+# Any variables defined here are not used anywhere other than lint
+
+clusterName: notarealcluster
+elasticsearchHost: notarealhost
+elasticsearchAdminPassword: notarealpassword

--- a/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Create a PriorityClassName.
 {{/*
 Lagoon Labels
 */}}
-{{- define "cli.lagoonLabels" -}}
+{{- define "logstash.lagoonLabels" -}}
 lagoon.sh/service: {{ .Release.Name }}
 lagoon.sh/service-type: {{ .Chart.Name }}
 lagoon.sh/project: {{ .Values.project }}
@@ -69,7 +69,7 @@ lagoon.sh/buildType: {{ .Values.buildType }}
 {{/*
 Annotations
 */}}
-{{- define "cli.annotations" -}}
+{{- define "logstash.annotations" -}}
 lagoon.sh/version: {{ .Values.lagoonVersion | quote }}
 {{- if .Values.branch }}
 lagoon.sh/branch: {{ .Values.branch | quote }}

--- a/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/service.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "logstash.labels" . | nindent 4 }}
   annotations:
-    {{- include "mariadb-shared.annotations" . | nindent 4 }}
+    {{- include "logstash.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         {{- include "redis-persistent.labels" . | nindent 8 }}
       annotations:
-        {{- include "redis-persistent.annotations" . | nindent  }}
+        {{- include "redis-persistent.annotations" . | nindent 8 }}
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:
     {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
A couple of mismatched label/annotation references back to source helm charts, and added a linter_values file for lagoon_logging

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied
