### PR TITLE
Use image cache and harbor for public images in kubernetes

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -21,4 +21,6 @@ COPY scripts /kubectl-build-deploy/scripts
 
 COPY helmcharts  /kubectl-build-deploy/helmcharts
 
+ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
+
 CMD ["/kubectl-build-deploy/build-deploy.sh"]

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -930,13 +930,13 @@ if [[ $THIS_IS_TUG == "true" ]]; then
 
 elif [ "$BUILD_TYPE" == "pullrequest" ] || [ "$BUILD_TYPE" == "branch" ]; then
 
-  # All images that should be pulled are tagged as Images directly in OpenShift Registry
+  # All images that should be pulled are copied to the harbor registry
   for IMAGE_NAME in "${!IMAGES_PULL[@]}"
   do
     PULL_IMAGE="${IMAGES_PULL[${IMAGE_NAME}]}"
-    # . /kubectl-build-deploy/scripts/exec-kubernetes-tag-dockerhub.sh
-    # TODO: check if we can download and push the images to harbour (e.g. how artifactory does this)
-    IMAGE_HASHES[${IMAGE_NAME}]=$(skopeo inspect docker://${PULL_IMAGE} --tls-verify=false | jq ".Name + \"@\" + .Digest" -r)
+    . /kubectl-build-deploy/scripts/exec-kubernetes-copy-to-registry.sh
+
+    IMAGE_HASHES[${IMAGE_NAME}]=$(skopeo inspect docker://${REGISTRY}/${PROJECT}/${ENVIRONMENT}/${IMAGE_NAME}:${IMAGE_TAG:-latest} --tls-verify=false | jq ".Name + \"@\" + .Digest" -r)
   done
 
   for IMAGE_NAME in "${!IMAGES_BUILD[@]}"

--- a/images/kubectl-build-deploy-dind/scripts/exec-kubernetes-copy-to-registry.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-kubernetes-copy-to-registry.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${REGISTRY}/${PROJECT}/${ENVIRONMENT}/${IMAGE_NAME}:${IMAGE_TAG:-latest}

--- a/images/kubectl-build-deploy-dind/scripts/exec-kubernetes-tag-dockerhub.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-kubernetes-tag-dockerhub.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-oc --insecure-skip-tls-verify -n ${NAMESPACE} tag --reference-policy=local --source=docker ${PULL_IMAGE} ${NAMESPACE}/${IMAGE_NAME}:latest


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This solves two problems:

1. Use the amazee.io image cache for public images in `kubectl-build-deploy-dind`
2. Copies public images into harbor, then use those images in k8s instead of pulling directly from docker hub (or the image cache)

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
