### PR TITLE
add :latest tag to amazeeio base/task image push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,6 +572,8 @@ publish-amazeeio-baseimages: $(publish-amazeeio-baseimages)
 $(publish-amazeeio-baseimages):
 #   Calling docker_publish for image, but remove the prefix '[publish-amazeeio-baseimages]-' first
 		$(eval image = $(subst [publish-amazeeio-baseimages]-,,$@))
+# 	Publish images as :latest
+		$(call docker_publish_amazeeio,$(image),$(image):latest)
 # 	Publish images with version tag
 		$(call docker_publish_amazeeio,$(image),$(image):$(LAGOON_VERSION))
 
@@ -586,6 +588,8 @@ publish-amazeeio-taskimages: $(publish-amazeeio-taskimages)
 $(publish-amazeeio-taskimages):
 #   Calling docker_publish for image, but remove the prefix '[publish-amazeeio-taskimages]-' first
 		$(eval image = $(subst [publish-amazeeio-taskimages]-,,$@))
+# 	Publish images as :latest
+		$(call docker_publish_amazeeio,$(image),$(image):latest)
 # 	Publish images with version tag
 		$(call docker_publish_amazeeio,$(image),$(image):$(LAGOON_VERSION))
 


### PR DESCRIPTION
When publishing base or task images to the amazeeio dockerhub, the :latest tag isn't updated to the latest release

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied
