### PR TITLE
Rely on tar in $PATH for elasticsearch backups

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/elasticsearch-cluster/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/elasticsearch-cluster/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "/usr/bin/tar -cf - -C /usr/share/elasticsearch/data ."
+    backupCommand: /bin/sh -c "tar -cf - -C /usr/share/elasticsearch/data ."
     fileExtension: .${SERVICE_NAME}-0.tar
     pod:
       metadata:

--- a/images/oc-build-deploy-dind/openshift-templates/elasticsearch/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/elasticsearch/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "/usr/bin/tar -cf - -C /usr/share/elasticsearch/data ."
+    backupCommand: /bin/sh -c "tar -cf - -C /usr/share/elasticsearch/data ."
     fileExtension: .${SERVICE_NAME}.tar
     pod:
       metadata:


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

`/usr/bin/tar` doesn't exist in elasticsearch images, and `$PATH` is set, so just rely on that.

# Closing issues
Closes: #2141
