### PR TITLE
Pin docker upstream tags to Alpine 3.11

### DIFF
--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM docker:19.03-dind
+FROM docker:19.03.10-dind
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=docker-host

--- a/images/kubectl/Dockerfile
+++ b/images/kubectl/Dockerfile
@@ -1,11 +1,12 @@
+ARG ALPINE_VERSION
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM golang:alpine as golang
+FROM golang:1.13-alpine${ALPINE_VERSION} as golang
 
 RUN apk add --no-cache git
 RUN go get github.com/a8m/envsubst/cmd/envsubst
 
-FROM docker:stable
+FROM docker:19.03.10
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=oc

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.13-alpine${ALPINE_VERSION} as golang
 RUN apk add --no-cache git
 RUN go get github.com/a8m/envsubst/cmd/envsubst
 
-FROM docker:stable
+FROM docker:19.03.10
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=oc


### PR DESCRIPTION
With the release of Alpine 3.12, I have reviewed the Alpine image usage inside Lagoon.

The only docker images that have been upgraded to 3.12 so far are the ones that use docker images.  This PR fixes them to the release of docker that was based on Alpine 3.11

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied