### PR TITLE
Adds error rc for no access and invalid project names on ssh:rsh.sh

### DIFF
--- a/services/ssh/home/rsh.sh
+++ b/services/ssh/home/rsh.sh
@@ -22,7 +22,7 @@ if [[ -n "$REQUESTED_PROJECT" ]]; then
     PROJECT=$REQUESTED_PROJECT
   else
     echo "ERROR: given project '$REQUESTED_PROJECT' contains illegal characters";
-    exit
+    exit 1
   fi
 else
   echo "ERROR: no project defined";
@@ -46,7 +46,7 @@ ENVIRONMENT=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" ap
 # Check if the returned OpenShift projectname is the same as the one being requested. This will only be true if the user actually has access to this environment
 if [[ ! "$(echo $ENVIRONMENT | jq --raw-output '.data.userCanSshToEnvironment.openshiftProjectName')" == "$PROJECT" ]]; then
   echo "no access to $PROJECT"
-  exit
+  exit 1
 fi
 
 ##


### PR DESCRIPTION
This PR simply adds error codes to rsh.sh in error cases. In this it follows the example elsewhere in the same script, returning a generic code of `1` rather than `0`

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

As explained in #2165, we should expect the return code from the ssh service to indicate an error state in just those cases that _are in fact_ error states.

# Closing issues
closes #2165 
