### PR TITLE
Remap database details in prebackuppod to avoid invalid names

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   backupCommand: >-
     /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db
-    -h ${{ include "mariadb-dbaas.fullnameUppercase" . }}_HOST
-    -u ${{ include "mariadb-dbaas.fullnameUppercase" . }}_USERNAME
-    -p${{ include "mariadb-dbaas.fullnameUppercase" . }}_PASSWORD
-    ${{ include "mariadb-dbaas.fullnameUppercase" . }}_DATABASE
+    -h $BACKUP_DB_HOST
+    -u $BACKUP_DB_USERNAME
+    -p$BACKUP_DB_PASSWORD
+    $BACKUP_DB_DATABASE
     > $dump && cat $dump && rm $dump"
   fileExtension: .{{ include "mariadb-dbaas.fullname" . }}.sql
   pod:
@@ -26,9 +26,27 @@ spec:
         - args:
             - sleep
             - '3600'
-          envFrom:
-            - configMapRef:
-                name: lagoon-env
+          env:
+            - name: BACKUP_DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ include "mariadb-dbaas.fullnameUppercase" . }}_HOST
+                  name: lagoon-env
+            - name: BACKUP_DB_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ include "mariadb-dbaas.fullnameUppercase" . }}_USERNAME
+                  name: lagoon-env
+            - name: BACKUP_DB_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ include "mariadb-dbaas.fullnameUppercase" . }}_PASSWORD
+                  name: lagoon-env
+            - name: BACKUP_DB_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ include "mariadb-dbaas.fullnameUppercase" . }}_DATABASE
+                  name: lagoon-env
           image: amazeeio/alpine-mysql-client
           imagePullPolicy: Always
           name: {{ include "mariadb-dbaas.fullname" . }}-prebackuppod

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $${SERVICE_NAME_UPPERCASE}_HOST -u $${SERVICE_NAME_UPPERCASE}_USERNAME -p$${SERVICE_NAME_UPPERCASE}_PASSWORD $${SERVICE_NAME_UPPERCASE}_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:
@@ -67,9 +67,27 @@ objects:
           - args:
               - sleep
               - '3600'
-            envFrom:
-              - configMapRef:
-                  name: lagoon-env
+            env:
+              - name: BACKUP_DB_HOST
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_HOST
+                    name: lagoon-env
+              - name: BACKUP_DB_USERNAME
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_USERNAME
+                    name: lagoon-env
+              - name: BACKUP_DB_PASSWORD
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_PASSWORD
+                    name: lagoon-env
+              - name: BACKUP_DB_DATABASE
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_DATABASE
+                    name: lagoon-env
             image: amazeeio/alpine-mysql-client
             imagePullPolicy: Always
             name: ${SERVICE_NAME}-prebackuppod

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -53,7 +53,7 @@ objects:
       branch: ${SAFE_BRANCH}
       project: ${SAFE_PROJECT}
   spec:
-    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $${SERVICE_NAME_UPPERCASE}_HOST -u $${SERVICE_NAME_UPPERCASE}_USERNAME -p$${SERVICE_NAME_UPPERCASE}_PASSWORD $${SERVICE_NAME_UPPERCASE}_DATABASE > $dump && cat $dump && rm $dump"
+    backupCommand: /bin/sh -c "dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && cat $dump && rm $dump"
     fileExtension: .${SERVICE_NAME}.sql
     pod:
       metadata:
@@ -67,9 +67,27 @@ objects:
           - args:
               - sleep
               - '3600'
-            envFrom:
-              - configMapRef:
-                  name: lagoon-env
+            env:
+              - name: BACKUP_DB_HOST
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_HOST
+                    name: lagoon-env
+              - name: BACKUP_DB_USERNAME
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_USERNAME
+                    name: lagoon-env
+              - name: BACKUP_DB_PASSWORD
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_PASSWORD
+                    name: lagoon-env
+              - name: BACKUP_DB_DATABASE
+                valueFrom:
+                  configMapKeyRef:
+                    key: $${SERVICE_NAME_UPPERCASE}_DATABASE
+                    name: lagoon-env
             image: amazeeio/alpine-mysql-client
             imagePullPolicy: Always
             name: ${SERVICE_NAME}-prebackuppod


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Rather than relying on the variable names for database details also being valid shell names, instead remap them manually to known valid variables. This fixes failing backups where the service name is something like `MARIADB-D7`.

# Closing issues
Closes: #2140 
