### PR TITLE
Add missing `builddeploy-kubernetes:complete` task to RC notifications

### DIFF
--- a/services/logs2rocketchat/src/readFromRabbitMQ.ts
+++ b/services/logs2rocketchat/src/readFromRabbitMQ.ts
@@ -112,6 +112,7 @@ export async function readFromRabbitMQ (msg: ConsumeMessage, channelWrapperLogs:
     case "task:deploy-openshift:finished":
     case "task:remove-openshift-resources:finished":
     case "task:builddeploy-openshift:complete":
+    case "task:builddeploy-kubernetes:complete":
       text = `*[${meta.projectName}]* `
       if (meta.shortSha) {
         text = `${text} \`${meta.branchName}\` (${meta.shortSha})`


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

closes #1970 