### PR TITLE
Adds image push to internal registry in the context of OpenShift

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -963,7 +963,7 @@ elif [ "$TYPE" == "pullrequest" ] || [ "$TYPE" == "branch" ]; then
 
   # If we have Images to Push to the the Internal Harbor, let's do so
   if [ -f /oc-build-deploy/lagoon/push_harbor ]; then
-    parallel < /oc-build-deploy/lagoon/push_harbor
+    parallel --retries 4 < /oc-build-deploy/lagoon/push_harbor
   fi
 
 elif [ "$TYPE" == "promote" ]; then

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -956,14 +956,9 @@ elif [ "$TYPE" == "pullrequest" ] || [ "$TYPE" == "branch" ]; then
     . /oc-build-deploy/scripts/exec-push-parallel.sh
   done
 
-  # If we have Images to Push to the OpenRegistry, let's do so
+  # If we have Images to Push to the OpenRegistry and Harbor, let's do so
   if [ -f /oc-build-deploy/lagoon/push ]; then
     parallel --retries 4 < /oc-build-deploy/lagoon/push
-  fi
-
-  # If we have Images to Push to the the Internal Harbor, let's do so
-  if [ -f /oc-build-deploy/lagoon/push_harbor ]; then
-    parallel --retries 4 < /oc-build-deploy/lagoon/push_harbor
   fi
 
 elif [ "$TYPE" == "promote" ]; then

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -961,6 +961,11 @@ elif [ "$TYPE" == "pullrequest" ] || [ "$TYPE" == "branch" ]; then
     parallel --retries 4 < /oc-build-deploy/lagoon/push
   fi
 
+  # If we have Images to Push to the the Internal Harbor, let's do so
+  if [ -f /oc-build-deploy/lagoon/push_harbor ]; then
+    parallel < /oc-build-deploy/lagoon/push_harbor
+  fi
+
 elif [ "$TYPE" == "promote" ]; then
 
   for IMAGE_NAME in "${IMAGES[@]}"

--- a/images/oc-build-deploy-dind/build-deploy.sh
+++ b/images/oc-build-deploy-dind/build-deploy.sh
@@ -40,6 +40,10 @@ DOCKER_REGISTRY_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 
 docker login -u=jenkins -p="${DOCKER_REGISTRY_TOKEN}" ${OPENSHIFT_REGISTRY}
 
+if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
+  echo "docker login -u '${INTERNAL_REGISTRY_USERNAME}' -p '${INTERNAL_REGISTRY_PASSWORD}' ${INTERNAL_REGISTRY_URL}" | /bin/bash
+fi
+
 DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
 
 oc login --insecure-skip-tls-verify --token="${DEPLOYER_TOKEN}" https://kubernetes.default.svc

--- a/images/oc-build-deploy-dind/build-deploy.sh
+++ b/images/oc-build-deploy-dind/build-deploy.sh
@@ -49,7 +49,7 @@ docker login -u=jenkins -p="${DOCKER_REGISTRY_TOKEN}" ${OPENSHIFT_REGISTRY}
 INTERNAL_REGISTRY_LOGGED_IN="false"
 if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
   echo "docker login -u '${INTERNAL_REGISTRY_USERNAME}' -p '${INTERNAL_REGISTRY_PASSWORD}' ${INTERNAL_REGISTRY_URL}" | /bin/bash
-  if ["$?" -eq 0 ] ; then
+  if [ "$?" -eq 0 ] ; then
     INTERNAL_REGISTRY_LOGGED_IN="true"
   fi
 fi

--- a/images/oc-build-deploy-dind/build-deploy.sh
+++ b/images/oc-build-deploy-dind/build-deploy.sh
@@ -7,6 +7,12 @@ OPENSHIFT_REGISTRY=docker-registry.default.svc:5000
 OPENSHIFT_PROJECT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 REGISTRY_REPOSITORY=$OPENSHIFT_PROJECT
 
+if [ ! -z "$LAGOON_PROJECT_VARIABLES" ]; then
+  INTERNAL_REGISTRY_URL=$(jq --argjson data "$LAGOON_PROJECT_VARIABLES" -n -r '$data | .[] | select(.scope == "internal_container_registry") | select(.name == "INTERNAL_REGISTRY_URL") | .value' | sed -e 's#^http://##' | sed -e 's#^https://##')
+  INTERNAL_REGISTRY_USERNAME=$(jq --argjson data "$LAGOON_PROJECT_VARIABLES" -n -r '$data | .[] | select(.scope == "internal_container_registry") | select(.name == "INTERNAL_REGISTRY_USERNAME") | .value')
+  INTERNAL_REGISTRY_PASSWORD=$(jq --argjson data "$LAGOON_PROJECT_VARIABLES" -n -r '$data | .[] | select(.scope == "internal_container_registry") | select(.name == "INTERNAL_REGISTRY_PASSWORD") | .value')
+fi
+
 if [ "$CI" == "true" ]; then
   CI_OVERRIDE_IMAGE_REPO=${OPENSHIFT_REGISTRY}/lagoon
 else
@@ -40,8 +46,12 @@ DOCKER_REGISTRY_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 
 docker login -u=jenkins -p="${DOCKER_REGISTRY_TOKEN}" ${OPENSHIFT_REGISTRY}
 
+INTERNAL_REGISTRY_LOGGED_IN="false"
 if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
   echo "docker login -u '${INTERNAL_REGISTRY_USERNAME}' -p '${INTERNAL_REGISTRY_PASSWORD}' ${INTERNAL_REGISTRY_URL}" | /bin/bash
+  if ["$?" -eq 0 ] ; then
+    INTERNAL_REGISTRY_LOGGED_IN="true"
+  fi
 fi
 
 DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)

--- a/images/oc-build-deploy-dind/scripts/exec-push-parallel.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-push-parallel.sh
@@ -4,7 +4,7 @@ docker tag ${TEMPORARY_IMAGE_NAME} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${
 
 echo "docker push ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NAME}:${IMAGE_TAG:-latest}" >> /oc-build-deploy/lagoon/push
 
-if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
+if [ "${INTERNAL_REGISTRY_LOGGED_IN}" = "true" ] ; then
     docker tag ${TEMPORARY_IMAGE_NAME} ${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
-    echo "docker push ${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}" >> /oc-build-deploy/lagoon/push_harbor
+    echo "docker push ${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest} || true" >> /oc-build-deploy/lagoon/push
 fi

--- a/images/oc-build-deploy-dind/scripts/exec-push-parallel.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-push-parallel.sh
@@ -4,3 +4,7 @@ docker tag ${TEMPORARY_IMAGE_NAME} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${
 
 echo "docker push ${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NAME}:${IMAGE_TAG:-latest}" >> /oc-build-deploy/lagoon/push
 
+if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
+    docker tag ${TEMPORARY_IMAGE_NAME} ${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
+    echo "docker push ${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}" >> /oc-build-deploy/lagoon/push_harbor
+fi


### PR DESCRIPTION

- [*] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [*] PR title is ready for changelog and subsystem label(s) applied

As described in #2250 - having the images built within the context of Openshift _also_ inside of Harbor will allow us to run vulnerability scans on those images automatically.

This PR logs into the internal registry (i.e. Harbor), then pushes the resulting images into the internal registry using similar logic to the standard image push.

# Closing issues

closes #2250 
