### PR TITLE
#2239 - remove un-needed dollar sign from env vars of prebackuppods

### DIFF
--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -90,24 +90,23 @@ objects:
               - name: BACKUP_DB_HOST
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_HOST
+                    key: ${SERVICE_NAME_UPPERCASE}_HOST
                     name: lagoon-env
               - name: BACKUP_DB_USERNAME
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_USERNAME
+                    key: ${SERVICE_NAME_UPPERCASE}_USERNAME
                     name: lagoon-env
               - name: BACKUP_DB_PASSWORD
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_PASSWORD
+                    key: ${SERVICE_NAME_UPPERCASE}_PASSWORD
                     name: lagoon-env
               - name: BACKUP_DB_DATABASE
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_DATABASE
+                    key: ${SERVICE_NAME_UPPERCASE}_DATABASE
                     name: lagoon-env
             image: amazeeio/alpine-mysql-client
             imagePullPolicy: Always
             name: ${SERVICE_NAME}-prebackuppod
-

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -90,24 +90,23 @@ objects:
               - name: BACKUP_DB_HOST
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_HOST
+                    key: ${SERVICE_NAME_UPPERCASE}_HOST
                     name: lagoon-env
               - name: BACKUP_DB_USERNAME
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_USERNAME
+                    key: ${SERVICE_NAME_UPPERCASE}_USERNAME
                     name: lagoon-env
               - name: BACKUP_DB_PASSWORD
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_PASSWORD
+                    key: ${SERVICE_NAME_UPPERCASE}_PASSWORD
                     name: lagoon-env
               - name: BACKUP_DB_DATABASE
                 valueFrom:
                   configMapKeyRef:
-                    key: $${SERVICE_NAME_UPPERCASE}_DATABASE
+                    key: ${SERVICE_NAME_UPPERCASE}_DATABASE
                     name: lagoon-env
             image: amazeeio/alpine-mysql-client
             imagePullPolicy: Always
             name: ${SERVICE_NAME}-prebackuppod
-


### PR DESCRIPTION
Removes excess $ from mariadb prebackuppods on openshift

closes #2239 