### PR TITLE
UI: Fixed long branch regex breaking out of the sidebar.

### DIFF
--- a/services/ui/src/components/ProjectDetailsSidebar/index.js
+++ b/services/ui/src/components/ProjectDetailsSidebar/index.js
@@ -201,6 +201,10 @@ const Project = ({ project }) => {
               &::before {
                 background-image: url('/static/images/branches.svg');
               }
+              
+              .field {
+                white-space: break-spaces;
+              }
             }
 
             &.prs {


### PR DESCRIPTION
For long branch regexes, the value is breaking out of the sidebar.

<img width="999" alt="vu___Project" src="https://user-images.githubusercontent.com/378794/99318100-351cb000-28bb-11eb-969f-0ebe915a9d7d.png">

With a fix in this PR:

<img width="1018" alt="vu___Project-2" src="https://user-images.githubusercontent.com/378794/99318190-59788c80-28bb-11eb-9eca-95b33d274580.png">

