### PR TITLE
add publish-amazeeiolagoon-taskimages step to makefile & Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ node {
                   try {
                     if (env.SKIP_IMAGE_PUBLISH != 'true') {
                       sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-                      sh script: "make -O${SYNC_MAKE_OUTPUT} -j4 publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
+                      sh script: "make -O${SYNC_MAKE_OUTPUT} -j4 publish-amazeeiolagoon-baseimages publish-amazeeiolagoon-serviceimages publish-amazeeiolagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
                     } else {
                       sh script: 'echo "skipped because of SKIP_IMAGE_PUBLISH env variable"', label: "Skipping image publishing"
                     }

--- a/Makefile
+++ b/Makefile
@@ -853,6 +853,22 @@ $(publish-amazeeiolagoon-serviceimages):
 		$(call docker_publish_amazeeiolagoon,$(image),$(image):$(BRANCH_NAME))
 
 
+# Publish command to amazeeio docker hub, this should probably only be done during a master deployments
+publish-amazeeiolagoon-taskimages = $(foreach image,$(task-images),[publish-amazeeiolagoon-taskimages]-$(image))
+# tag and push all images
+.PHONY: publish-amazeeiolagoon-taskimages
+publish-amazeeiolagoon-taskimages: $(publish-amazeeiolagoon-taskimages)
+
+
+# tag and push of each image
+.PHONY: $(publish-amazeeiolagoon-taskimages)
+$(publish-amazeeiolagoon-taskimages):
+#   Calling docker_publish for image, but remove the prefix '[publish-amazeeiolagoon-taskimages]-' first
+		$(eval image = $(subst [publish-amazeeiolagoon-taskimages]-,,$@))
+# 	Publish images with version tag
+		$(call docker_publish_amazeeiolagoon,$(image),$(image):$(BRANCH_NAME))
+
+
 s3-save = $(foreach image,$(s3-images),[s3-save]-$(image))
 # save all images to s3
 .PHONY: s3-save


### PR DESCRIPTION
the new task-images weren't added to the amazeeiolagoon publish step in Lagoon 1.9.0

Example task image at https://hub.docker.com/r/amazeeiolagoon/task-activestandby/tags

This adds the publish step to the makefile and the jenkinsfile

# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied
