### PR TITLE
Fix hard-coded DB host in wait-for-mariadb.sh scripts

### DIFF
--- a/services/api/wait-for-mariadb.sh
+++ b/services/api/wait-for-mariadb.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-set -eo pipefail
-
-echo "Waiting until mariadb is ready "
-until $(nc -zv api-db 3306); do
-    printf '.'
+set -eu
+echo "Waiting until ${API_DB_HOST:-api-db} is ready"
+until nc -vzw5 "${API_DB_HOST:-api-db}" 3306; do
     sleep 1
 done

--- a/services/keycloak/start.sh
+++ b/services/keycloak/start.sh
@@ -1622,15 +1622,11 @@ configure_keycloak &
 
 /bin/sh /opt/jboss/tools/databases/change-database.sh mariadb
 
-if [ -z "$BIND" ]; then
-    BIND=$(hostname --all-ip-addresses)
-fi
-if [ -z "$BIND_OPTS" ]; then
-    for BIND_IP in $BIND
-    do
-        BIND_OPTS+=" -Djboss.bind.address=$BIND_IP -Djboss.bind.address.private=$BIND_IP "
-    done
-fi
+BIND=$(hostname --all-ip-addresses | cut -d' ' -f1)
+BIND_OPTS=" -Djboss.bind.address=0.0.0.0"
+BIND_OPTS+=" -Djboss.bind.address.private=0.0.0.0"
+BIND_OPTS+=" -Djgroups.bind_addr=$BIND"
+
 SYS_PROPS+=" $BIND_OPTS"
 
 # If the server configuration parameter is not present, append the HA profile.

--- a/services/keycloak/wait-for-mariadb.sh
+++ b/services/keycloak/wait-for-mariadb.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
-
-set -eo pipefail
-
-echo "Waiting until mariadb is ready "
-until $(nc -zv keycloak-db 3306); do
-    printf '.'
+set -eu
+echo "Waiting until $DB_ADDR is ready"
+until nc -vzw5 "$DB_ADDR" 3306; do
     sleep 1
 done


### PR DESCRIPTION

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR removes hard-coded DB service names in the `keycloak` and `api` services, and allows the default DB service names to be overridden by environment variable.

# Closing issues
n/a
