### PR TITLE
Label using the target env-type instead of the build env-type

### DIFF
--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -360,7 +360,7 @@ const messageConsumer = async msg => {
           "labels": {
             "lagoon.sh/project": projectName,
             "lagoon.sh/environment": environmentName,
-            "lagoon.sh/environmentType": lagoonEnvironmentType
+            "lagoon.sh/environmentType": environmentType
           }
         }
       }

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -358,7 +358,7 @@ const messageConsumer = async msg => {
             "labels": {
               "lagoon.sh/project": safeProjectName,
               "lagoon.sh/environment": safeBranchName,
-              "lagoon.sh/environmentType": lagoonEnvironmentType
+              "lagoon.sh/environmentType": environmentType
             }
           },
           "displayName":`[${projectName}] ${branchName}`


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Update new namespace labelling to use the target `environmentType` instead of _build_ namespace `environmentType`.

# Closing issues
Closes #2041 
