### PR TITLE
refactor entrypoint-readiness

### DIFF
--- a/images/commons/entrypoint-readiness
+++ b/images/commons/entrypoint-readiness
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -eo pipefail
-
 # simple readiness check to see if a late-running entrypoint has completed
 # but only if the entrypoint actually exists
 if [ -f /lagoon/entrypoints/999-readiness.sh ]; then

--- a/images/commons/entrypoint-readiness
+++ b/images/commons/entrypoint-readiness
@@ -1,19 +1,9 @@
-#! /bin/sh
+#!/bin/sh
+
+set -eo pipefail
 
 # simple readiness check to see if a late-running entrypoint has completed
-
-function version_check() {
-  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
-}
-
-function file_check() {
+# but only if the entrypoint actually exists
+if [ -f /lagoon/entrypoints/999-readiness.sh ]; then
   test -f /tmp/ready
-}
-
-VERSION="${LAGOON_VERSION}:1"
-if version_check $VERSION 1.8.2 || [ "${LAGOON_VERSION}" = "development" ]; then
-  file_check
-else
-  # older version, just exit
-  exit 0
 fi

--- a/images/commons/lagoon/entrypoints/999-readiness.sh
+++ b/images/commons/lagoon/entrypoints/999-readiness.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-set -eo pipefail
-
 touch /tmp/ready


### PR DESCRIPTION
as https://github.com/amazeeio/lagoon/pull/2196/ has landed we don't need versioncheck anymore

the entrypoint-readiness would never be called if it does not exist.
also making sure that we only check for the ready file if the entrypoint actually exists (prevents issues with modified images)
