### PR TITLE
HOTFIX: 1.8.0 - bug fix for BillingCost query, missing sqlClient for Project …

### DIFF
--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -84,7 +84,7 @@ const apolloServer = new ApolloServer({
         requestCache,
         models: {
           UserModel: User.User({ keycloakAdminClient, redisClient }),
-          GroupModel: Group.Group({ keycloakAdminClient, redisClient }),
+          GroupModel: Group.Group({ keycloakAdminClient, sqlClient, redisClient }),
           BillingModel: BillingModel.BillingModel({
             keycloakAdminClient,
             sqlClient
@@ -139,7 +139,7 @@ const apolloServer = new ApolloServer({
         requestCache,
         models: {
           UserModel: User.User({ keycloakAdminClient, redisClient }),
-          GroupModel: Group.Group({ keycloakAdminClient, redisClient }),
+          GroupModel: Group.Group({ keycloakAdminClient, sqlClient, redisClient }),
           BillingModel: BillingModel.BillingModel({
             keycloakAdminClient,
             sqlClient


### PR DESCRIPTION
The following Query was throwing an error: 

```
query billingGroupCosts {
  billingGroupCost(input: {name: "xxxx"}, month: "2020-04")
}
```

```
{
  "errors": [
    {
      "message": "Cannot read property 'query' of undefined",
      "locations": [
        {
          "line": 108,
          "column": 3
        }
      ],
      "path": [
        "billingGroupCost"
      ]
    }
  ],
  "data": {
    "billingGroupCost": null
  }
}
```

Related to this commit removing the sqlClient from the GroupModel instantiation: https://github.com/amazeeio/lagoon/commit/6985a18ddfe8448507c6c7afb781e99a7c6d71a8#diff-1916635edf2bd714a3c23ba55962aaee