### PR TITLE
Label namespaces with lagoon.sh/environmentType

### DIFF
--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -318,7 +318,8 @@ const messageConsumer = async msg => {
           "name":openshiftProject,
           "labels": {
             "lagoon.sh/project": projectName,
-            "lagoon.sh/environment": environmentName
+            "lagoon.sh/environment": environmentName,
+            "lagoon.sh/environmentType": lagoonEnvironmentType
           }
         }
       }

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -333,7 +333,8 @@ const messageConsumer = async msg => {
             "name":openshiftProject,
             "labels": {
               "lagoon.sh/project": safeProjectName,
-              "lagoon.sh/environment": safeBranchName
+              "lagoon.sh/environment": safeBranchName,
+              "lagoon.sh/environmentType": lagoonEnvironmentType
             }
           },
           "displayName":`[${projectName}] ${branchName}`


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR makes information about Lagoon environment types available in the Kubernetes API. This facilitates, among other things, a fix for #1364.

# Closing issues
In combination with #1959, closes #1364.
