### PR TITLE
Updated default robot token duration to 500 days.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -594,7 +594,7 @@ services:
       - HTTPS_PROXY=
       - NO_PROXY=harbor-core,harbor-jobservice,harbor-database,harborregistry,harbor-portal,harbor-trivy,127.0.0.1,localhost,.local,.internal
       - HARBOR_NGINX_ENDPOINT=http://harbor-nginx:8080
-      - ROBOT_TOKEN_DURATION=999
+      - ROBOT_TOKEN_DURATION=500
       - CORE_SECRET=secret123
       - JOBSERVICE_SECRET=secret123
       - REGISTRY_HTTP_SECRET=secret123

--- a/services/harbor-core/harbor-core.yml
+++ b/services/harbor-core/harbor-core.yml
@@ -190,6 +190,7 @@ objects:
     CLAIR_HEALTH_CHECK_SERVER_URL: "http://harborclair:6061"
     WITH_TRIVY: "true"
     TRIVY_ADAPTER_URL: "harbor-trivy:8080"
+    ROBOT_TOKEN_DURATION: 500
     HTTP_PROXY: ""
     HTTPS_PROXY: ""
     NO_PROXY: "harbor-core,harbor-jobservice,harbor-database,harborclair,harborclairadapter,harborregistry,harbor-portal,harbor-trivy,127.0.0.1,localhost,.local,.internal"


### PR DESCRIPTION
# Checklist
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR updates the default robot token duration from 30 days to 500 days. This will prevent robot tokens from becoming stale and stopping Lagoon deployments.
