### PR TITLE
Fixed the re-creation of .my.cnf symbolic link

### DIFF
--- a/images/mariadb/entrypoints/9999-mariadb-init.bash
+++ b/images/mariadb/entrypoints/9999-mariadb-init.bash
@@ -39,7 +39,7 @@ if [ -n "$MARIADB_COPY_DATA_DIR_SOURCE" ]; then
   fi
 fi
 
-ln -s ${MARIADB_DATA_DIR:-/var/lib/mysql}/.my.cnf /home/.my.cnf
+ln -sf ${MARIADB_DATA_DIR:-/var/lib/mysql}/.my.cnf /home/.my.cnf
 
 if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
   if [ ! -d "/run/mysqld" ]; then


### PR DESCRIPTION
One of the mariadb image's entrypoints, creates `/home/.my.cnf` symlink at first running.
The second time container is started (so with already existent data), it fails because file already exists.
This PR will fix by `forcing` the re-creation of the symlink.

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

PR solves the fails of starting of MariaDB containers because of `.my.cnf` file already exists

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #2042 
