### PR TITLE
Fix autogenerated routes handling

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -435,7 +435,7 @@ if [[ "$TYPE" == "pullrequest" && "$ROUTES_AUTOGENERATE_ALLOW_PRS" == "true" ]];
 fi
 ## fail silently if the key autogenerateRoutes doesn't exist and default to whatever ROUTES_AUTOGENERATE_ENABLED is set to
 ROUTES_AUTOGENERATE_BRANCH=$(cat .lagoon.yml | shyaml -q get-value environments.${BRANCH//./\\.}.autogenerateRoutes $ROUTES_AUTOGENERATE_ENABLED)
-if [ "$ROUTES_AUTOGENERATE_BRANCH" =~ [Tt]rue ]; then
+if [[ "$ROUTES_AUTOGENERATE_BRANCH" =~ [Tt]rue ]]; then
   ROUTES_AUTOGENERATE_ENABLED=true
 fi
 


### PR DESCRIPTION
#Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR fixes handling of auto-generated routes in some cases, which could lead to this error and cause auto-generated routes not to be created properly.
```
/oc-build-deploy/build-deploy-docker-compose.sh: line 438: [: =~: binary operator expected
```

# Closing issues
n/a
