### PR TITLE
Update curl to `7.70.0-r0` in the PHP images

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -45,7 +45,7 @@ ENV NEWRELIC_VERSION=9.10.1.263
 # @see https://github.com/curl/curl/issues/4624
 # @see https://pkgs.alpinelinux.org/packages?name=curl&branch=v3.11
 # TODO: Remove as soon as Alpine 3.11 is shipped with a version higher than 7.67.0
-RUN apk add --no-cache curl=7.70.0-r0 libcurl=7.70.0-r0 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
+RUN apk add --no-cache curl --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
 
 RUN apk add --no-cache fcgi \
         ssmtp \

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -41,10 +41,11 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
 ENV NEWRELIC_VERSION=9.10.1.263
 
-# Pin curl to Version 7.69.1-r0 as the current shipped one 7.67.0 has a bug, see
-# https://github.com/curl/curl/issues/4624
+# Pin curl to Version 7.70.0-r0 as the current shipped one 7.67.0 has a bug.
+# @see https://github.com/curl/curl/issues/4624
+# @see https://pkgs.alpinelinux.org/packages?name=curl&branch=v3.11
 # TODO: Remove as soon as Alpine 3.11 is shipped with a version higher than 7.67.0
-RUN apk add --no-cache curl=7.69.1-r0 libcurl=7.69.1-r0 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
+RUN apk add --no-cache curl=7.70.0-r0 libcurl=7.70.0-r0 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
 
 RUN apk add --no-cache fcgi \
         ssmtp \

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -41,10 +41,6 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
 ENV NEWRELIC_VERSION=9.10.1.263
 
-# Pin curl to Version 7.70.0-r0 as the current shipped one 7.67.0 has a bug.
-# @see https://github.com/curl/curl/issues/4624
-# @see https://pkgs.alpinelinux.org/packages?name=curl&branch=v3.11
-# TODO: Remove as soon as Alpine 3.11 is shipped with a version higher than 7.67.0
 RUN apk add --no-cache curl --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
 
 RUN apk add --no-cache fcgi \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This updates the version of curl to `7.70.0-r0` to allow the PHP images to build again.

# Proof this works

```
$ make clean
$ make -j4 build/php__7.4-cli
docker build --quiet --build-arg LAGOON_VERSION=development --build-arg IMAGE_REPO=lagoon --build-arg ALPINE_VERSION=3.11 -t lagoon/commons -f images/commons/Dockerfile images/commons
sha256:70c0910409dc9822d0a52f46ace18c86661a7af1a7b55165cfca78e9aa42a615
touch build/commons
docker build --quiet --build-arg LAGOON_VERSION=development --build-arg IMAGE_REPO=lagoon --build-arg PHP_VERSION=7.4  --build-arg PHP_IMAGE_VERSION=7.4 --build-arg ALPINE_VERSION=3.11 -t lagoon/php:7.4-fpm -f images/php/fpm/Dockerfile images/php/fpm
sha256:a72fe0e1b70dad8c31aa067f8ddee2ee0994c9044e4cf49310031af8ce6bdae4
touch build/php__7.4-fpm
docker build --quiet --build-arg LAGOON_VERSION=development --build-arg IMAGE_REPO=lagoon --build-arg PHP_VERSION=7.4  --build-arg PHP_IMAGE_VERSION=7.4 --build-arg ALPINE_VERSION=3.11 -t lagoon/php:7.4-cli -f images/php/cli/Dockerfile images/php/cli
sha256:33306dac7cf00083d07a713c365db63d546132c88882cf0692da23a82e1da4d5
touch build/php__7.4-cli
```

Works again 🎉 

# Closing issues
Closes #1949 
