### PR TITLE
Make the CLI readiness probe backwards-compatible

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/deployment.yaml
@@ -71,7 +71,12 @@ spec:
             failureThreshold: 3
             exec:
               command:
-              - /bin/entrypoint-readiness
+              - "/bin/sh"
+              - "-c"
+              - >
+                if [ -x /bin/entrypoint-readiness ]; then
+                  /bin/entrypoint-readiness;
+                fi
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/deployment.yaml
@@ -62,7 +62,12 @@ spec:
             failureThreshold: 3
             exec:
               command:
-              - /bin/entrypoint-readiness
+              - "/bin/sh"
+              - "-c"
+              - >
+                if [ -x /bin/entrypoint-readiness ]; then
+                  /bin/entrypoint-readiness;
+                fi
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli-persistent/deployment.yml
@@ -141,7 +141,12 @@ objects:
                 failureThreshold: 3
                 exec:
                   command:
-                  - /bin/entrypoint-readiness
+                  - "/bin/sh"
+                  - "-c"
+                  - >
+                    if [ -x /bin/entrypoint-readiness ]; then
+                      /bin/entrypoint-readiness;
+                    fi
       test: false
       triggers:
         - type: ConfigChange

--- a/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/cli/deployment.yml
@@ -118,7 +118,12 @@ objects:
                 failureThreshold: 3
                 exec:
                   command:
-                  - /bin/entrypoint-readiness
+                  - "/bin/sh"
+                  - "-c"
+                  - >
+                    if [ -x /bin/entrypoint-readiness ]; then
+                      /bin/entrypoint-readiness;
+                    fi
 
       test: false
       triggers:


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This makes it possible to deploy <1.9.0 Lagoon images on Lagoon 1.9.0.

# Closing issues
n/a
