### PR TITLE
Ignore the watchdog table for backups

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -21,6 +21,7 @@ spec:
     && mysqldump --max-allowed-packet=500M --events --routines --quick
     --add-locks --no-autocommit --single-transaction --no-create-db
     --ignore-table=$BACKUP_DB_DATABASE.watchdog
+    --no-create-info
     -h $BACKUP_DB_HOST
     -u $BACKUP_DB_USERNAME
     -p$BACKUP_DB_PASSWORD

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -9,13 +9,24 @@ metadata:
     {{- include "mariadb-dbaas.annotations" . | nindent 4 }}
 spec:
   backupCommand: >-
-    /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db
+    /bin/sh -c "dump=$(mktemp)
+    && mysqldump --max-allowed-packet=500M --events --routines --quick
+    --add-locks --no-autocommit --single-transaction --no-create-db
+    --no-data
+    -h $BACKUP_DB_HOST
+    -u $BACKUP_DB_USERNAME
+    -p$BACKUP_DB_PASSWORD
+    $BACKUP_DB_DATABASE
+    > $dump
+    && mysqldump --max-allowed-packet=500M --events --routines --quick
+    --add-locks --no-autocommit --single-transaction --no-create-db
     --ignore-table=$BACKUP_DB_DATABASE.watchdog
     -h $BACKUP_DB_HOST
     -u $BACKUP_DB_USERNAME
     -p$BACKUP_DB_PASSWORD
     $BACKUP_DB_DATABASE
-    > $dump && cat $dump && rm $dump"
+    >> $dump
+    && cat $dump && rm $dump"
   fileExtension: .{{ include "mariadb-dbaas.fullname" . }}.sql
   pod:
     metadata:

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   backupCommand: >-
     /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog
     -h $BACKUP_DB_HOST
     -u $BACKUP_DB_USERNAME
     -p$BACKUP_DB_PASSWORD

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -66,6 +66,7 @@ objects:
       && mysqldump --max-allowed-packet=500M --events --routines --quick
       --add-locks --no-autocommit --single-transaction --no-create-db
       --ignore-table=$BACKUP_DB_DATABASE.watchdog
+      --no-create-info
       -h $BACKUP_DB_HOST
       -u $BACKUP_DB_USERNAME
       -p$BACKUP_DB_PASSWORD

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -53,7 +53,25 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: >-
+      /bin/sh -c "dump=$(mktemp)
+      && mysqldump --max-allowed-packet=500M --events --routines --quick
+      --add-locks --no-autocommit --single-transaction --no-create-db
+      --no-data
+      -h $BACKUP_DB_HOST
+      -u $BACKUP_DB_USERNAME
+      -p$BACKUP_DB_PASSWORD
+      $BACKUP_DB_DATABASE
+      > $dump
+      && mysqldump --max-allowed-packet=500M --events --routines --quick
+      --add-locks --no-autocommit --single-transaction --no-create-db
+      --ignore-table=$BACKUP_DB_DATABASE.watchdog
+      -h $BACKUP_DB_HOST
+      -u $BACKUP_DB_USERNAME
+      -p$BACKUP_DB_PASSWORD
+      $BACKUP_DB_DATABASE
+      >> $dump
+      && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -66,6 +66,7 @@ objects:
       && mysqldump --max-allowed-packet=500M --events --routines --quick
       --add-locks --no-autocommit --single-transaction --no-create-db
       --ignore-table=$BACKUP_DB_DATABASE.watchdog
+      --no-create-info
       -h $BACKUP_DB_HOST
       -u $BACKUP_DB_USERNAME
       -p$BACKUP_DB_PASSWORD

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -53,7 +53,25 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: >-
+      /bin/sh -c "dump=$(mktemp)
+      && mysqldump --max-allowed-packet=500M --events --routines --quick
+      --add-locks --no-autocommit --single-transaction --no-create-db
+      --no-data
+      -h $BACKUP_DB_HOST
+      -u $BACKUP_DB_USERNAME
+      -p$BACKUP_DB_PASSWORD
+      $BACKUP_DB_DATABASE
+      > $dump
+      && mysqldump --max-allowed-packet=500M --events --routines --quick
+      --add-locks --no-autocommit --single-transaction --no-create-db
+      --ignore-table=$BACKUP_DB_DATABASE.watchdog
+      -h $BACKUP_DB_HOST
+      -u $BACKUP_DB_USERNAME
+      -p$BACKUP_DB_PASSWORD
+      $BACKUP_DB_DATABASE
+      >> $dump
+      && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Backups can fail for big tables. The table can be enormous and for lagoon will be unused since project will be using the `lagoon_logs` module. Not sure if this is really the best approach though, since `watchdog` might be used for something else in a non-drupal project.


# Closing issues
Closes: #2142 
