### PR TITLE
Improve the efficiency of fix-permissions

### DIFF
--- a/images/commons/fix-permissions
+++ b/images/commons/fix-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Fix permissions on the given directory to allow group read/write of
 # regular files and execute of directories.
-find -L "$1" -exec chgrp 0 {} \;
-find -L "$1" -exec chmod g+rw {} \;
+find -L "$1" -exec chgrp 0 {} +
+find -L "$1" -exec chmod g+rw {} +
 find -L "$1" -type d -exec chmod g+x {} +


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

I noticed that builds occasionally took a long time in CI. `fix-permissions` seemed to be the culprit in this case.

I timed the `fix-permissions` invocation in the `kibana` image build.

Before this change:
```
make DOCKER_BUILD_PARAMS= build/kibana__7
...
Step 16/19 : RUN time fix-permissions /usr/share/kibana
 ---> Running in c55da6236f22

real	2m31.300s
user	1m47.457s
sys	0m46.562s
Removing intermediate container c55da6236f22
 ---> b1112380c5d6
```
After this change:
```
make DOCKER_BUILD_PARAMS= build/kibana__7
Step 16/19 : RUN time fix-permissions /usr/share/kibana
 ---> Running in c2e2a3799371

real	0m2.456s
user	0m0.224s
sys	0m2.174s
Removing intermediate container c2e2a3799371
 ---> 8cb8433b7c96
```

Approx. 60x speed-up.

# Closing issues

n/a
