### PR TITLE
Removes return statement in custom vcl to allow fallback in order to deal with no-cache/private/no-store

### DIFF
--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -329,6 +329,12 @@ sub vcl_backend_response {
     set beresp.http.Expires = "" + (now + beresp.ttl);
   }
 
+  if (!beresp.http.Surrogate-Control && beresp.http.Cache-Control ~ "(?i:no-cache|no-store|private)") {
+    # Mark as "Hit-For-Miss" for the next 120 seconds
+    set beresp.ttl = 120s;
+    set beresp.uncacheable = true;
+  }
+
   # Files larger than 10 MB get streamed.
   if (beresp.http.Content-Length ~ "[0-9]{8,}") {
     set beresp.do_stream = true;

--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -329,12 +329,6 @@ sub vcl_backend_response {
     set beresp.http.Expires = "" + (now + beresp.ttl);
   }
 
-  if (!beresp.http.Surrogate-Control && beresp.http.Cache-Control ~ "(?i:no-cache|no-store|private)") {
-    # Mark as "Hit-For-Miss" for the next 120 seconds
-    set beresp.ttl = 120s;
-    set beresp.uncacheable = true;
-  }
-
   # Files larger than 10 MB get streamed.
   if (beresp.http.Content-Length ~ "[0-9]{8,}") {
     set beresp.do_stream = true;
@@ -347,8 +341,6 @@ sub vcl_backend_response {
     set beresp.do_stream = true;
     set beresp.ttl = 0s;
   }
-
-  return (deliver);
 }
 
 # Set a header to track a cache HIT/MISS.


### PR DESCRIPTION
This PR introduces some VCL from the default.vcl to deal with cache-control scenarios where we're currently caching assets that are explicitly marked for no caching

Before the change, when running the current varnish-drupal image, I'm getting the following (erroneous) behaviour:

```
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: HIT

```

Whereas, locally, after building and using the new varnish-drupal with this PRs changes we have

```
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/.lagoonhealthz | grep Cache
Cache-Control: must-revalidate, no-cache, private
X-Varnish-Cache: MISS
```

Standard responses are still cached
```
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/en | grep Cache
Cache-Control: max-age=900, public
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/en | grep Cache
Cache-Control: max-age=900, public
X-Varnish-Cache: HIT
```

And sessions are uncached, as expected

```
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/en --cookie SSESS123123=12312313 | grep Cache
Cache-Control: max-age=900, public
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/en --cookie SSESS123123=12312313 | grep Cache
Cache-Control: max-age=900, public
X-Varnish-Cache: MISS
bomoko@ADA:/work/Amazee/AmazeeLabsV4_com$ curl -sLIXGET http://amazeelabs-v4.com.docker.amazee.io/en --cookie SSESS123123=12312313 | grep Cache
Cache-Control: max-age=900, public
X-Varnish-Cache: MISS
```

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The details are given fully in issue #2065 

# Closing issues
closes #2065 
