### PR TITLE
2259 - Use defined log_format to also log http_x_forwarded_for

### DIFF
--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log      /dev/stdout;
+    access_log      /dev/stdout main;
 
     sendfile        on;
     tcp_nopush      on;


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

We define a log_format in the nginx.conf but never use it - I stumbled over this due to the fact that we saw that http_x_forwarded_for isn't shipped into the logs (which is helpful when a CDN is used). This change fixes it to use the defined log_format.

Old Log format:
```
::ffff:185.31.18.74 - - [20/Oct/2020:05:46:55 +0000] "GET / HTTP/1.1" 200 549226 "-" "curl/7.64.1"
```
New Log format:
````
::ffff:185.31.18.74 - - [20/Oct/2020:05:48:29 +0000] "GET / HTTP/1.1" 200 549218 "-" "curl/7.64.1" "212.51.157.164, 157.52.100.40, ::ffff:185.31.18.74"



```<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2259 