### PR TITLE
Paramaterise API graphql URL in various locations

### DIFF
--- a/services/auto-idler/idle-clis.sh
+++ b/services/auto-idler/idle-clis.sh
@@ -32,7 +32,7 @@ GRAPHQL='query environments {
 }'
 # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
 query=$(echo $GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-ALL_ENVIRONMENTS=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}")
+ALL_ENVIRONMENTS=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}")
 
 # All data successfully loaded, now we don't want to fail anymore if a single idle fails
 set +eo pipefail

--- a/services/auto-idler/idle-services.sh
+++ b/services/auto-idler/idle-services.sh
@@ -34,7 +34,7 @@ GRAPHQL='query developmentEnvironments {
 }'
 # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
 query=$(set -e -o pipefail; echo $GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-DEVELOPMENT_ENVIRONMENTS=$(set -e -o pipefail; curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}")
+DEVELOPMENT_ENVIRONMENTS=$(set -e -o pipefail; curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}")
 
 # All data successfully loaded, now we don't want to fail anymore if a single idle fails
 set +eo pipefail

--- a/services/ssh/home/grant.sh
+++ b/services/ssh/home/grant.sh
@@ -22,7 +22,7 @@ ADMIN_GRAPHQL="query GetUserIdBySshKey {
 }"
 # GraphQL query on single line with \\n for newlines and escaped quotes
 ADMIN_QUERY=$(echo $ADMIN_GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" api:3000/graphql -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
+USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
 
 CONTENT_TYPE="Content-Type: application/json"
 AUTHORIZATION="Authorization: Bearer $API_ADMIN_TOKEN"

--- a/services/ssh/home/rsh.sh
+++ b/services/ssh/home/rsh.sh
@@ -41,7 +41,7 @@ GRAPHQL="query userCanSshToEnvironment {
 }"
 # GraphQL query on single line with \\n for newlines and escaped quotes
 QUERY=$(echo $GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-ENVIRONMENT=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$QUERY\"}")
+ENVIRONMENT=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$QUERY\"}")
 
 # Check if the returned OpenShift projectname is the same as the one being requested. This will only be true if the user actually has access to this environment
 if [[ ! "$(echo $ENVIRONMENT | jq --raw-output '.data.userCanSshToEnvironment.openshiftProjectName')" == "$PROJECT" ]]; then
@@ -66,7 +66,7 @@ ADMIN_GRAPHQL="query getEnvironmentByOpenshiftProjectName {
 }"
 # GraphQL query on single line with \\n for newlines and escaped quotes
 ADMIN_QUERY=$(echo $ADMIN_GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-ADMIN_ENVIRONMENT=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" api:3000/graphql -d "{\"query\": \"$ADMIN_QUERY\"}")
+ADMIN_ENVIRONMENT=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$ADMIN_QUERY\"}")
 
 OPENSHIFT_CONSOLE=$(echo $ADMIN_ENVIRONMENT | jq --raw-output '.data.environmentByOpenshiftProjectName.project.openshift.consoleUrl')
 OPENSHIFT_TOKEN=$(echo $ADMIN_ENVIRONMENT | jq --raw-output '.data.environmentByOpenshiftProjectName.project.openshift.token')

--- a/services/ssh/home/rsh.sh
+++ b/services/ssh/home/rsh.sh
@@ -16,6 +16,9 @@ USER_SSH_KEY=$2
 REQUESTED_PROJECT=$3
 shift 3
 
+# get the graphql endpoint, if set
+eval "$(grep GRAPHQL_ENDPOINT /authorize.env)"
+
 # check if project is a valid one
 if [[ -n "$REQUESTED_PROJECT" ]]; then
   if [[ "$REQUESTED_PROJECT" =~ ^[A-Za-z0-9-]+$ ]]; then

--- a/services/ssh/home/token-debug.sh
+++ b/services/ssh/home/token-debug.sh
@@ -22,7 +22,7 @@ ADMIN_GRAPHQL="query GetUserIdBySshKey {
 }"
 # GraphQL query on single line with \\n for newlines and escaped quotes
 ADMIN_QUERY=$(echo $ADMIN_GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" api:3000/graphql -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
+USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
 
 echo "USER_ID='${USER_ID}'"  >> /proc/1/fd/1
 

--- a/services/ssh/home/token.sh
+++ b/services/ssh/home/token.sh
@@ -22,7 +22,7 @@ ADMIN_GRAPHQL="query GetUserIdBySshKey {
 }"
 # GraphQL query on single line with \\n for newlines and escaped quotes
 ADMIN_QUERY=$(echo $ADMIN_GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" api:3000/graphql -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
+USER_ID=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$ADMIN_BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$ADMIN_QUERY\"}" | jq --raw-output '.data.userBySshKey.id')
 
 CONTENT_TYPE="Content-Type: application/json"
 AUTHORIZATION="Authorization: Bearer $API_ADMIN_TOKEN"

--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -23,7 +23,7 @@ GRAPHQL='query environments {
 
 # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
 query=$(echo $GRAPHQL | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-ALL_ENVIRONMENTS=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}")
+ALL_ENVIRONMENTS=$(curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}")
 
 echo "$ALL_ENVIRONMENTS" | jq -c '.data.environments[] | select((.environments|length)>=1)' | while read project
 do
@@ -54,7 +54,7 @@ do
 
         # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
         query=$(echo $MUTATION | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}"
+        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}"
 
         continue
 
@@ -114,7 +114,7 @@ do
 
         # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
         query=$(echo $MUTATION | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}"
+        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}"
 
       else
         for PVC in "${PVCS[@]}"
@@ -131,7 +131,7 @@ do
 
             # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
             query=$(echo $MUTATION | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-            curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}"
+            curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}"
 
             # Update namespace labels
             if [ ! -z "$LAGOON_STORAGE_LABEL_NAMESPACE"]; then
@@ -152,7 +152,7 @@ do
 
         # Convert GraphQL file into single line (but with still \n existing), turn \n into \\n, esapee the Quotes
         query=$(echo $MUTATION | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
-        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" api:3000/graphql -d "{\"query\": \"$query\"}"
+        curl -s -XPOST -H 'Content-Type: application/json' -H "$BEARER" "${GRAPHQL_ENDPOINT:-api:3000/graphql}" -d "{\"query\": \"$query\"}"
       fi
 
       ${OC} delete deploymentconfig/storage-calc


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This allows overriding the API URL via environment variables, using the same variable name that `backup-handler` already uses.

# Closing issues
n/a
