### PR TITLE
Make the prebackuppod wait until the backup completes

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
         - args:
             - sleep
-            - '3600'
+            - infinity
           env:
             - name: BACKUP_DB_HOST
               valueFrom:

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/prebackuppod.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - args:
             - sleep
-            - '3600'
+            - infinity
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/prebackuppod.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - args:
             - sleep
-            - '3600'
+            - infinity
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/prebackuppod.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - args:
             - sleep
-            - '3600'
+            - infinity
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/elasticsearch-cluster/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/elasticsearch-cluster/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env
@@ -126,7 +126,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env
@@ -174,7 +174,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/elasticsearch/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/elasticsearch/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-dbaas/prebackuppod.yml
@@ -85,7 +85,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             env:
               - name: BACKUP_DB_HOST
                 valueFrom:

--- a/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mariadb-shared/prebackuppod.yml
@@ -85,7 +85,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             env:
               - name: BACKUP_DB_HOST
                 valueFrom:

--- a/images/oc-build-deploy-dind/openshift-templates/mongo/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/mongo/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/postgres/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/postgres/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/rabbitmq-cluster/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/rabbitmq-cluster/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env
@@ -126,7 +126,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env
@@ -174,7 +174,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/rabbitmq/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/rabbitmq/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/redis-persistent/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/redis-persistent/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/solr/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/solr/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env

--- a/images/oc-build-deploy-dind/openshift-templates/varnish-persistent/prebackuppod.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/varnish-persistent/prebackuppod.yml
@@ -78,7 +78,7 @@ objects:
         containers:
           - args:
               - sleep
-              - '3600'
+              - infinity
             envFrom:
               - configMapRef:
                   name: lagoon-env


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This fixes the problem where if the backup takes longer than an hour it gets killed. It is also the [documented](https://k8up.io/docs/0.1.9/advanced-config.html#_prebackup_pods) way to run prebackuppods.

Without this fix backups can fail like this:
```
Oct 30, 2020 @ 09:30:08.274 command terminated with exit code 137
Oct 30, 2020 @ 09:30:08.274 io: read/write on closed pipe
```

You can reproduce the issue locally like this:
```
docker run --rm --name test-backup --detach amazeeio/alpine-mysql-client:latest sleep 4; sleep 2; docker exec -it test-backup sleep 4; echo $?
```

# Closing issues

n/a
