### PR TITLE
Update New Relic PHP agent to 9.13.0.270, Composer to 1.10.13, Drush to 8.3.6.

### DIFF
--- a/helpers/update-versions.yml
+++ b/helpers/update-versions.yml
@@ -9,15 +9,15 @@
   connection: local
   vars:
     # Newrelic - https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
-    NEWRELIC_VERSION: '9.12.0.268'
+    NEWRELIC_VERSION: '9.13.0.270'
     # Composer - https://getcomposer.org/download/
-    COMPOSER_VERSION: '1.10.9'
-    COMPOSER_HASH_SHA256: '70d6b9c3e0774b398a372dcb7f89dfe22fc25884e6e09ebf277286dd64cfaf35'
+    COMPOSER_VERSION: '1.10.13'
+    COMPOSER_HASH_SHA256: '5ca7445cfd48dd27c5a84aa005a47b4d9fd91132313830609875df3a6973708f'
     # Drupal Console Launcher - https://github.com/hechoendrupal/drupal-console-launcher/releases
     DRUPAL_CONSOLE_LAUNCHER_VERSION: 1.9.4
     DRUPAL_CONSOLE_LAUNCHER_SHA: b7759279668caf915b8e9f3352e88f18e4f20659
     # Drush - https://github.com/drush-ops/drush/releases
-    DRUSH_VERSION: 8.3.5
+    DRUSH_VERSION: 8.3.6
     # Drush Launcher Version - https://github.com/drush-ops/drush-launcher/releases
     DRUSH_LAUNCHER_VERSION: 0.6.0
   tasks:

--- a/images/php/cli-drupal/Dockerfile
+++ b/images/php/cli-drupal/Dockerfile
@@ -9,7 +9,7 @@ ENV LAGOON=cli-drupal
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.4 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=b7759279668caf915b8e9f3352e88f18e4f20659 \
-    DRUSH_VERSION=8.3.5 \
+    DRUSH_VERSION=8.3.6 \
     DRUSH_LAUNCHER_VERSION=0.6.0 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 

--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -9,8 +9,8 @@ ENV LAGOON=cli
 
 # Defining Versions - Composer
 # @see https://getcomposer.org/download/
-ENV COMPOSER_VERSION=1.10.9 \
-  COMPOSER_HASH_SHA256=70d6b9c3e0774b398a372dcb7f89dfe22fc25884e6e09ebf277286dd64cfaf35
+ENV COMPOSER_VERSION=1.10.13 \
+  COMPOSER_HASH_SHA256=5ca7445cfd48dd27c5a84aa005a47b4d9fd91132313830609875df3a6973708f
 
 COPY --from=commons /bin/entrypoint-readiness /bin/
 

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -48,7 +48,7 @@ COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.12.0.268
+ENV NEWRELIC_VERSION=9.13.0.270
 
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/main/ 'curl>7.68'
 


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

Patch version updates for:

* New Relic PHP agent to `9.13.0.270` (with Slim v4 support)
* Composer to `1.10.13` (PHP 8 compatibility fixes)
* Drush to `8.3.6` ([release notes](https://github.com/drush-ops/drush/releases/tag/8.3.6))

# Closing issues

