### PR TITLE
Include feature branch cron example

### DIFF
--- a/docs/using_lagoon/lagoon_yml.md
+++ b/docs/using_lagoon/lagoon_yml.md
@@ -83,8 +83,6 @@ environments:
        service: cli
 ```
 
-> Note: You can define feature branch tasks when Lagoon unlike other Lagoon processes it looks for the branch name directly.
-
 ## General Settings
 
 ### `docker-compose-yaml`

--- a/docs/using_lagoon/lagoon_yml.md
+++ b/docs/using_lagoon/lagoon_yml.md
@@ -75,8 +75,15 @@ environments:
        schedule: "H * * * *" # This will run the cron once per hour.
        command: drush cron
        service: cli
+  feature/feature-branch:
+    cronjobs:
+     - name: drush cron
+       schedule: "H * * * *" # This will run the cron once per hour.
+       command: drush cron
+       service: cli
 ```
 
+> Note: You can define feature branch tasks when Lagoon unlike other Lagoon processes it looks for the branch name directly.
 
 ## General Settings
 


### PR DESCRIPTION
There is a little confusion between when Lagoon uses `GIT_SAFE_BRANCH` and `GIT_BRANCH`. When defining a custom cron task on a feature branch it appears to use the `GIT_BRANCH` directly when looking for a valid YAML key.

**Example:**

```
shyaml keys environments.feature/feature-branch.cronjobs
```
