### PR TITLE
Added Quotes for Harbor-Core Configmap

### DIFF
--- a/services/harbor-core/harbor-core.yml
+++ b/services/harbor-core/harbor-core.yml
@@ -190,7 +190,7 @@ objects:
     CLAIR_HEALTH_CHECK_SERVER_URL: "http://harborclair:6061"
     WITH_TRIVY: "true"
     TRIVY_ADAPTER_URL: "harbor-trivy:8080"
-    ROBOT_TOKEN_DURATION: 500
+    ROBOT_TOKEN_DURATION: "500"
     HTTP_PROXY: ""
     HTTPS_PROXY: ""
     NO_PROXY: "harbor-core,harbor-jobservice,harbor-database,harborclair,harborclairadapter,harborregistry,harbor-portal,harbor-trivy,127.0.0.1,localhost,.local,.internal"


### PR DESCRIPTION
 # Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This bugfix adds quotes around the value for `ROBOT_TOKEN_DURATION`, which are required.
