### PR TITLE
Changing twig emptyDir mount to only mount "php" folder

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/_helpers.tpl
@@ -86,5 +86,5 @@ Generate name for twig storage emptyDir
 Generate path for twig storage emptyDir
 */}}
 {{- define "cli-persistent.twig-storage.path" -}}
-{{- printf "%s/php/twig" .Values.persistentStorage.path }}
+{{- printf "%s/php" .Values.persistentStorage.path }}
 {{- end -}}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/_helpers.tpl
@@ -100,5 +100,5 @@ Generate name for twig storage emptyDir
 Generate path for twig storage emptyDir
 */}}
 {{- define "nginx-php-persistent.twig-storage.path" -}}
-{{- printf "%s/php/twig" .Values.persistentStorage.path }}
+{{- printf "%s/php" .Values.persistentStorage.path }}
 {{- end -}}

--- a/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
@@ -128,7 +128,7 @@ objects:
                   name: lagoon-sshkey
                   readOnly: true
                 - name: ${PERSISTENT_STORAGE_NAME}-twig
-                  mountPath: ${PERSISTENT_STORAGE_PATH}/php/twig
+                  mountPath: ${PERSISTENT_STORAGE_PATH}/php
               resources:
                 requests:
                   cpu: 10m

--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php-persistent/deployment.yml
@@ -173,7 +173,7 @@ objects:
                 - name: ${SERVICE_NAME}
                   mountPath: ${PERSISTENT_STORAGE_PATH}
                 - name: ${SERVICE_NAME}-twig
-                  mountPath: ${PERSISTENT_STORAGE_PATH}/php/twig
+                  mountPath: ${PERSISTENT_STORAGE_PATH}/php
               resources:
                 requests:
                   cpu: 10m

--- a/images/oc-build-deploy-dind/openshift-templates/nginx-php-redis-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/nginx-php-redis-persistent/deployment.yml
@@ -183,7 +183,7 @@ objects:
                 - name: ${SERVICE_NAME}
                   mountPath: ${PERSISTENT_STORAGE_PATH}
                 - name: ${SERVICE_NAME}-twig
-                  mountPath: ${PERSISTENT_STORAGE_PATH}/php/twig
+                  mountPath: ${PERSISTENT_STORAGE_PATH}/php
               resources:
                 requests:
                   cpu: 10m


### PR DESCRIPTION
 # Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR changes the way we are mounting the default twig caching directory such that it no longer tries to create a subfolder with erroneous permissions.