### PR TITLE
Make test kubectl configuration compatible with lagoon-test helm chart

### DIFF
--- a/tests/checks/check-ingress-annotations.yaml
+++ b/tests/checks/check-ingress-annotations.yaml
@@ -4,7 +4,7 @@
     set -e
     # create the $annotation and $value variables from item
     eval $(echo "{{ item }}" | awk -F= '{sep=index($0,"="); print "annotation=\"" $1 "\" value=\"" substr($0,sep+1) "\""}')
-    [ $(kubectl --insecure-skip-tls-verify=true -n {{ project }}-{{ branch }} get ingress {{ingress}} -o json |
+    [ $(kubectl -n {{ project }}-{{ branch }} get ingress {{ingress}} -o json |
     jq -er ".metadata.annotations | .\"$annotation\"") = "$value" ]
   loop: "{{ expected_annotations }}"
   register: result

--- a/tests/checks/check-ingress-annotations.yaml
+++ b/tests/checks/check-ingress-annotations.yaml
@@ -2,10 +2,6 @@
 - name: "{{ testname }} - Check if {{ingress}} ingress of namespace {{ project }}-{{ branch }} has annotation"
   shell: |
     set -e
-    export KUBECONFIG=$(mktemp)
-    echo "{{ kubeconfig }}" > $KUBECONFIG
-    # replace with the IP of host from within container
-    sed -i "s/localhost/$(ip -4 route list match 0/0 | cut -d' ' -f3)/" $KUBECONFIG
     # create the $annotation and $value variables from item
     eval $(echo "{{ item }}" | awk -F= '{sep=index($0,"="); print "annotation=\"" $1 "\" value=\"" substr($0,sep+1) "\""}')
     [ $(kubectl --insecure-skip-tls-verify=true -n {{ project }}-{{ branch }} get ingress {{ingress}} -o json |

--- a/tests/checks/check-namespace-labels.yaml
+++ b/tests/checks/check-namespace-labels.yaml
@@ -4,7 +4,7 @@
     set -e
     # create the $label and $value variables from item
     eval $(echo "{{ item }}" | awk -F= '{sep=index($0,"="); print "label=\"" $1 "\" value=\"" substr($0,sep+1) "\""}')
-    [ $(kubectl --insecure-skip-tls-verify=true get namespace {{ project }}-{{ branch }} -o json |
+    [ $(kubectl get namespace {{ project }}-{{ branch }} -o json |
     jq -er ".metadata.labels | .\"$label\"") = "$value" ]
   loop: "{{ expected_labels }}"
   register: result

--- a/tests/checks/check-namespace-labels.yaml
+++ b/tests/checks/check-namespace-labels.yaml
@@ -2,10 +2,6 @@
 - name: "{{ testname }} - Check if {{project}} namespace is labelled"
   shell: |
     set -e
-    export KUBECONFIG=$(mktemp)
-    echo "{{ kubeconfig }}" > $KUBECONFIG
-    # replace with the IP of host from within container
-    sed -i "s/localhost/$(ip -4 route list match 0/0 | cut -d' ' -f3)/" $KUBECONFIG
     # create the $label and $value variables from item
     eval $(echo "{{ item }}" | awk -F= '{sep=index($0,"="); print "label=\"" $1 "\" value=\"" substr($0,sep+1) "\""}')
     [ $(kubectl --insecure-skip-tls-verify=true get namespace {{ project }}-{{ branch }} -o json |


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change is required for kubectl to run correctly in the test suite running in the lagoon-test helm chart.
kubectl obtains its configuration automatically using the service-account token running inside the pod.

IMPORTANT NOTE: this change breaks the current test suite running in Jenkins, so I've made it a draft to gather feedback on if we want to merge this.

# Closing issues

n/a
