### PR TITLE
Add Cluster Name on Billing Group Admin pages

### DIFF
--- a/services/ui/src/components/BillingGroups/index.js
+++ b/services/ui/src/components/BillingGroups/index.js
@@ -13,10 +13,10 @@ const BillingGroups = ({ billingGroups }) => (
     <div className="data-table">
       {!billingGroups.length && <div className="data-none">No BillingGroups</div>}
       {
-        billingGroups.map(({name, id, currency}) => (
+        billingGroups.map(({name, id, currency, projects}) => (
           <BillingGroupLink billingGroupSlug={name} key={id}>
             <div className="data-row" key={id}>
-              <div className="name">{name}</div>
+              <div className="name">{name}<br/><span className="cluster">{projects[0].openshift.name}</span></div>
               <div className="currency">{currency}</div>
             </div>
           </BillingGroupLink>
@@ -59,6 +59,10 @@ const BillingGroups = ({ billingGroups }) => (
             }
           }
         }
+      }
+
+      .cluster {
+        color: gray;
       }
 
       .data-table {

--- a/services/ui/src/lib/query/AllBillingGroups.js
+++ b/services/ui/src/lib/query/AllBillingGroups.js
@@ -6,6 +6,11 @@ export default gql`
       id, name
       ... on BillingGroup {
         currency
+        projects{
+          openshift {
+            name
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied


Minor UI update to show the cluster name for each billing group

# Closing issues
https://github.com/amazeeio/lagoon/issues/2069
