### PR TITLE
Un-break port-forwarding for keycloak

### DIFF
--- a/services/keycloak/start.sh
+++ b/services/keycloak/start.sh
@@ -1682,15 +1682,11 @@ configure_keycloak &
 
 /bin/sh /opt/jboss/tools/databases/change-database.sh mariadb
 
-if [ -z "$BIND" ]; then
-    BIND=$(hostname --all-ip-addresses)
-fi
-if [ -z "$BIND_OPTS" ]; then
-    for BIND_IP in $BIND
-    do
-        BIND_OPTS+=" -Djboss.bind.address=$BIND_IP -Djboss.bind.address.private=$BIND_IP "
-    done
-fi
+BIND=$(hostname --all-ip-addresses | cut -d' ' -f1)
+BIND_OPTS=" -Djboss.bind.address=0.0.0.0"
+BIND_OPTS+=" -Djboss.bind.address.private=0.0.0.0"
+BIND_OPTS+=" -Djgroups.bind_addr=$BIND"
+
 SYS_PROPS+=" $BIND_OPTS"
 
 # If the server configuration parameter is not present, append the HA profile.


### PR DESCRIPTION

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change allows `kubectl port-forward` to work for the keycloak service.

`port-forward` connects to the service port on `127.0.0.1`. Previously keycloak was only listening on the pod's external interface. With this change it listens on all interfaces, including localhost.

The new `jgroups` option avoids an error on startup since apparently keycloak binds a UDP port for that service (and it can't bind `0.0.0.0`).

# Closing issues
n/a
