### PR TITLE
Add authentication support in redis base image

### DIFF
--- a/docs/using_lagoon/docker_images/redis.md
+++ b/docs/using_lagoon/docker_images/redis.md
@@ -25,7 +25,7 @@ Environment variables defined in Redis base image. See also [https://raw.githubu
 
 | Environment Variable | Default | Description |
 | :--- | :--- | :--- |
-| `LOGLEVEL` | notice | Define the level of logs |
 | `DATABASES` | -1 | Default number of databases created at startup |
+| `LOGLEVEL` | notice | Define the level of logs |
 | `MAXMEMORY` | 100mb | Maximum amount of memory |
-
+| `REDIS_PASSWORD` | disabled | Enables [authentication feature](https://redis.io/topics/security#authentication-feature) |

--- a/images/redis/conf/redis.conf
+++ b/images/redis/conf/redis.conf
@@ -11,4 +11,6 @@ maxmemory-policy allkeys-lru
 protected-mode no
 bind 0.0.0.0
 
+${REQUIREPASS_CONF:-}
+
 include /etc/redis/${FLAVOR:-ephemeral}.conf

--- a/images/redis/docker-entrypoint
+++ b/images/redis/docker-entrypoint
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+if [[ -n "${REDIS_PASSWORD}" ]]; then
+  export REQUIREPASS_CONF="# Enable basic/simple authentication
+# Warning: since Redis is pretty fast an outside user can try up to
+# 150k passwords per second against a good box. This means that you should
+# use a very strong password otherwise it will be very easy to break.
+requirepass ${REDIS_PASSWORD}"
+fi
+
 ep /etc/redis/*
 
 exec "$@"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Adds a new environment variable `REDIS_PASSWORD` that will turn on the [authentication feature](https://redis.io/topics/security#authentication-feature) of redis. When using the API to set the environment variable, it can be used in the other services (e.g. php-fpm) to authenticate correctly.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
n/a
