### PR TITLE
Use image cache and harbor for public images in openshift

### DIFF
--- a/images/oc-build-deploy-dind/Dockerfile
+++ b/images/oc-build-deploy-dind/Dockerfile
@@ -21,4 +21,6 @@ COPY scripts /oc-build-deploy/scripts
 
 COPY openshift-templates  /oc-build-deploy/openshift-templates
 
+ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
+
 CMD ["/oc-build-deploy/build-deploy.sh"]

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -368,7 +368,7 @@ if [[ ( "$TYPE" == "pullrequest"  ||  "$TYPE" == "branch" ) && ! $THIS_IS_TUG ==
 
       # if the image just is an image name (like "alpine") we prefix it with `libary/` as the imagecache does not understand
       # the magic `alpine` images
-      if [[ ! "$IMAGE" =~ "/" ]]; then
+      if [[ ! "$PULL_IMAGE" =~ "/" ]]; then
         PULL_IMAGE="library/$PULL_IMAGE"
       fi
 

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -940,11 +940,11 @@ if [[ $THIS_IS_TUG == "true" ]]; then
 
 elif [ "$TYPE" == "pullrequest" ] || [ "$TYPE" == "branch" ]; then
 
-  # All images that should be pulled are tagged as Images directly in OpenShift Registry
+  # All images that should be pulled are copied to the openshift and harbor registry
   for IMAGE_NAME in "${!IMAGES_PULL[@]}"
   do
     PULL_IMAGE="${IMAGES_PULL[${IMAGE_NAME}]}"
-    . /oc-build-deploy/scripts/exec-openshift-tag-dockerhub.sh
+    . /oc-build-deploy/scripts/exec-openshift-copy-to-registry.sh
   done
 
   for IMAGE_NAME in "${!IMAGES_BUILD[@]}"

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -366,6 +366,12 @@ if [[ ( "$TYPE" == "pullrequest"  ||  "$TYPE" == "branch" ) && ! $THIS_IS_TUG ==
         PULL_IMAGE=$(echo "${OVERRIDE_IMAGE}" | envsubst)
       fi
 
+      # if the image just is an image name (like "alpine") we prefix it with `libary/` as the imagecache does not understand
+      # the magic `alpine` images
+      if [[ ! "$IMAGE" =~ "/" ]]; then
+        PULL_IMAGE="library/$PULL_IMAGE"
+      fi
+
       # Add the images we should pull to the IMAGES_PULL array, they will later be tagged from dockerhub
       IMAGES_PULL["${IMAGE_NAME}"]="${PULL_IMAGE}"
 

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-copy-to-registry.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-copy-to-registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
+
+if [ "${INTERNAL_REGISTRY_LOGGED_IN}" = "true" ] ; then
+    skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
+fi

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-copy-to-registry.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-copy-to-registry.sh
@@ -2,5 +2,5 @@
 skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${OPENSHIFT_REGISTRY}/${OPENSHIFT_PROJECT}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
 
 if [ "${INTERNAL_REGISTRY_LOGGED_IN}" = "true" ] ; then
-    skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}
+    skopeo copy --dest-tls-verify=false docker://${IMAGECACHE_REGISTRY}/${PULL_IMAGE} docker://${INTERNAL_REGISTRY_URL}/${PROJECT}/${SAFE_BRANCH}/${IMAGE_NAME}:${IMAGE_TAG:-latest}  || true
 fi

--- a/images/oc-build-deploy-dind/scripts/exec-openshift-tag-dockerhub.sh
+++ b/images/oc-build-deploy-dind/scripts/exec-openshift-tag-dockerhub.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} tag --reference-policy=local --source=docker ${PULL_IMAGE} ${OPENSHIFT_PROJECT}/${IMAGE_NAME}:latest

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -42,7 +42,7 @@ ENV OC_VERSION=v3.11.0 \
 
 # To run the openshift client library `oc` we need glibc, install that first. Copied from https://github.com/jeanblanchard/docker-alpine-glibc/blob/master/Dockerfile
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util && \
-    apk add --update openssl curl jq parallel && \
+    apk add --update openssl curl jq parallel skopeo && \
     curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
     curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \


### PR DESCRIPTION


 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This solves two problems:

1. Use the amazee.io image cache for public images in oc-build-deploy-dind
2. Copies public images into the openshift and harbor registries, then use those images in instead of pulling directly from docker hub (or the image cache)

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
