### PR TITLE
add update-images.sh for docker-host

### DIFF
--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -34,6 +34,7 @@ ENV DOCKER_HOST=docker-host \
 RUN fix-permissions /home
 
 COPY update-push-images.sh /update-push-images.sh
+COPY update-images.sh /update-images.sh
 COPY prune-images.sh /prune-images.sh
 COPY remove-exited.sh /remove-exited.sh
 

--- a/images/docker-host/update-images.sh
+++ b/images/docker-host/update-images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+set -x
+
+if ! docker -H ${DOCKER_HOST} info &> /dev/null; then
+    echo "could not connect to ${DOCKER_HOST}"; exit 1
+fi
+
+# Iterates through all images that have the name of the repository we are interested in in it
+for FULL_IMAGE in $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep -E "${REPOSITORY_TO_UPDATE}/" | grep -v none); do
+  # pull newest version of found image
+  docker pull ${FULL_IMAGE} | cat
+done


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

In Kubernetes cluster, we don't have the Openshift registry (https://github.com/amazeeio/lagoon/blob/master/images/docker-host/update-push-images.sh#L23) so I've added a new script for docker-host that only pull images from Docker Hub (using imagecache) to keep them up to date.

Related PR https://github.com/uselagoon/lagoon-charts/pull/173
<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

