### PR TITLE
Fix test for ingress-nginx compatibility

### DIFF
--- a/tests/tests/nginx/check-first.yaml
+++ b/tests/tests/nginx/check-first.yaml
@@ -43,7 +43,7 @@
   vars:
     url: "http://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','ROUTE_SUFFIX_HTTP') }}:{{ lookup('env','ROUTE_SUFFIX_HTTP_PORT') }}"
     host: "insecure-redirect.com"
-    expected_redirect_location: "https://insecure-redirect.com/$"
+    expected_redirect_location: "https://insecure-redirect.com/?$"
   tasks:
   - include: ../../checks/check-url-redirect-host.yaml
 

--- a/tests/tests/nginx/check-second.yaml
+++ b/tests/tests/nginx/check-second.yaml
@@ -34,7 +34,7 @@
   vars:
     url: "http://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','ROUTE_SUFFIX_HTTP') }}:{{ lookup('env','ROUTE_SUFFIX_HTTP_PORT') }}"
     host: "insecure-redirect.com"
-    expected_redirect_location: "https://insecure-redirect.com/$"
+    expected_redirect_location: "https://insecure-redirect.com/?$"
   tasks:
   - include: ../../checks/check-url-redirect-host.yaml
 


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The successor to the `stable/nginx-ingress` chart is the `ingress-nginx` [chart](https://kubernetes.github.io/ingress-nginx/).

When performing redirects the old ingress controller would have a trailing slash on bare domains.

```
Location: https://lagoon.sh/
```

The new one doesn't do that.

```
Location: https://lagoon.sh
```

So we need to update our test suite to handle either case.

# Closing issues

n/a
