### PR TITLE
Bump libcurl to the same version as curl - 7.69.1.

### DIFF
--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -50,7 +50,7 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
 ENV NEWRELIC_VERSION=9.12.0.268
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/main/ 'curl>7.68'
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/main/ 'curl>7.68' 'libcurl>7.68'
 
 RUN apk add --no-cache fcgi \
         ssmtp \


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Updates `libcurl` to the same version as `curl`.

Proof this works

`libcurl`:

```php
php > var_dump(curl_version()['version']);
string(6) "7.69.1"
```

`curl`:

```bash
php:/app$ curl --version
curl 7.69.1 (x86_64-alpine-linux-musl) libcurl/7.69.1 OpenSSL/1.1.1g zlib/1.2.11 nghttp2/1.40.0
```

# Closing issues
closes #2207
