### PR TITLE
Only run auto-idler service in production Lagoon

### DIFF
--- a/services/auto-idler/idle-clis.sh
+++ b/services/auto-idler/idle-clis.sh
@@ -2,6 +2,8 @@
 
 # set -e -o pipefail
 
+if [ "${LAGOON_ENVIRONMENT_TYPE}" == "production" ]; then
+
 prefixwith() {
   local prefix="$1"
   shift
@@ -46,3 +48,5 @@ done
 sleep 5
 # clean up the tmp file
 rm $TMP_DATA
+
+fi

--- a/services/auto-idler/idle-services.sh
+++ b/services/auto-idler/idle-services.sh
@@ -3,6 +3,8 @@
 # make sure we stop if we fail
 set -eo pipefail
 
+if [ "${LAGOON_ENVIRONMENT_TYPE}" == "production" ]; then
+
 prefixwith() {
   local prefix="$1"
   shift
@@ -52,3 +54,5 @@ done
 sleep 5
 # clean up the tmp file
 rm $TMP_DATA
+
+fi


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Idling is not required in development lagoons, so we should disable it.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #2044 
