### PR TITLE
Adds conditional check when running add_metadata_to_project

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1161,10 +1161,19 @@ CREATE OR REPLACE PROCEDURE
   add_metadata_to_project()
 
   BEGIN
-    ALTER TABLE project
-    ADD metadata JSON DEFAULT '{}' CHECK (JSON_VALID(metadata));
-    UPDATE project
-    SET metadata = '{}';
+    IF NOT EXISTS(
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'project'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'metadata'
+    ) THEN
+      ALTER TABLE project
+      ADD metadata JSON DEFAULT '{}' CHECK (JSON_VALID(metadata));
+      UPDATE project
+      SET metadata = '{}';
+    END IF;
   END;
 $$
 


### PR DESCRIPTION
This PR adds a conditional check before running the add_metadata_to_project migration so that it doesn't attempt to add the "metadata" column to the database more than once.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Currently the migrations break because of a lack of conditional check, this fixes that

closes #2208 