### PR TITLE
Add PECL Yaml 2.1.0 to the base PHP images

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -61,6 +61,8 @@ RUN apk add --no-cache fcgi \
         # for webp
         libwebp-dev \
         postgresql-dev \
+        # for yaml
+        yaml-dev \
         # for imagemagick
         imagemagick \
         imagemagick-libs \
@@ -68,6 +70,7 @@ RUN apk add --no-cache fcgi \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && yes '' | pecl install -f apcu \
     && yes '' | pecl install -f xdebug \
+    && yes '' | pecl install -f yaml \
     && yes '' | pecl install -f redis-4.3.0 \
     && yes '' | pecl install -f imagick \
     && docker-php-ext-enable apcu redis xdebug imagick \
@@ -83,6 +86,7 @@ RUN apk add --no-cache fcgi \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && rm -rf /var/cache/apk/* /tmp/pear/ \
     && apk del .phpize-deps \
+    && echo "extension=yaml.so" > /usr/local/etc/php/conf.d/yaml.ini \
     && mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

Adds the PECL Yaml extension into the base PHP images. The extension supports PHP 7.1.0+, so it should build fine on all supported images.

Drupal 8 will make use of this extension automatically for all Yaml reads.

# Closing issues
Closes #2056
