### PR TITLE
Addresses errors with HarborScanMatch capture group fallbacks

### DIFF
--- a/services/api/src/resources/problem/resolvers.ts
+++ b/services/api/src/resources/problem/resolvers.ts
@@ -199,7 +199,7 @@ export const addProblemHarborScanMatch = async (
       description,
       defaultLagoonProject,
       defaultLagoonEnvironment,
-      defaultLagoonServiceName,
+      defaultLagoonService,
       regex
     },
   },
@@ -219,7 +219,7 @@ export const addProblemHarborScanMatch = async (
         description,
         default_lagoon_project: defaultLagoonProject,
         default_lagoon_environment: defaultLagoonEnvironment,
-        default_lagoon_service_name: defaultLagoonServiceName,
+        default_lagoon_service_name: defaultLagoonService,
         regex
       }
     ),

--- a/services/api/src/resources/problem/sql.ts
+++ b/services/api/src/resources/problem/sql.ts
@@ -24,7 +24,7 @@ const standardProblemHarborScanMatchReturn = {
     description: 'description',
     default_lagoon_project: 'defaultLagoonProject',
     default_lagoon_environment: 'defaultLagoonEnvironment',
-    default_lagoon_service_name: 'defaultLagoonServiceName',
+    default_lagoon_service: 'defaultLagoonServiceName',
     regex: 'regex'
 };
 

--- a/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
+++ b/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
@@ -175,11 +175,10 @@ const matchRepositoryAgainstPatterns = (repoFullName, matchPatterns = []) => {
   }
 
   const matchPatternDetails = matchingRes.pop() || DEFAULT_REPO_DETAILS_MATCHER;
-
   const {
-    lagoonProjectName = matchPatternDetails.defaultProjectName,
-    lagoonEnvironmentName = matchPatternDetails.defaultEnvironmentName,
-    lagoonServiceName = matchPatternDetails.defaultServiceName,
+    lagoonProjectName = matchPatternDetails.defaultLagoonProject,
+    lagoonEnvironmentName = matchPatternDetails.defaultLagoonEnvironment,
+    lagoonServiceName = matchPatternDetails.defaultLagoonService,
   } = extractRepositoryDetailsGivenRegex(repoFullName, matchPatternDetails.regex);
 
   return {lagoonProjectName, lagoonEnvironmentName, lagoonServiceName};
@@ -190,7 +189,7 @@ const generateRegex = R.memoizeWith(R.identity, re => new RegExp(re));
 const extractRepositoryDetailsGivenRegex = (repoFullName, pattern = DEFAULT_REPO_DETAILS_REGEX) => {
   const re = generateRegex(pattern);
   const match = re.exec(repoFullName);
-  return match.groups;
+  return match.groups || {};
 }
 
 const generateWebhookData = (


### PR DESCRIPTION
This fixes the errors described in #2279 

Namely, incorrect field names for the defaults as well as a new error discovered when there are _no_ capture groups in the match regex (but you still want to map to a project/environment/service directly)

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Note: all changes except for the line `  return match.groups || {};` are naming issues (from, I believe, last minute changes before the feature was released). The return of the default object fixes the case where `match.groups` is null.

Closes #2279 