### PR TITLE
Add newrelic to api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -267,6 +267,10 @@ services:
       - keycloak
     ports:
       - '3000:3000'
+    # Uncomment for local new relic tracking
+    # environment:
+    #   - NEW_RELIC_LICENSE_KEY=
+    #   - NEW_RELIC_APP_NAME=api-local
     labels:
       lagoon.type: custom
       lagoon.template: services/api/.lagoon.app.yml

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -23,8 +23,14 @@
     "sync:harbor:projects": "node dist/migrations/2-harbor/harborSync.js"
   },
   "nodemonConfig": {
-    "ignore": ["*.test.js", "../../node-packages/commons/dist/"],
-    "watch": ["src", "../../node-packages/"],
+    "ignore": [
+      "*.test.js",
+      "../../node-packages/commons/dist/"
+    ],
+    "watch": [
+      "src",
+      "../../node-packages/"
+    ],
     "ext": "js,ts,json",
     "exec": "yarn build --incremental && yarn start --inspect=0.0.0.0:9229"
   },
@@ -60,6 +66,7 @@
     "mariasql": "^0.2.6",
     "moment": "^2.24.0",
     "morgan": "^1.9.0",
+    "newrelic": "^6.9.0",
     "node-cache": "^4.2.1",
     "ramda": "^0.25.0",
     "snakecase-keys": "^1.2.0",

--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -2,14 +2,16 @@ const R = require('ramda');
 const {
   ApolloServer,
   AuthenticationError,
-  makeExecutableSchema,
+  makeExecutableSchema
 } = require('apollo-server-express');
 const NodeCache = require('node-cache');
+const gql = require('graphql-tag');
+const newrelic = require('newrelic');
 const {
   getCredentialsForLegacyToken,
   getGrantForKeycloakToken,
   legacyHasPermission,
-  keycloakHasPermission,
+  keycloakHasPermission
 } = require('./util/auth');
 const { getSqlClient } = require('./clients/sqlClient');
 const { getKeycloakAdminClient } = require('./clients/keycloak-admin');
