### PR TITLE
Fix PHP 7.4 deprecated argument order for implode()

### DIFF
--- a/docs/docs/examples/drupal7-mariadb/sites/default/settings.php
+++ b/docs/docs/examples/drupal7-mariadb/sites/default/settings.php
@@ -58,7 +58,7 @@
 
     $conf['reverse_proxy'] = TRUE;
     $conf['reverse_proxy_addresses'] = array_merge(explode(',', getenv('VARNISH_HOSTS')), array('varnish'));
-    $conf['varnish_control_terminal'] = implode($varnish_hosts, " ");
+    $conf['varnish_control_terminal'] = implode(" ", $varnish_hosts);
     $conf['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
     $conf['varnish_version'] = 4;
   }

--- a/tests/files/drupal8-mariadb-single/web/sites/default/settings.php
+++ b/tests/files/drupal8-mariadb-single/web/sites/default/settings.php
@@ -72,7 +72,7 @@ if (getenv('LAGOON')) {
   $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
   array_walk($varnish_hosts, function(&$value, $key) { $value .= ':6082'; });
 
-  $config['varnish.settings']['varnish_control_terminal'] = implode($varnish_hosts, " ");
+  $config['varnish.settings']['varnish_control_terminal'] = implode(" ", $varnish_hosts);
   $config['varnish.settings']['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
   $config['varnish.settings']['varnish_version'] = 4;
 }

--- a/tests/files/drupal8-mariadb/web/sites/default/settings.php
+++ b/tests/files/drupal8-mariadb/web/sites/default/settings.php
@@ -72,7 +72,7 @@ if (getenv('LAGOON')) {
   $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
   array_walk($varnish_hosts, function(&$value, $key) { $value .= ':6082'; });
 
-  $config['varnish.settings']['varnish_control_terminal'] = implode($varnish_hosts, " ");
+  $config['varnish.settings']['varnish_control_terminal'] = implode(" ", $varnish_hosts);
   $config['varnish.settings']['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
   $config['varnish.settings']['varnish_version'] = 4;
 }

--- a/tests/files/drupal8-postgres/web/sites/default/settings.php
+++ b/tests/files/drupal8-postgres/web/sites/default/settings.php
@@ -72,7 +72,7 @@ if (getenv('LAGOON')) {
   $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
   array_walk($varnish_hosts, function(&$value, $key) { $value .= ':6082'; });
 
-  $config['varnish.settings']['varnish_control_terminal'] = implode($varnish_hosts, " ");
+  $config['varnish.settings']['varnish_control_terminal'] = implode(" ", $varnish_hosts);
   $config['varnish.settings']['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
   $config['varnish.settings']['varnish_version'] = 4;
 }

--- a/tests/files/drupal9-mariadb/web/sites/default/settings.php
+++ b/tests/files/drupal9-mariadb/web/sites/default/settings.php
@@ -72,7 +72,7 @@ if (getenv('LAGOON')) {
   $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
   array_walk($varnish_hosts, function(&$value, $key) { $value .= ':6082'; });
 
-  $config['varnish.settings']['varnish_control_terminal'] = implode($varnish_hosts, " ");
+  $config['varnish.settings']['varnish_control_terminal'] = implode(" ", $varnish_hosts);
   $config['varnish.settings']['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
   $config['varnish.settings']['varnish_version'] = 4;
 }


### PR DESCRIPTION
In PHP 7.4 passing the glue after the pieces (i.e. not using the documented order of parameters) has been deprecated for implode().

In docs/docs/examples/drupal7-mariadb/sites/default/settings.php the deprecated form is used:
`$conf['varnish_control_terminal'] = implode($varnish_hosts, " ");`

Fixes #2328