### PR TITLE
Fix display of dev hours on polysite billing projects

### DIFF
--- a/services/api/src/resources/billing/billingCalculations.ts
+++ b/services/api/src/resources/billing/billingCalculations.ts
@@ -299,30 +299,44 @@ export const devCost = ({ currency, projects }: IBillingGroup) => {
   const polySiteGroups = (Math.max(Math.round(projects.length / 10), 1));
   const polySiteIncludedHours = polySiteGroups * (averageProdHours * 2);
 
-  const polyReducerFn = (acc, project) => ({
-    // Poly Sites get two free dev environments per lot of 10 polysite groups
-    // See IDGSDF in BillingCalculations.test.ts
-    // EXAMPLE:   8 projects w/ 720 hours each dev site :
-    //            total dev hours = 720 * 8 ->  5760
-    //            Included free hours =  (1 x (720 x 2)) -> 1440
-    //            Dev Site Per Hour Cost = 0.0139
-    //            (5760 - 1440) * 0.0139 = 60.05
-    cost:  ((acc.quantity + project.devHours) - polySiteIncludedHours) * devSitePerHour,
-    description: [
-      ...acc.description,
-      {
-        name: project.name,
-        hours: project.devHours,
-        included: 0,
-        additional: project.devHours
-      }
-    ],
-    quantity: acc.quantity + project.devHours
+  // Poly Sites get two free dev environments per lot of 10 polysite groups
+  // See IDGSDF in BillingCalculations.test.ts
+  // EXAMPLE:   8 projects w/ 720 hours each dev site :
+  //            total dev hours = 720 * 8 ->  5760
+  //            Included free hours =  (1 x (720 x 2)) -> 1440
+  //            Dev Site Per Hour Cost = 0.0139
+  //            (5760 - 1440) * 0.0139 = 60.05
+  const polyReducerFn = (acc, project) => {
+    const totalDevHours = acc.totalDevHours + project.devHours;
+    const quantity = totalDevHours - polySiteIncludedHours;
+
+    return {
+      totalDevHours,
+      quantity,
+      cost: quantity * devSitePerHour,
+      description: [
+        ...acc.description,
+        {
+          name: project.name,
+          hours: project.devHours,
+          included: 'N/A',
+          additional: 'N/A'
+        }
+      ]
+    };
+  };
+
+  const reducerFn =
+    availability === AVAILABILITY.POLYSITE
+      ? polyReducerFn
+      : standardHighReducerFn;
+
+  const { cost, description, quantity } = projects.reduce(reducerFn, {
+    totalDevHours: 0,
+    quantity: 0,
+    cost: 0,
+    description: []
   });
-
-  const reducerFn =  availability === AVAILABILITY.POLYSITE ? polyReducerFn : standardHighReducerFn;
-
-  const {cost, description, quantity} = projects.reduce(reducerFn, { cost: 0, description: [], quantity: 0});
 
   return {
     cost: Number(cost.toFixed(2)),


### PR DESCRIPTION
Remove display of dev hours on individual polysite projects and fix "total additional hours"

 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

According to the math, the cost for the example in the issue is correct, it's just the display of the quantity (total additional hours) that is incorrect. The billing cost calculator was taking into account the number of included hours for polysites when calculating cost, but accumulating all hours regardless of what is included for the quantity.

Also, for each project, the "included hours" was hardcoded to zero and the "additional hours" was not taking into account what's included for polysites. Since the calculation of what's included and what's additional happens at the billing group level, this PR sets the fields for individual projects as "N/A" instead of 0 or an incorrect number.

![2164](https://user-images.githubusercontent.com/92499/90937964-8ce77000-e3cd-11ea-9c0b-38ad34256d80.png)

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #2164 