@@ -29,6 +31,7 @@ const apolloServer = new ApolloServer({
   schema,
   debug: process.env.NODE_ENV === 'development',
   introspection: true,
+  tracing: true,
   subscriptions: {
     onConnect: async (connectionParams, webSocket) => {
       const token = R.prop('authToken', connectionParams);
@@ -54,7 +57,7 @@ const apolloServer = new ApolloServer({
         if (!grant) {
           legacyCredentials = await getCredentialsForLegacyToken(
             sqlClientLegacy,
-            token,
+            token
           );
           sqlClientLegacy.end();
         }
@@ -66,7 +69,7 @@ const apolloServer = new ApolloServer({
       const keycloakAdminClient = await getKeycloakAdminClient();
       const requestCache = new NodeCache({
         stdTTL: 0,
-        checkperiod: 0,
+        checkperiod: 0
       });
 
       const sqlClient = getSqlClient();
@@ -82,10 +85,16 @@ const apolloServer = new ApolloServer({
         models: {
           UserModel: User.User({ keycloakAdminClient }),
           GroupModel: Group.Group({ keycloakAdminClient }),
-          BillingModel: BillingModel.BillingModel({ keycloakAdminClient, sqlClient }),
-          ProjectModel: ProjectModel.ProjectModel({ keycloakAdminClient, sqlClient }),
+          BillingModel: BillingModel.BillingModel({
+            keycloakAdminClient,
+            sqlClient
+          }),
+          ProjectModel: ProjectModel.ProjectModel({
+            keycloakAdminClient,
+            sqlClient
+          }),
           EnvironmentModel: EnvironmentModel.EnvironmentModel({ sqlClient })
-        },
+        }
       };
     },
     onDisconnect: (websocket, context) => {
@@ -95,14 +104,14 @@ const apolloServer = new ApolloServer({
       if (context.requestCache) {
         context.requestCache.flushAll();
       }
-    },
+    }
   },
   context: async ({ req, connection }) => {
     // Websocket requests
     if (connection) {
       // onConnect must always provide connection.context.
       return {
-        ...connection.context,
+        ...connection.context
       };
     }
 
@@ -111,10 +120,10 @@ const apolloServer = new ApolloServer({
       const keycloakAdminClient = await getKeycloakAdminClient();
       const requestCache = new NodeCache({
         stdTTL: 0,
-        checkperiod: 0,
+        checkperiod: 0
       });
 
-      const sqlClient = getSqlClient()
+      const sqlClient = getSqlClient();
 
       return {
         keycloakAdminClient,
@@ -123,7 +132,7 @@ const apolloServer = new ApolloServer({
           ? keycloakHasPermission(
               req.kauth.grant,
               requestCache,
-              keycloakAdminClient,
+              keycloakAdminClient
             )
           : legacyHasPermission(req.legacyCredentials),
         keycloakGrant: req.kauth ? req.kauth.grant : null,
@@ -131,10 +140,19 @@ const apolloServer = new ApolloServer({
         models: {
           UserModel: User.User({ keycloakAdminClient }),
           GroupModel: Group.Group({ keycloakAdminClient, sqlClient }),
-          BillingModel: BillingModel.BillingModel({ keycloakAdminClient, sqlClient }),
-          ProjectModel: ProjectModel.ProjectModel({ keycloakAdminClient, sqlClient }),
-          EnvironmentModel: EnvironmentModel.EnvironmentModel({ keycloakAdminClient, sqlClient })
-        },
+          BillingModel: BillingModel.BillingModel({
+            keycloakAdminClient,
+            sqlClient
+          }),
+          ProjectModel: ProjectModel.ProjectModel({
+            keycloakAdminClient,
+            sqlClient
+          }),
+          EnvironmentModel: EnvironmentModel.EnvironmentModel({
+            keycloakAdminClient,
+            sqlClient
+          })
+        }
       };
     }
   },
@@ -146,10 +164,11 @@ const apolloServer = new ApolloServer({
       path: error.path,
       ...(process.env.NODE_ENV === 'development'
         ? { extensions: error.extensions }
-        : {}),
+        : {})
     };
   },
   plugins: [
+    // mariasql client closer plugin
     {
       requestDidStart: () => ({
         willSendResponse: response => {
@@ -159,10 +178,61 @@ const apolloServer = new ApolloServer({
           if (response.context.requestCache) {
             response.context.requestCache.flushAll();
           }
-        },
-      }),
+        }
+      })
     },
-  ],
+    // newrelic instrumentation plugin. Based heavily on https://github.com/essaji/apollo-newrelic-extension-plus
+    {
+      requestDidStart({ request }) {
+        const operationName = R.prop('operationName', request);
+        const queryString = R.prop('query', request);
+        const variables = R.prop('variables', request);
+
+        const queryObject = gql`
+          ${queryString}
+        `;
+        const rootFieldName = queryObject.definitions[0].selectionSet.selections.reduce(
+          (init, q, idx) =>
+            idx === 0 ? `${q.name.value}` : `${init}, ${q.name.value}`,
+          ''
+        );
+
+        // operationName is set by the client and optional. rootFieldName is
+        // set by the API type defs.
+        // operationName would be "getHighCottonProjectId" and rootFieldName
+        // would be "getProjectByName" with a query like:
+        // query getHighCottonProjectId { getProjectByName(name: "high-cotton") { id } }
+        const transactionName = operationName ? operationName : rootFieldName;
+        newrelic.setTransactionName(`graphql (${transactionName})`);
+        newrelic.addCustomAttribute('gqlQuery', queryString);
+        newrelic.addCustomAttribute('gqlVars', JSON.stringify(variables));
+
+        return {
+          willSendResponse: data => {
+            const { response } = data;
+            const traceDuration = R.pathSatisfies(
+              R.is(Number),
+              ['extensions', 'tracing', 'duration'],
+              response
+            )
+              ? `Total Duration (ms): ${R.path(
+                  ['extensions', 'tracing', 'duration'],
+                  response
+                ) / 1000000}`
+              : 'No trace data';
+            newrelic.addCustomAttribute('totalDuration', traceDuration);
+            newrelic.addCustomAttribute(
+              'errorCount',
+              R.pipe(
+                R.propOr([], 'errors'),
+                R.length
+              )(response)
+            );
+          }
+        };
+      }
+    }
+  ]
 });
 
 module.exports = apolloServer;

--- a/services/api/src/index.js
+++ b/services/api/src/index.js
@@ -1,3 +1,4 @@
+require('newrelic');
 const { initSendToLagoonLogs } = require('@lagoon/commons/dist/logs');
 const { initSendToLagoonTasks } = require('@lagoon/commons/dist/tasks');
 const waitForKeycloak = require('./util/waitForKeycloak');

--- a/services/api/src/newrelic.js
+++ b/services/api/src/newrelic.js
@@ -1,0 +1,49 @@
+'use strict'
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['api'],
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'info'
+  },
+  /**
+   * When true, all request headers except for those listed in attributes.exclude
+   * will be captured for all traces, unless otherwise specified in a destination's
+   * attributes include/exclude lists.
+   */
+  allow_all_headers: true,
+  attributes: {
+    /**
+     * Prefix of attributes to exclude from all destinations. Allows * as wildcard
+     * at end.
+     *
+     * NOTE: If excluding headers, they must be in camelCase form to be filtered.
+     *
+     * @env NEW_RELIC_ATTRIBUTES_EXCLUDE
+     */
+    exclude: [
+      'request.headers.cookie',
+      'request.headers.authorization',
+      'request.headers.proxyAuthorization',
+      'request.headers.setCookie*',
+      'request.headers.x*',
+      'response.headers.cookie',
+      'response.headers.authorization',
+      'response.headers.proxyAuthorization',
+      'response.headers.setCookie*',
+      'response.headers.x*'
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,21 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
+"@grpc/grpc-js@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.0.3.tgz#7fa2ba293ccc1e91b24074c2628c8c68336e18c4"
+  integrity sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==
+  dependencies:
+    semver "^6.2.0"
+
+"@grpc/proto-loader@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.5.4.tgz#038a3820540f621eeb1b05d81fbedfb045e14de0"
+  integrity sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    protobufjs "^6.8.6"
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
@@ -2015,6 +2030,33 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
+
+"@newrelic/aws-sdk@^1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/aws-sdk/-/aws-sdk-1.1.3.tgz#e51adcf0cd3b5a527b96a86ac24b5adaeac1cb0c"
+  integrity sha512-8O//20g3WxpTWiUcY8EWodfSlQ9qre0smbvA8N1B9sw42DYDfuYq011No/7/yynMPL5taY7cOwKkTUfqzzslCA==
+
+"@newrelic/koa@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/koa/-/koa-3.0.0.tgz#048f636c6c06ab4e823674a2ed3d67677a22ed50"
+  integrity sha512-SxfcMqSxiKa3pi7dRmVoCXnh/VLc196GmwyGU2Fr5+vMxS5jPVj2a15v1mn2DGu04XngfXDvyt9Xa6u1JVRDpQ==
+  dependencies:
+    methods "^1.1.2"
+
+"@newrelic/native-metrics@^5.1.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/native-metrics/-/native-metrics-5.2.0.tgz#db5fb09bc50b73dabe2620629c24dc9fa903a5d5"
+  integrity sha512-vqqC3uwbiAMsmDkDecqm4Bcn6gwskl31SpYY6X/Zzuee+CcNifry5kcfD2iW7w4ENGDjn53dntvuRLQcxnQyKQ==
+  dependencies:
+    nan "^2.14.1"
+    semver "^5.5.1"
+
+"@newrelic/superagent@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/superagent/-/superagent-2.0.1.tgz#8a0280598fedefd1b45fc83bdbc2707d129c47d5"
+  integrity sha512-1kOtaYh00DcK0IZ0LD3M6ja3urvm4a/waplr7TzrT/fDN/zgazpGSuRbYVg+O6zZacE4/Iw7OoKYGZW3bgBjJw==
+  dependencies:
+    methods "^1.1.2"
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -3217,6 +3259,11 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
+"@tyriar/fibonacci-heap@^2.0.7":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz#df3dcbdb1b9182168601f6318366157ee16666e9"
+  integrity sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA==
+
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -3642,6 +3689,11 @@ address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agentkeepalive@^3.4.1:
   version "3.5.2"
@@ -5957,6 +6009,16 @@ concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
+
 configstore@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
@@ -6721,7 +6783,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -7417,6 +7479,18 @@ escodegen@^1.12.0, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@^1.14.1:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.2.tgz#14ab71bf5026c2aa08173afba22c6f3173284a84"
+  integrity sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-airbnb-base@^12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
@@ -7548,7 +7622,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -9152,6 +9226,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -10469,7 +10551,7 @@ json-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-stream/-/json-stream-1.0.0.tgz#1a3854e28d2bbeeab31cc7ddf683d2ddc5652708"
   integrity sha1-GjhU4o0rvuqzHMfd9oPS3cVlJwg=
 
-json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.x, json-stringify-safe@^5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -11367,7 +11449,7 @@ messageformat@^1.0.2:
     nopt "~3.0.6"
     reserved-words "^0.1.2"
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -11719,6 +11801,11 @@ nan@^2.0.9, nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nan@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
 nano@^6.4.3:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/nano/-/nano-6.4.4.tgz#4902a095e5186cfb23612c78826ea755b76fadf0"
@@ -11796,6 +11883,28 @@ newman@^4.5.4:
     serialised-error "1.1.3"
     word-wrap "1.2.3"
     xmlbuilder "13.0.2"
+
+newrelic@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-6.9.0.tgz#b117a68cb2564dff917966984e6f3e073eb9712e"
+  integrity sha512-prgxTJ4sxS8bG87WbRMW9e7/E0TE9gEiMz/bjrLvo9Pgwo9bCoV7bzIFBaxnaLQReLvr5xWuNEQB+lHackSSSQ==
+  dependencies:
+    "@grpc/grpc-js" "1.0.3"
+    "@grpc/proto-loader" "^0.5.4"
+    "@newrelic/aws-sdk" "^1.1.1"
+    "@newrelic/koa" "^3.0.0"
+    "@newrelic/superagent" "^2.0.1"
+    "@tyriar/fibonacci-heap" "^2.0.7"
+    async "^2.1.4"
+    concat-stream "^2.0.0"
+    escodegen "^1.14.1"
+    esprima "^4.0.1"
+    https-proxy-agent "^4.0.0"
+    json-stringify-safe "^5.0.0"
+    readable-stream "^3.6.0"
+    semver "^5.3.0"
+  optionalDependencies:
+    "@newrelic/native-metrics" "^5.1.0"
 
 next-server@8.1.0:
   version "8.1.0"
@@ -14328,6 +14437,15 @@ read-pkg@^3.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@^3.0.2, readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^3.1.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.5.0.tgz#465d70e6d1087f6162d079cd0b5db7fbebfd1606"
@@ -15146,7 +15264,17 @@ serialised-error@1.1.3:
     stack-trace "0.0.9"
     uuid "^3.0.0"
 
-serialize-javascript@1.6.1, serialize-javascript@^1.7.0, serialize-javascript@^2.1.0, serialize-javascript@^2.1.1:
+serialize-javascript@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
+  integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
+
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
+serialize-javascript@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

In an effort to get more info into performance issues (see #1908) this PR adds new relic tracking support to the API. We offer it to our amazee.io customers, may as well take advantage of it ourselves too!

This initial work is very basic. [SQL tracing](https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent#database) is only supported out of the box with the mysql/mysql2 packages. That's different than our planned switch to mariadb (#1270). There is no OOTB support for apollo/graphql, so the only data we currently get is timing info.

Instrumenting of external requests (keycloak) also looks to be somewhat bare at this time.

To enable in production, add an environment variable `NEW_RELIC_LICENSE_KEY`

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
n/a
