### PR TITLE
Bugfix: Recent Billing Projects w/o Billing Groups

### DIFF
--- a/services/ui/src/lib/mutation/UpdateProjectBillingGroup.js
+++ b/services/ui/src/lib/mutation/UpdateProjectBillingGroup.js
@@ -1,0 +1,9 @@
+import gql from "graphql-tag";
+
+export default gql`
+  mutation updateProjectBillingGroup($input: ProjectBillingGroupInput!) {
+    updateProjectBillingGroup(input: $input){
+      id
+    }
+  }
+`;


### PR DESCRIPTION
This PR fixes an issue with a billing admin page so you can add and change the billing group for a recent project. 

![image](https://user-images.githubusercontent.com/1117989/95623270-fd605400-0a42-11eb-99a1-be3785977de9.png)
