### PR TITLE
Re-add local-minio to main-test-services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ wait-for-keycloak:
 	grep -m 1 "Config of Keycloak done." <(docker-compose -p $(CI_BUILD_TAG) --compatibility logs -f keycloak 2>&1)
 
 # Define a list of which Lagoon Services are needed for running any deployment testing
-main-test-services = broker logs2email logs2slack logs2rocketchat logs2microsoftteams api api-db keycloak keycloak-db ssh auth-server local-git local-api-data-watcher-pusher harbor-core harbor-database harbor-jobservice harbor-portal harbor-nginx harbor-redis harborregistry harborregistryctl harbor-trivy
+main-test-services = broker logs2email logs2slack logs2rocketchat logs2microsoftteams api api-db keycloak keycloak-db ssh auth-server local-git local-api-data-watcher-pusher harbor-core harbor-database harbor-jobservice harbor-portal harbor-nginx harbor-redis harborregistry harborregistryctl harbor-trivy local-minio
 
 # Define a list of which Lagoon Services are needed for openshift testing
 openshift-test-services = openshiftremove openshiftbuilddeploy openshiftbuilddeploymonitor openshiftmisc tests-openshift

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ build/harbor-jobservice: services/harbor-jobservice/Dockerfile
 build/harbor-nginx: services/harbor-nginx/Dockerfile
 build/harbor-portal: services/harbor-portal/Dockerfile
 build/harbor-redis: services/harbor-redis/Dockerfile
-build/harbor-trivy: services/harbor-trivy/Dockerfile
+build/harbor-trivy build/local-minio: services/harbor-trivy/Dockerfile
 build/harborregistry: services/harborregistry/Dockerfile
 build/harborregistryctl: services/harborregistryctl/Dockerfile
 build/keycloak-db: services/keycloak-db/Dockerfile


### PR DESCRIPTION
in #2242, I inadvertently removed local-minio from the `main-test-services` list in the Makefile - this PR returns it to re-enable local builds (that don't use `make up` - as these were unaffected)

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied