### PR TITLE
Pin curl to >7.68 and pull from Alpine v3.12

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -50,7 +50,7 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
 ENV NEWRELIC_VERSION=9.12.0.268
 
-RUN apk add --no-cache curl --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/main/ 'curl>7.68'
 
 RUN apk add --no-cache fcgi \
         ssmtp \


### PR DESCRIPTION
in #1954 we inadvertently unpinned a curl upgrade that was needed (because #1723). 

In this PR I specify a minimum version of curl required, as well as stipulate that it can be downloaded from the Alpine 3.12 repos (instead of edge)

Fun fact - In Alpine package management `>7.68` means 7.68 or greater - https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Add_a_Package

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

