### PR TITLE
HOTFIX: Don't cache keycloak authz denials in redis

### DIFF
--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -284,11 +284,12 @@ export const keycloakHasPermission = (grant, requestCache, keycloakAdminClient) 
     }
 
     requestCache.set(cacheKey, false);
-    try {
-      await saveRedisCache(resourceScope, 0);
-    } catch (err) {
-      logger.warn(`Could not save authz cache: ${err.message}`);
-    }
+    // TODO: Re-enable when we can distinguish between error and access denied
+    // try {
+    //   await saveRedisCache(resourceScope, 0);
+    // } catch (err) {
+    //   logger.warn(`Could not save authz cache: ${err.message}`);
+    // }
     throw new KeycloakUnauthorizedError(`Unauthorized: You don't have permission to "${scope}" on "${resource}".`);
   };
 };


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

They keycloak node library doesn't tell us if a keycloak authz denial is because the user doesn't have permission or if because there was some other error, like a network timeout. So we shouldn't cache a denial until we know it's a legit access check.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
Hotfix for #2078 
