### PR TITLE
Wraps OS login in an "if" to prevent build breaking on error

### DIFF
--- a/images/oc-build-deploy-dind/build-deploy.sh
+++ b/images/oc-build-deploy-dind/build-deploy.sh
@@ -48,8 +48,7 @@ docker login -u=jenkins -p="${DOCKER_REGISTRY_TOKEN}" ${OPENSHIFT_REGISTRY}
 
 INTERNAL_REGISTRY_LOGGED_IN="false"
 if [ ! -z ${INTERNAL_REGISTRY_URL} ] && [ ! -z ${INTERNAL_REGISTRY_USERNAME} ] && [ ! -z ${INTERNAL_REGISTRY_PASSWORD} ] ; then
-  echo "docker login -u '${INTERNAL_REGISTRY_USERNAME}' -p '${INTERNAL_REGISTRY_PASSWORD}' ${INTERNAL_REGISTRY_URL}" | /bin/bash
-  if [ "$?" -eq 0 ] ; then
+  if echo "docker login -u '${INTERNAL_REGISTRY_USERNAME}' -p '${INTERNAL_REGISTRY_PASSWORD}' ${INTERNAL_REGISTRY_URL}" | /bin/bash; then
     INTERNAL_REGISTRY_LOGGED_IN="true"
   fi
 fi


### PR DESCRIPTION
This is a fix for issue #2288 - it simply wraps the login command in an if, so that if it does fail, the whole build script doesn't exit with error

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied


closes #2288 
