### PR TITLE
Add a new environment variable to control New Relic browser monitoring.

### DIFF
--- a/docs/using_lagoon/docker_images/php-fpm.md
+++ b/docs/using_lagoon/docker_images/php-fpm.md
@@ -88,6 +88,7 @@ Environment variables are meant to contain common information for the PHP contai
 | :--- | :--- | :--- |
 | `NEWRELIC_ENABLED` | `false` | Enable NewRelic performance monitoring, needs `NEWRELIC_LICENSE` be configured. |
 | `NEWRELIC_LICENSE` | \(not set\) | NewRelic license to be used, Important: `NEWRELIC_ENABLED` needs to be set to`true` in order for NewRelic to be enabled. |
+| `NEWRELIC_BROWSER_MONITORING_ENABLED` | `true` | This enables auto-insertion of the JavaScript fragments for NewRelic browser monitoring, Important: `NEWRELIC_ENABLED` needs to be set to`true` in order for NewRelic to be enabled. |
 | `PHP_APC_ENABLED` | `1` | Can be set to 0 to disable APC. [See php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.enabled). |
 | `PHP_APC_SHM_SIZE` | `32m` | The size of each shared memory segment given. [See php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.shm-size). |
 | `PHP_DISPLAY_ERRORS` | `Off` | This determines whether errors should be printed to the screen as part of the output or if they should be hidden from the user. [See php.net](http://php.net/display-errors). |
@@ -104,4 +105,3 @@ Environment variables are meant to contain common information for the PHP contai
 | `PHP_MAX_INPUT_VARS` | `2000` | How many input variables will be accepted. [See php.net](http://php.net/manual/en/info.configuration.php#ini.max-input-vars). |
 | `PHP_MEMORY_LIMIT` | `400M` | Maximum amount of memory a script may consume. [See php.net](http://php.net/memory-limit). |
 | `XDEBUG_ENABLE` | \(not set\) | Used to enable `xdebug` extension. [See php.net](http://php.net/manual/en/apc.configuration.php#ini.apc.enabled). |
-

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -92,6 +92,7 @@ RUN apk add --no-cache fcgi \
     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/;newrelic.browser_monitoring.auto_instrument = .*/newrelic.browser_monitoring.auto_instrument = \${NEWRELIC_BROWSER_MONITORING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/newrelic.license = .*/newrelic.license = \"\${NEWRELIC_LICENSE:-}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.loglevel = .*/newrelic.loglevel = \"\${NEWRELIC_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.daemon.loglevel = .*/newrelic.daemon.loglevel = \"\${NEWRELIC_DAEMON_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Adds a new environment variable in the PHP images `NEWRELIC_BROWSER_MONITORING_ENABLED` to which defaults to `true` (existing behaviour). Setting this to `false` will prevent the additional JS being inserted into the HTML, and will disable NewRelic Browser monitoring (APM will be fine).

Likely this PR will fail until #1954 is merged.

What this changes the configuration to (running in a container):

```
php:/app$ grep -A0 -B8 NEWRELIC_BROWSER_MONITORING_ENABLED /usr/local/etc/php/conf.d/newrelic.disable
; Setting: newrelic.browser_monitoring.auto_instrument
; Type   : boolean
; Scope  : per-directory
; Default: true
; Info   : Enables or disables automatic real user monitoring ("auto-RUM").
;          When enabled will cause the agent to insert a header and a footer
;          in HTML output that will time the actual end-user experience.
;
newrelic.browser_monitoring.auto_instrument = ${NEWRELIC_BROWSER_MONITORING_ENABLED:-true}
```

# Closing issues
Closes #1951