### PR TITLE
Fix some incorrect values in test fixtures

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -215,7 +215,6 @@ mutation PopulateApi {
     }
   ) {
     id
-    }
   }
 
 

--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -207,6 +207,17 @@ mutation PopulateApi {
     id
   }
 
+  # Fake email address for testing
+  CiEmail: addNotificationEmail(
+    input: {
+      name: "local-email-testing",
+      emailAddress: "mail@example.com"
+    }
+  ) {
+    id
+    }
+  }
+
 
   #### Lagoon Kickstart Objects
   # Customer with a private key that has access to the local-git server.

--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -450,7 +450,7 @@ mutation PopulateApi {
     input: {
       name: "build-3"
       status: RUNNING
-      environment: 2
+      environment: 3
       created: "2018-10-07 23:02:41"
       started: "2018-10-07 23:03:41"
     }

--- a/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-openshift.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-openshift.gql
@@ -1005,7 +1005,7 @@ mutation PopulateApi {
         id: 23
         name: "ci-branch-picky-openshift"
         productionEnvironment: "master"
-        openshift: 1
+        openshift: 2
         branches: "^feature/|^(dev|test|develop|master)$"
         developmentEnvironmentsLimit: 5
         gitUrl: "ssh://git@172.17.0.1:2222/git/node.git"


### PR DESCRIPTION
#1245 Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR fixes some errors displayed in the api-data-watcher-pusher logs when injecting test fixtures into the API.

For example:
```
 {"errors":[{"message":"Cannot read property 'environmentType' of undefined","locations":[{"line":449,"column":3}],"path": ...
```
https://github.com/uselagoon/lagoon-charts/runs/1308924932

# Closing issues

n/a
