### PR TITLE
Add `skip-openshift-tests` label to Jenkins to reduce intermittent test failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,14 @@ node {
           }
         }
 
+        stage ('check PR labels') {
+          if (env.BRANCH_NAME ==~ /PR-\d+/) {
+            pullRequest.labels.each{
+              echo "This PR has labels: $it"
+              }
+            }
+        }
+
         stage ('build images') {
           sh "make -O${SYNC_MAKE_OUTPUT} -j6 build"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,13 +79,13 @@ node {
               stage ('minishift tests') {
                 try {
                   if (pullRequest.labels.contains("skip-openshift-tests")) {
-                    echo "PR identified as not needing Openshift Testing, skipping stage."
+                    sh script: 'echo "PR identified as not needing Openshift testing."', label: "Skipping Openshift testing stage"
                   } else {
                     sh 'make minishift/cleanall || echo'
                     sh script: "make minishift MINISHIFT_CPUS=\$(nproc --ignore 3) MINISHIFT_MEMORY=24GB MINISHIFT_DISK_SIZE=70GB MINISHIFT_VERSION=${minishift_version} OPENSHIFT_VERSION=${openshift_version}", label: "Making openshift"
                     sh script: "make -O${SYNC_MAKE_OUTPUT} push-minishift -j5", label: "Pushing built images into openshift"
                     sh script: "make -O${SYNC_MAKE_OUTPUT} openshift-tests -j2", label: "Making openshift tests"
-		              }
+                  }
                 } catch (e) {
                   echo "Something went wrong, trying to cleanup"
                   cleanup()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,10 +78,14 @@ node {
               }
               stage ('minishift tests') {
                 try {
-                  sh 'make minishift/cleanall || echo'
-                  sh "make minishift MINISHIFT_CPUS=16 MINISHIFT_MEMORY=32GB MINISHIFT_DISK_SIZE=50GB MINISHIFT_VERSION=${minishift_version} OPENSHIFT_VERSION=${openshift_version}"
-                  sh "make -O${SYNC_MAKE_OUTPUT} push-minishift -j5"
-                  sh "make -O${SYNC_MAKE_OUTPUT} openshift-tests -j7"
+                  if (pullRequest.labels.contains("skip-openshift-tests")) {
+                    echo "PR identified as not needing Openshift Testing, skipping stage."
+                  } else {
+                    sh 'make minishift/cleanall || echo'
+                    sh "make minishift MINISHIFT_CPUS=16 MINISHIFT_MEMORY=32GB MINISHIFT_DISK_SIZE=50GB MINISHIFT_VERSION=${minishift_version} OPENSHIFT_VERSION=${openshift_version}"
+                    sh "make -O${SYNC_MAKE_OUTPUT} push-minishift -j5"
+                    sh "make -O${SYNC_MAKE_OUTPUT} openshift-tests -j7"
+		              }
                 } catch (e) {
                   echo "Something went wrong, trying to cleanup"
                   cleanup()


### PR DESCRIPTION
This PR makes Jenkins aware of the existence of the `skip-openshift-tests`[ label.](https://github.com/amazeeio/lagoon/labels/skip-openshift-tests)

Adding this label to a PR will cause Jenkins to not undertake the Minishift tests, which will dramatically reduce the incidence of failed PRs.

This label needs to be applied prior to the submitting of a PR only if you are confident that your changes will not impact Openshift (i.e. are limited to base images, Kubernetes or other components of Lagoon).  If in doubt, **do not** apply the label, and ask our opinion.

This label can be added and removed independent of commits to PRs.  If the PR has failed without the label applied, it can be applied and the test restarted within Jenkins to re-run without Openshift tests.

This label is intended to be used with a de-parallelisation of the minishift tests, as lower `j` values have been shown to work more successfully.  This label does not take effect on Branch or Tag testing - which both automatically have Openshift tests enabled.

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Closes _all manner of PRs relating to failed Jenkins runs because of Minishift_

