### PR TITLE
Get CI running using helm charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/_build
 yarn-debug.log*
 yarn-error.log*
 site
+kubeconfig.*
+kindconfig.*
+kind

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local-dev/helm
 local-dev/minishift
 local-dev/minikube
 local-dev/k3d
+local-dev/jq
 k3d
 local-dev/kubectl
 **/v8-*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,199 +1,118 @@
-node {
+pipeline {
+  agent any
+  environment {
+    // configure build params
+    CI_BUILD_TAG = env.BUILD_TAG.replaceAll('%2f','').replaceAll('[^A-Za-z0-9]+', '').toLowerCase()
+    SAFEBRANCH_NAME = env.BRANCH_NAME.replaceAll('%2f','-').replaceAll('[^A-Za-z0-9]+', '-').toLowerCase()
+  }
 
-  openshift_version = 'v3.11.0'
-  minishift_version = '1.34.1'
-  kubernetes_versions = [
-    // ["kubernetes": "v1.15", "k3s": "v0.9.1", "kubectl": "v1.15.4"],
-    // ["kubernetes": "v1.16", "k3s": "v1.0.1", "kubectl": "v1.16.3"],
-    ["kubernetes": "v1.17", "k3s": "v1.17.0-k3s.1", "kubectl": "v1.17.0"]
-  ]
-
-  env.MINISHIFT_HOME = "/data/jenkins/.minishift"
-
-  withEnv(['AWS_BUCKET=jobs.amazeeio.services', 'AWS_DEFAULT_REGION=us-east-2']) {
-    withCredentials([
-      usernamePassword(credentialsId: 'aws-s3-lagoon', usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY'),
-      string(credentialsId: 'SKIP_IMAGE_PUBLISH', variable: 'SKIP_IMAGE_PUBLISH')
-    ]) {
-      try {
-        env.CI_BUILD_TAG = env.BUILD_TAG.replaceAll('%2f','').replaceAll("[^A-Za-z0-9]+", "").toLowerCase()
-        env.SAFEBRANCH_NAME = env.BRANCH_NAME.replaceAll('%2f','-').replaceAll("[^A-Za-z0-9]+", "-").toLowerCase()
-        env.SYNC_MAKE_OUTPUT = 'target'
-        // make/tests will synchronise (buffer) output by default to avoid interspersed
-        // lines from multiple jobs run in parallel. However this means that output for
-        // each make target is not written until the command completes.
-        //
-        // See `man -P 'less +/-O' make` for more information about this option.
-        //
-        // Uncomment the line below to disable output synchronisation.
-        env.SYNC_MAKE_OUTPUT = 'none'
-
-        stage ('env') {
-          sh "env"
+  stages {
+    stage ('notify started') {
+      steps {
+        notifySlack('STARTED')
+      }
+    }
+    stage ('env') {
+      steps {
+        sh 'env'
+      }
+    }
+    // in order to have the newest images from upstream (with all the security
+    // updates) we clean our local docker cache on tag deployments
+    // we don't do this all the time to still profit from image layer caching
+    // but we want this on tag deployments in order to ensure that we publish
+    // images always with the newest possible images.
+    stage ('clean docker image cache') {
+      when {
+        buildingTag()
+      }
+      steps {
+        sh script: "docker image prune -af", label: "Pruning images"
+      }
+    }
+    stage ('build images') {
+      steps {
+        sh script: "make -O -j8 build", label: "Building images"
+      }
+    }
+    stage ('push images to testlagoon/*') {
+      when {
+        not {
+          environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
         }
-
-        deleteDir()
-
-        stage ('Checkout') {
-          def checkout = checkout scm
-          env.GIT_COMMIT = checkout["GIT_COMMIT"]
+      }
+      environment {
+        PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+      }
+      steps {
+        sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+        sh script: "make -O -j8 publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
+      }
+    }
+    stage ('run test suite') {
+      steps {
+        sh script: "make -j8 kind/test BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+      }
+    }
+    stage ('push images to testlagoon/* with :latest tag') {
+      when {
+        branch 'main'
+      }
+      environment {
+        PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+      }
+      steps {
+        sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+        sh script: "make -O -j8 publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=latest", label: "Publishing built images with :latest tag"
+      }
+    }
+    stage ('deploy to test environment') {
+      when {
+        branch 'main'
+      }
+      environment {
+        TOKEN = credentials('vshn-gitlab-helmfile-ci-trigger')
+      }
+      steps {
+        sh script: "curl -X POST -F token=$TOKEN -F ref=master https://git.vshn.net/api/v4/projects/1263/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
+      }
+    }
+    stage ('push images to uselagoon/*') {
+      when {
+        buildingTag()
+        not {
+          environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
         }
-
-        // in order to have the newest images from upstream (with all the security updates) we clean our local docker cache on tag deployments
-        // we don't do this all the time to still profit from image layer caching
-        // but we want this on tag deployments in order to ensure that we publish images always with the newest possible images.
-        if (env.TAG_NAME) {
-          stage ('clean docker image cache') {
-            sh script: "docker image prune -af", label: "Pruning images"
-          }
-        }
-
-        stage ('check PR labels') {
-          if (env.BRANCH_NAME ==~ /PR-\d+/) {
-            pullRequest.labels.each{
-              echo "This PR has labels: $it"
-              }
-            }
-        }
-
-        stage ('build images') {
-          sh script: "make -O${SYNC_MAKE_OUTPUT} -j8 build", label: "Building images"
-        }
-
-        try {
-          parallel (
-            // '1 tests': {
-            //   kubernetes_versions.each { kubernetes_version ->
-            //     stage ("kubernetes ${kubernetes_version['kubernetes']} tests") {
-            //       try {
-            //         sh script: "make k3d/clean K3S_VERSION=${kubernetes_version['k3s']} KUBECTL_VERSION=${kubernetes_version['kubectl']}", label: "Removing any previous k3d versions"
-            //         sh script: "make k3d K3S_VERSION=${kubernetes_version['k3s']} KUBECTL_VERSION=${kubernetes_version['kubectl']}", label: "Making k3d"
-            //         sh script: "make -O${SYNC_MAKE_OUTPUT} k8s-tests -j2", label: "Making kubernetes tests"
-            //       } catch (e) {
-            //         echo "Something went wrong, trying to cleanup"
-            //         cleanup()
-            //         throw e
-            //       }
-            //     }
-            //   }
-            //   stage ('minishift tests') {
-            //     withCredentials([string(credentialsId: 'github_api_public_read', variable: 'MINISHIFT_GITHUB_API_TOKEN')]) {
-            //       try {
-            //         if (env.CHANGE_ID && pullRequest.labels.contains("skip-openshift-tests")) {
-            //           sh script: 'echo "PR identified as not needing Openshift testing."', label: "Skipping Openshift testing stage"
-            //         } else {
-            //           sh 'make minishift/cleanall || echo'
-            //           sh script: "make minishift MINISHIFT_GITHUB_API_TOKEN=$MINISHIFT_GITHUB_API_TOKEN MINISHIFT_CPUS=\$(nproc --ignore 3) MINISHIFT_MEMORY=24GB MINISHIFT_DISK_SIZE=70GB MINISHIFT_VERSION=${minishift_version} OPENSHIFT_VERSION=${openshift_version}", label: "Making openshift"
-            //           sh script: "make -O${SYNC_MAKE_OUTPUT} push-minishift -j5", label: "Pushing built images into openshift"
-            //           sh script: "make -O${SYNC_MAKE_OUTPUT} openshift-tests -j1", label: "Making openshift tests"
-            //         }
-            //       } catch (e) {
-            //         echo "Something went wrong, trying to cleanup"
-            //         cleanup()
-            //         throw e
-            //       }
-            //     }
-            //   }
-            //   stage ('cleanup') {
-            //     cleanup()
-            //   }
-            // },
-            // '2 start services': {
-            //   stage ('start services') {
-            //     try {
-            //       notifySlack()
-            //       sh "make kill"
-            //       sh "make up"
-            //       sh "make logs"
-            //     } catch (e) {
-            //       echo "Something went wrong, trying to cleanup"
-            //       cleanup()
-            //       throw e
-            //     }
-            //   }
-            // },
-            '3 push images to testlagoon': {
-              stage ('push images to testlagoon/*') {
-                withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
-                  try {
-                    if (env.SKIP_IMAGE_PUBLISH != 'true') {
-                      sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-                      sh script: "make -O${SYNC_MAKE_OUTPUT} -j8 publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
-                    } else {
-                      sh script: 'echo "skipped because of SKIP_IMAGE_PUBLISH env variable"', label: "Skipping image publishing"
-                    }
-                    if (env.BRANCH_NAME == 'main' ) {
-                      sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-                      sh script: "make -O${SYNC_MAKE_OUTPUT} -j8 publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=latest", label: "Publishing built images with :latest tag"
-                      withCredentials([string(credentialsId: 'vshn-gitlab-helmfile-ci-trigger', variable: 'TOKEN')]) {
-                        sh script: "curl -X POST -F token=$TOKEN -F ref=master https://git.vshn.net/api/v4/projects/1263/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
-                      }
-                    }
-                  } catch (e) {
-                    echo "Something went wrong, trying to cleanup"
-                    cleanup()
-                    throw e
-                  }
-                }
-              }
-            }
-          )
-        } catch (e) {
-          echo "Something went wrong, trying to cleanup"
-          cleanup()
-          throw e
-        }
-
-        if (env.TAG_NAME && env.SKIP_IMAGE_PUBLISH != 'true') {
-          stage ('publish-amazeeio') {
-            withCredentials([string(credentialsId: 'amazeeiojenkins-dockerhub-password', variable: 'PASSWORD')]) {
-              sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-              sh script: "make -O${SYNC_MAKE_OUTPUT} -j8 publish-uselagoon-baseimages publish-uselagoon-serviceimages publish-uselagoon-taskimages", label: "Publishing built images to uselagoon"
-            }
-          }
-        }
-
-      } catch (e) {
-        currentBuild.result = 'FAILURE'
-        throw e
-      } finally {
-        notifySlack(currentBuild.result)
+      }
+      environment {
+        PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+      }
+      steps {
+        sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+        sh script: "make -O -j8 publish-uselagoon-baseimages publish-uselagoon-serviceimages publish-uselagoon-taskimages", label: "Publishing built images to uselagoon"
       }
     }
   }
 
-}
-
-def cleanup() {
-  try {
-    sh "make minishift/cleanall"
-    sh "make k3d/cleanall"
-    sh "make down || true"
-    sh "make kill"
-    sh "make down"
-    sh "make clean"
-  } catch (error) {
-    echo "cleanup failed, ignoring this."
+  post {
+    always {
+      sh "make clean kind/clean"
+    }
+    success {
+      notifySlack('SUCCESS')
+      deleteDir()
+    }
+    failure {
+      notifySlack('FAILURE')
+    }
+    aborted {
+      notifySlack('ABORTED')
+    }
   }
 }
 
-def notifySlack(String buildStatus = 'STARTED') {
-    // Build status of null means success.
-    buildStatus = buildStatus ?: 'SUCCESS'
-
-    def color
-
-    if (buildStatus == 'STARTED') {
-        color = '#68A1D1'
-    } else if (buildStatus == 'SUCCESS') {
-        color = '#BDFFC3'
-    } else if (buildStatus == 'UNSTABLE') {
-        color = '#FFFE89'
-    } else {
-        color = '#FF9FA1'
-    }
-
-    def msg = "${buildStatus}: `${env.JOB_NAME}` #${env.BUILD_NUMBER}:\n${env.BUILD_URL}"
-
-    slackSend(color: color, message: msg)
+def notifySlack(String status) {
+  slackSend(
+    color: ([STARTED: '#68A1D1', SUCCESS: '#BDFFC3', FAILURE: '#FF9FA1', ABORTED: '#949393'][status]),
+    message: "${status}: `${env.JOB_NAME}` #${env.BUILD_NUMBER}:\n${env.BUILD_URL}")
 }

--- a/Makefile
+++ b/Makefile
@@ -931,7 +931,7 @@ KIND_VERSION = v0.9.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
 TESTS = [features-kubernetes,nginx,active-standby-kubernetes,drupal-php72,drupal-php73,drupal-php74]
-CHARTS_TREEISH = lagoon-test-0.8.1
+CHARTS_TREEISH = lagoon-test-0.8.2
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/Makefile
+++ b/Makefile
@@ -988,8 +988,10 @@ kind/cluster: local-dev/kind
 		&& echo '  - containerPath: /var/lib/kubelet/config.json'                                                    >> $$KINDCONFIG \
 		&& echo '    hostPath: $(HOME)/.docker/config.json'                                                          >> $$KINDCONFIG \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind create cluster --config=$$KINDCONFIG \
-		&& echo -e 'Interact with the cluster during the test run like so:\n' \
+		&& echo -e 'Interact with the cluster during the test run in Jenkins like so:\n' \
 		&& echo "export KUBECONFIG=\$$(mktemp) && scp $$NODE_NAME:$$KUBECONFIG \$$KUBECONFIG && KIND_PORT=\$$(sed -nE 's/.+server:.+:([0-9]+)/\1/p' \$$KUBECONFIG) && ssh -fNL \$$KIND_PORT:127.0.0.1:\$$KIND_PORT $$NODE_NAME" \
+		&& echo -e '\nOr running locally:\n' \
+		&& echo -e './local-dev/kind export kubeconfig --name "$(CI_BUILD_TAG)"\n' \
 		&& echo -e 'kubectl ...\n'
 
 KIND_SERVICES = api api-db api-redis auth-server broker controllerhandler drush-alias keycloak keycloak-db ssh

--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ KIND_TOOLS = kind helm kubectl jq
 
 .PHONY: kind/test
 kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addprefix build/,$(KIND_SERVICES))
-	export CHARTSDIR=$$(mktemp -dp . lagoon-charts.XXX) \
+	export CHARTSDIR=$$(mktemp -d ./lagoon-charts.XXX) \
 		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \

--- a/Makefile
+++ b/Makefile
@@ -965,7 +965,7 @@ helm/repos: local-dev/helm
 kind/cluster: local-dev/kind
 	# these IPs are a result of the docker config on our build nodes
 	export KUBECONFIG=$$(mktemp) \
-		KINDCONFIG=$$(mktemp -p . kindconfig.XXX) \
+		KINDCONFIG=$$(mktemp ./kindconfig.XXX) \
 		&& chmod 644 $$KUBECONFIG \
 		&& curl -sSLo $$KINDCONFIG https://raw.githubusercontent.com/uselagoon/lagoon-charts/$(CHARTS_TREEISH)/test-suite.kind-config.yaml \
 		&& echo '  [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.192.168.48.2.nip.io:32443".tls]'  >> $$KINDCONFIG \
@@ -1005,7 +1005,7 @@ kind/test: kind/cluster kind/preload local-dev/helm local-dev/kind local-dev/kub
 		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \
-		&& export KUBECONFIG=$$(mktemp -p .. kubeconfig.XXX) \
+		&& export KUBECONFIG=$$(mktemp ../kubeconfig.XXX) \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ../local-dev/kind export kubeconfig \
 		&& $(MAKE) -O fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
 		HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \

--- a/Makefile
+++ b/Makefile
@@ -949,8 +949,15 @@ ifeq ($(GOJQ_VERSION), $(shell jq -v 2>/dev/null | sed -nE 's/gojq ([0-9.]+).*/v
 	ln -s $(shell command -v jq) ./local-dev/jq
 else
 	$(info downloading gojq version $(GOJQ_VERSION) for $(ARCH))
+ifeq ($(ARCH), darwin)
+	TMPDIR=$$(mktemp -d) \
+		&& curl -sSL https://github.com/itchyny/gojq/releases/download/$(GOJQ_VERSION)/gojq_$(GOJQ_VERSION)_$(ARCH)_amd64.zip -o $$TMPDIR/gojq.zip \
+		&& (cd $$TMPDIR && unzip gojq.zip) && cp $$TMPDIR/gojq_$(GOJQ_VERSION)_$(ARCH)_amd64/gojq ./local-dev/jq && rm -rf $$TMPDIR
+else
 	curl -sSL https://github.com/itchyny/gojq/releases/download/$(GOJQ_VERSION)/gojq_$(GOJQ_VERSION)_$(ARCH)_amd64.tar.gz | tar -xzC local-dev --strip-components=1 gojq_$(GOJQ_VERSION)_$(ARCH)_amd64/gojq
-	mv ./local-dev/{go,}jq && chmod a+x local-dev/jq
+	mv ./local-dev/{go,}jq
+endif
+	chmod a+x local-dev/jq
 endif
 
 .PHONY: helm/repos

--- a/Makefile
+++ b/Makefile
@@ -986,10 +986,9 @@ kind: local-dev/kind
 		&& echo '  - containerPath: /var/lib/kubelet/config.json'                                                    >> $$KINDCONFIG \
 		&& echo '    hostPath: $(HOME)/.docker/config.json'                                                          >> $$KINDCONFIG \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind create cluster --config=$$KINDCONFIG \
-		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" KUBECONFIG="../kubeconfig.kind.$$KIND_CLUSTER_NAME" ../local-dev/kind export kubeconfig
 		&& echo -e 'Interact with the cluster during the test run like so:\n' \
 		&& echo "export KUBECONFIG=\$$(mktemp) && scp $$NODE_NAME:$$KUBECONFIG \$$KUBECONFIG && KIND_PORT=\$$(sed -nE 's/.+server:.+:([0-9]+)/\1/p' \$$KUBECONFIG) && ssh -fNL \$$KIND_PORT:127.0.0.1:\$$KIND_PORT $$NODE_NAME" \
-		&& echo -e 'kubectl ...\n' \
+		&& echo -e 'kubectl ...\n'
 	echo "$(CI_BUILD_TAG)" > $@
 
 KIND_SERVICES = api api-db api-redis auth-server broker controllerhandler drush-alias keycloak keycloak-db ssh
@@ -1006,13 +1005,15 @@ kind/test: kind kind/preload local-dev/helm local-dev/kind local-dev/kubectl loc
 		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \
+		&& export KUBECONFIG=$$(mktemp ../kubeconfig.XXX) \
+		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ../local-dev/kind export kubeconfig \
 		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
 		HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 		JQ=$$(realpath ../local-dev/jq) OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=testlagoon/kubectl-build-deploy-dind:$(BRANCH_NAME) \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
-			--volume "$$(pwd)/kubeconfig.kind.$$KIND_CLUSTER_NAME:/root/.kube/config" \
+			--volume "$$(realpath $$KUBECONFIG):/root/.kube/config" \
 			--workdir /workdir \
 			"quay.io/helmpack/chart-testing:v3.1.1" \
 			ct install

--- a/Makefile
+++ b/Makefile
@@ -961,8 +961,7 @@ helm/repos: local-dev/helm
 	./local-dev/helm repo add stable https://charts.helm.sh/stable
 	./local-dev/helm repo add bitnami https://charts.bitnami.com/bitnami
 
-.PHONY: kind/cluster
-kind/cluster: local-dev/kind
+kind: local-dev/kind
 	# these IPs are a result of the docker config on our build nodes
 	export KUBECONFIG=$$(mktemp) \
 		KINDCONFIG=$$(mktemp ./kindconfig.XXX) \
@@ -990,18 +989,19 @@ kind/cluster: local-dev/kind
 		&& echo -e 'Interact with the cluster during the test run like so:\n' \
 		&& echo "export KUBECONFIG=\$$(mktemp) && scp $$NODE_NAME:$$KUBECONFIG \$$KUBECONFIG && KIND_PORT=\$$(sed -nE 's/.+server:.+:([0-9]+)/\1/p' \$$KUBECONFIG) && ssh -fNL \$$KIND_PORT:127.0.0.1:\$$KIND_PORT $$NODE_NAME" \
 		&& echo -e 'kubectl ...\n'
+	echo "$(CI_BUILD_TAG)" > $@
 
 KIND_SERVICES = api api-db api-redis auth-server broker controllerhandler drush-alias keycloak keycloak-db ssh
 
 .PHONY: kind/preload
-kind/preload: kind/cluster $(addprefix build/,$(KIND_SERVICES))
+kind/preload: kind $(addprefix build/,$(KIND_SERVICES))
 	for image in $(KIND_SERVICES); do \
 		KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind load docker-image $(CI_BUILD_TAG)/$$image; \
 		done
 
 .PHONY: kind/test
-kind/test: kind/cluster kind/preload local-dev/helm local-dev/kind local-dev/kubectl local-dev/jq helm/repos
-	export CHARTSDIR=$$(mktemp -dp . lagoon-charts.XXX) \
+kind/test: kind kind/preload local-dev/helm local-dev/kind local-dev/kubectl local-dev/jq helm/repos
+	export CHARTSDIR=$$(mktemp -d ./lagoon-charts.XXX) \
 		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \
@@ -1021,3 +1021,4 @@ kind/test: kind/cluster kind/preload local-dev/helm local-dev/kind local-dev/kub
 .PHONY: kind/clean
 kind/clean: local-dev/kind
 	KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind delete cluster
+	rm -f kind

--- a/Makefile
+++ b/Makefile
@@ -964,7 +964,8 @@ helm/repos: local-dev/helm
 .PHONY: kind/cluster
 kind/cluster: local-dev/kind
 	# these IPs are a result of the docker config on our build nodes
-	export KUBECONFIG=$$(mktemp) \
+	./local-dev/kind get clusters | grep -q "$(CI_BUILD_TAG)" && exit; \
+		export KUBECONFIG=$$(mktemp) \
 		KINDCONFIG=$$(mktemp ./kindconfig.XXX) \
 		&& chmod 644 $$KUBECONFIG \
 		&& curl -sSLo $$KINDCONFIG https://raw.githubusercontent.com/uselagoon/lagoon-charts/$(CHARTS_TREEISH)/test-suite.kind-config.yaml \

--- a/Makefile
+++ b/Makefile
@@ -988,6 +988,7 @@ kind/cluster: local-dev/kind
 		&& echo '  - containerPath: /var/lib/kubelet/config.json'                                     >> $$KINDCONFIG \
 		&& echo '    hostPath: $(HOME)/.docker/config.json'                                           >> $$KINDCONFIG \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind create cluster --config=$$KINDCONFIG \
+		&& cp $$KUBECONFIG "kubeconfig.kind.$(CI_BUILD_TAG)" \
 		&& echo -e 'Interact with the cluster during the test run in Jenkins like so:\n' \
 		&& echo "export KUBECONFIG=\$$(mktemp) && scp $$NODE_NAME:$$KUBECONFIG \$$KUBECONFIG && KIND_PORT=\$$(sed -nE 's/.+server:.+:([0-9]+)/\1/p' \$$KUBECONFIG) && ssh -fNL \$$KIND_PORT:127.0.0.1:\$$KIND_PORT $$NODE_NAME" \
 		&& echo -e '\nOr running locally:\n' \

--- a/Makefile
+++ b/Makefile
@@ -981,6 +981,8 @@ kind/cluster: local-dev/kind
 		&& echo '    insecure_skip_verify = true'                                                                    >> $$KINDCONFIG \
 		&& echo '  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.172.25.0.2.nip.io:32080"]'        >> $$KINDCONFIG \
 		&& echo '    endpoint = ["http://registry.172.25.0.2.nip.io:32080"]'                                         >> $$KINDCONFIG \
+		&& echo '  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]'                               >> $$KINDCONFIG \
+		&& echo '    endpoint = ["https://imagecache.amazeeio.cloud", "https://index.docker.io/v1/"]'                >> $$KINDCONFIG \
 		&& echo 'nodes:'                                                                                             >> $$KINDCONFIG \
 		&& echo '- role: control-plane'                                                                              >> $$KINDCONFIG \
 		&& echo '  image: $(KIND_IMAGE)'                                                                             >> $$KINDCONFIG \

--- a/Makefile
+++ b/Makefile
@@ -1007,7 +1007,7 @@ kind/test: kind kind/preload local-dev/helm local-dev/kind local-dev/kubectl loc
 		&& git checkout $(CHARTS_TREEISH) \
 		&& export KUBECONFIG=$$(mktemp ../kubeconfig.XXX) \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ../local-dev/kind export kubeconfig \
-		&& $(MAKE) -O fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
+		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
 		HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 		JQ=$$(realpath ../local-dev/jq) OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=testlagoon/kubectl-build-deploy-dind:$(BRANCH_NAME) \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -1007,7 +1007,9 @@ kind/test: kind/cluster kind/preload local-dev/helm local-dev/kind local-dev/kub
 		&& git checkout $(CHARTS_TREEISH) \
 		&& export KUBECONFIG=$$(mktemp -p .. kubeconfig.XXX) \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ../local-dev/kind export kubeconfig \
-		&& $(MAKE) -O fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) JQ=$$(realpath ../local-dev/jq) \
+		&& $(MAKE) -O fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
+		HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
+		JQ=$$(realpath ../local-dev/jq) OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=testlagoon/kubectl-build-deploy-dind:$(BRANCH_NAME) \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \

--- a/Makefile
+++ b/Makefile
@@ -931,7 +931,7 @@ KIND_VERSION = v0.9.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
 TESTS = [features-kubernetes,nginx,active-standby-kubernetes,drupal-php72,drupal-php73,drupal-php74]
-CHARTS_TREEISH = lagoon-test-0.8.0
+CHARTS_TREEISH = lagoon-test-0.8.1
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/local-dev/api-data-watcher-pusher/api-data/03-populate-api-data-kubernetes.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/03-populate-api-data-kubernetes.gql
@@ -9,7 +9,7 @@ mutation PopulateApi {
       routerPattern: "${project}.${environment}.${INGRESS_IP}.nip.io"
       sshHost: "172.17.0.1"
       sshPort: "2020"
-      token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IndkVEhaM0xqWl9TVDNEcFpmaTZDcEV5X3ZlVnBtdEIxMFpYVTI2SmRaTkUifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJsYWdvb24iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoibGFnb29uLXJlbW90ZS1rdWJlcm5ldGVzLWJ1aWxkLWRlcGxveS10b2tlbi1oY2xsYyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJsYWdvb24tcmVtb3RlLWt1YmVybmV0ZXMtYnVpbGQtZGVwbG95Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiMTM1Mzg5NWQtYzRmNC00NzYxLWEyNjAtYmE5NzY1MDgxYzU5Iiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmxhZ29vbjpsYWdvb24tcmVtb3RlLWt1YmVybmV0ZXMtYnVpbGQtZGVwbG95In0.FP1roVoZ03GmmSePu6bYBnSNhAocAOZ3xlD0PJ09Km-_3nYQ46RwZzW7bBzZWlJTvRWhqoae3oFt8pLUDyq2Ibg9MBUjVixGsQ58bY7WiF5gyoYNlq79-8rglAdVK_6IzIgrEEBBaMMySEY4jOTOJfsxtgiACi3m-nsf8u2epAXBqX0MaF9AZe4ILsEnhLSOiAuuzCr173rsY-bezrITtBuOdkFmwptB55d1GCiHPvEh5C17GGZtKs6Wyo_yBIQOyEti5bpG2Vc3Bwm1taA2OPox41pApvRlfQSa32_ZtVyFyi_zsZKYTq-fnex7BNmJfPiJG9B9q0Ib3HM3K6bjyQ" # make-kubernetes-token
+      token: "${TOKEN}" # make-kubernetes-token
     }
   ) {
     id

--- a/tests/tests/active-standby/deploy-active-standby.yaml
+++ b/tests/tests/active-standby/deploy-active-standby.yaml
@@ -23,7 +23,7 @@
         body_format: json
         body: '{ "query": "query($id: Int!) {taskById(id: $id){status}}", "variables": {"id":{{ apiresponse.json.data.switchActiveStandby.id }}}}'
       register: taskresult
-      until: taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed"
+      until: taskresult.json.data is defined and (taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed")
       retries: 10
       delay: 5
     - name: "{{ testname }} - fail if task fails"


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR refactors the Jenkins pipeline to get CI running using the Lagoon helm charts. The pipeline now uses [declarative syntax](https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline) so it's a bit shorter and hopefully easier to understand. It also makes it easier to run a test [matrix](https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-matrix) in future (e.g. multiple k8s versions).

Where the workflow has changed, it now does this:

* Build the images
* Push the images to `testlagoon/*`
* Create a kind cluster
* Copy the built images into the cluster cache (avoid pulling layers down again)
* Run tests in the cluster

The steps following a successful test run should be the same.

Because of the way that the [chart-testing](https://github.com/helm/chart-testing) tool works, we no longer have live log messages in Jenkins. Instead the test job will print a command which sets up a local `$KUBECONFIG` and a ssh port-forward so that you can interact with the `kind` cluster while it's running to tail logs, watch the tests run etc. Check the logs of the `Running tests on kind cluster` stage to see something like this:

![Screenshot from 2020-12-03 10-52-50](https://user-images.githubusercontent.com/861778/100958593-9bf6c600-3557-11eb-814e-35bb8fb0f4b3.png)

The things that I'd like special review attention on:

* Does the `Jenkinsfile` logic look correct compared to the old pipeline? Particularly around `SKIP_IMAGE_PUBLISH`, and when to push to `uselagoon/*`?
* Do the other workflows that use the `Makefile` still work? I don't do much with e.g. `docker-compose`, so could someone who uses that functionality confirm that it still works?
* Is there documentation that needs updating?
* Have I missed any test suites that need to be included and run?

# Closing issues

n/a
