### PR TITLE
Fix column type for active/standby routes

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -181,7 +181,7 @@ CREATE OR REPLACE PROCEDURE
         AND column_name = 'production_routes'
     ) THEN
       ALTER TABLE `project`
-      ADD `production_routes` varchar(100);
+      ADD `production_routes` text;
     END IF;
   END;
 $$
@@ -217,7 +217,7 @@ CREATE OR REPLACE PROCEDURE
         AND column_name = 'standby_routes'
     ) THEN
       ALTER TABLE `project`
-      ADD `standby_routes` varchar(100);
+      ADD `standby_routes` text;
     END IF;
   END;
 $$


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The column type was incorrectly defined as varchar(100) when it should be text.
I think there may be another step required to actually modify this though on existing clusters (may need to update this PR with a alter table modify command)?

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #2171 