### PR TITLE
Segment groups lookup

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -1018,6 +1018,14 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
           value
           scope
         }
+      }
+    }
+`);
+
+export const getBillingGroupForProject = (project: string): Promise<any> =>
+  graphqlapi.query(`
+    {
+      project:projectByName(name: "${project}"){
         groups {
           ... on BillingGroup {
             type

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -6,7 +6,7 @@ import sha1 from 'sha1';
 import crypto from 'crypto';
 import moment from 'moment';
 import { logger } from '@lagoon/commons/dist/local-logging';
-import { getOpenShiftInfoForProject, addOrUpdateEnvironment, getEnvironmentByName, addDeployment } from '@lagoon/commons/dist/api';
+import { getOpenShiftInfoForProject, addOrUpdateEnvironment, getEnvironmentByName, addDeployment, getBillingGroupForProject } from '@lagoon/commons/dist/api';
 
 import { sendToLagoonLogs, initSendToLagoonLogs } from '@lagoon/commons/dist/logs';
 import { consumeTasks, initSendToLagoonTasks, createTaskMonitor } from '@lagoon/commons/dist/tasks';
@@ -44,6 +44,8 @@ const messageConsumer = async msg => {
 
   const result = await getOpenShiftInfoForProject(projectName);
   const projectOpenShift = result.project
+  const billingGroupResult = await getBillingGroupForProject(projectName);
+  const projectBillingGroup = billingGroupResult.project
 
   try {
 
@@ -94,7 +96,7 @@ const messageConsumer = async msg => {
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
     }
     var availability = projectOpenShift.availability || "STANDARD"
-    const billingGroup = projectOpenShift.groups.find(i => i.type == "billing" ) || ""
+    const billingGroup = projectBillingGroup.groups.find(i => i.type == "billing" ) || ""
     var uptimeRobotStatusPageId = billingGroup.uptimeRobotStatusPageId || ""
   } catch(error) {
     logger.error(`Error while loading information for project ${projectName}`)

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -5,7 +5,7 @@ import R from 'ramda';
 import sha1 from 'sha1';
 import crypto from 'crypto';
 import { logger } from '@lagoon/commons/dist/local-logging';
-import { getOpenShiftInfoForProject, addOrUpdateEnvironment, getEnvironmentByName, addDeployment } from '@lagoon/commons/dist/api';
+import { getOpenShiftInfoForProject, addOrUpdateEnvironment, getEnvironmentByName, addDeployment, getBillingGroupForProject } from '@lagoon/commons/dist/api';
 
 import { sendToLagoonLogs, initSendToLagoonLogs } from '@lagoon/commons/dist/logs';
 import { consumeTasks, initSendToLagoonTasks, createTaskMonitor } from '@lagoon/commons/dist/tasks';
@@ -39,6 +39,8 @@ const messageConsumer = async msg => {
 
   const result = await getOpenShiftInfoForProject(projectName);
   const projectOpenShift = result.project
+  const billingGroupResult = await getBillingGroupForProject(projectName);
+  const projectBillingGroup = billingGroupResult.project
 
   const ocsafety = string => string.toLocaleLowerCase().replace(/[^0-9a-z-]/g,'-')
 
@@ -95,7 +97,7 @@ const messageConsumer = async msg => {
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
     }
     var availability = projectOpenShift.availability || "STANDARD"
-    const billingGroup = projectOpenShift.groups.find(i => i.type == "billing" ) || ""
+    const billingGroup = projectBillingGroup.groups.find(i => i.type == "billing" ) || ""
     var uptimeRobotStatusPageId = billingGroup.uptimeRobotStatusPageId || ""
   } catch(error) {
     logger.error(`Error while loading information for project ${projectName}`)


### PR DESCRIPTION
# Changelog Entry
Look up the billingGroup in it's own query, so that it is only executed when needed, rather than on every call to `getOpenShiftInfoForProject`

closes #2023 