### PR TITLE
Hotfix - BillingGroups Removing Cluster

### DIFF
--- a/services/ui/src/components/BillingGroups/index.js
+++ b/services/ui/src/components/BillingGroups/index.js
@@ -13,10 +13,10 @@ const BillingGroups = ({ billingGroups }) => (
     <div className="data-table">
       {!billingGroups.length && <div className="data-none">No BillingGroups</div>}
       {
-        billingGroups.map(({name, id, currency, projects}) => (
+        billingGroups.map(({name, id, currency}) => (
           <BillingGroupLink billingGroupSlug={name} key={id}>
             <div className="data-row" key={id}>
-              <div className="name">{name}<br/><span className="cluster">{projects[0].openshift.name}</span></div>
+              <div className="name">{name}</div>
               <div className="currency">{currency}</div>
             </div>
           </BillingGroupLink>
@@ -59,10 +59,6 @@ const BillingGroups = ({ billingGroups }) => (
             }
           }
         }
-      }
-
-      .cluster {
-        color: gray;
       }
 
       .data-table {

--- a/services/ui/src/lib/query/AllBillingGroups.js
+++ b/services/ui/src/lib/query/AllBillingGroups.js
@@ -6,11 +6,6 @@ export default gql`
       id, name
       ... on BillingGroup {
         currency
-        projects{
-          openshift {
-            name
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Fixes an issue with the Billing Group Admin page. Deleted projects caused the graphql projects query to fail. This needs to be addresses separately. 