### PR TITLE
Improve resilience of logs-forwarder

### DIFF
--- a/services/logs-forwarder/.lagoon.multi.yml
+++ b/services/logs-forwarder/.lagoon.multi.yml
@@ -266,6 +266,7 @@ objects:
           ssl_version TLSv1_2
           request_timeout 600s
           slow_flush_log_threshold 300s
+          log_es_400_reason true
           <buffer>
             @type file
             path /fluentd/buffer/elasticsearch

--- a/services/logs-forwarder/.lagoon.multi.yml
+++ b/services/logs-forwarder/.lagoon.multi.yml
@@ -267,6 +267,8 @@ objects:
           request_timeout 600s
           slow_flush_log_threshold 300s
           log_es_400_reason true
+          # mapping exception ignore. these chunks will be dropped
+          ignore_exceptions ["Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchError"]
           <buffer tag,index_name>
             @type file
             path /fluentd/buffer/elasticsearch

--- a/services/logs-forwarder/.lagoon.multi.yml
+++ b/services/logs-forwarder/.lagoon.multi.yml
@@ -267,7 +267,7 @@ objects:
           request_timeout 600s
           slow_flush_log_threshold 300s
           log_es_400_reason true
-          <buffer>
+          <buffer tag,index_name>
             @type file
             path /fluentd/buffer/elasticsearch
             # buffer params (per worker)

--- a/services/logs-forwarder/.lagoon.multi.yml
+++ b/services/logs-forwarder/.lagoon.multi.yml
@@ -317,7 +317,8 @@ objects:
           "index.refresh_interval" : "5s",
           "number_of_shards": 1,
           "number_of_replicas": 1,
-          "index.routing.allocation.require.box_type": "live"
+          "index.routing.allocation.require.box_type": "live",
+          "index.mapping.ignore_malformed": true
         },
         "mappings" : {
           "dynamic_templates" : [ {

--- a/services/logs-forwarder/.lagoon.single.yml
+++ b/services/logs-forwarder/.lagoon.single.yml
@@ -250,7 +250,7 @@ objects:
           request_timeout 600s
           slow_flush_log_threshold 300s
           log_es_400_reason true
-          <buffer>
+          <buffer tag,index_name>
             @type file
             path /fluentd/buffer/elasticsearch
             # buffer params (per worker)

--- a/services/logs-forwarder/.lagoon.single.yml
+++ b/services/logs-forwarder/.lagoon.single.yml
@@ -250,6 +250,8 @@ objects:
           request_timeout 600s
           slow_flush_log_threshold 300s
           log_es_400_reason true
+          # mapping exception ignore. these chunks will be dropped
+          ignore_exceptions ["Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchError"]
           <buffer tag,index_name>
             @type file
             path /fluentd/buffer/elasticsearch

--- a/services/logs-forwarder/.lagoon.single.yml
+++ b/services/logs-forwarder/.lagoon.single.yml
@@ -300,7 +300,8 @@ objects:
           "index.refresh_interval" : "5s",
           "number_of_shards": 1,
           "number_of_replicas": 1,
-          "index.routing.allocation.require.box_type": "live"
+          "index.routing.allocation.require.box_type": "live",
+          "index.mapping.ignore_malformed": true
         },
         "mappings" : {
           "dynamic_templates" : [ {

--- a/services/logs-forwarder/.lagoon.single.yml
+++ b/services/logs-forwarder/.lagoon.single.yml
@@ -249,6 +249,7 @@ objects:
           ssl_version TLSv1_2
           request_timeout 600s
           slow_flush_log_threshold 300s
+          log_es_400_reason true
           <buffer>
             @type file
             path /fluentd/buffer/elasticsearch


### PR DESCRIPTION

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Logs Forwarder was having trouble keeping up with log volumes in some clusters. These changes improved things. Please see the individual commits for the changes. Commit messages are:

* Ignore exceptions caused by Elasticsearch rejecting chunks
  If we don't ignore these exceptions the chunks will be retried
  pointlessly.
* Ignore malformed index data
  Malformed entries won't be indexed, but they will at least be stored
  instead of causing the entire chunk to be rejected. See this link for
  details:
  https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-malformed.html
* Split chunks by index_name
  This way if a chunk is rejected it will only affect a single index.
* Log the reason why Elasticsearch rejects a chunk

# Closing issues
n/a
