### PR TITLE
Add Lagoon labels to OpenShift projects/namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -651,8 +651,12 @@ local-registry-up: build/local-registry
 openshift-run-api-tests = $(foreach image,$(api-tests),openshift-tests/$(image))
 .PHONY: $(openshift-run-api-tests)
 $(openshift-run-api-tests): minishift build/oc-build-deploy-dind openshift-test-services-up push-minishift
-		$(eval testname = $(subst openshift-tests/,,$@))
-		IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility run --rm tests-openshift ansible-playbook /ansible/tests/$(testname).yaml
+	$(eval testname = $(subst openshift-tests/,,$@))
+	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) \
+		--compatibility run --rm tests-openshift ansible-playbook \
+		/ansible/tests/$(testname).yaml \
+		--extra-vars \
+		"$$(./local-dev/minishift/minishift --profile $(CI_BUILD_TAG) ssh -- cat /home/docker/.kube/config | jq -rcsR '{kubeconfig: .}')"
 
 openshift-run-drupal-tests = $(foreach image,$(drupal-tests),openshift-tests/$(image))
 .PHONY: $(openshift-run-drupal-tests)

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -322,7 +322,6 @@ const messageConsumer = async msg => {
   // openshift-client does not know about the OpenShift Resources, let's teach it.
   openshift.ns.addResource('buildconfigs');
   openshift.ns.addResource('rolebindings');
-  openshift.addResource('projectrequests');
 
   // If we should promote, first check if the source project does exist
   if (type == "promote") {
@@ -347,21 +346,23 @@ const messageConsumer = async msg => {
     // a non existing project also throws an error, we check if it's a 404, means it does not exist, so we create it.
     if (err.code == 404 || err.code == 403) {
       logger.info(`${openshiftProject}: Project ${openshiftProject}  does not exist, creating`)
-      const projectrequestsPost = promisify(openshift.projectrequests.post)
+      const projectsPost = promisify(openshift.projects.post)
       // @ts-ignore
-      await projectrequestsPost({
+      await projectsPost({
         body: {
           "apiVersion":"v1",
-          "kind":"ProjectRequest",
+          "kind":"Project",
           "metadata": {
             "name":openshiftProject,
             "labels": {
               "lagoon.sh/project": safeProjectName,
               "lagoon.sh/environment": safeBranchName,
               "lagoon.sh/environmentType": environmentType
+            },
+            "annotations": {
+              "openshift.io/display-name":`[${projectName}] ${branchName}`
             }
-          },
-          "displayName":`[${projectName}] ${branchName}`
+          }
         } });
     } else {
       logger.error(err)

--- a/tests/tests/features-openshift.yaml
+++ b/tests/tests/features-openshift.yaml
@@ -4,6 +4,13 @@
   vars:
     testname: "API TOKEN"
 
+- include: features/namespace-labels.yaml
+  vars:
+    testname: "NAMESPACE LABELS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    git_repo_name: features.git
+    project: ci-features-{{ lookup('env','CLUSTER_TYPE') }}
+    branch: namespace-labels
+
 - include: features/remote-shell.yaml
   vars:
     testname: "REMOTE SHELL {{ lookup('env','CLUSTER_TYPE')|upper }}"

--- a/tests/tests/features/namespace-labels.yaml
+++ b/tests/tests/features/namespace-labels.yaml
@@ -24,6 +24,7 @@
     expected_labels:
     - "lagoon.sh/project={{ project }}"
     - "lagoon.sh/environment={{ branch }}"
+    - "lagoon.sh/environmentType=development"
   tasks:
   - include: ../../checks/check-namespace-labels.yaml
 


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR fixes project/namespace labelling for OpenShift.

# Closing issues
Closes #1969 

Thanks @shreddedbacon for the tip on how to fix this :)
