### PR TITLE
Restore some logging services

### DIFF
--- a/services/logs-concentrator/Dockerfile
+++ b/services/logs-concentrator/Dockerfile
@@ -1,0 +1,22 @@
+FROM fluent/fluentd:v1.11-1
+LABEL maintainer="support@amazee.io"
+
+USER root
+
+RUN apk add --no-cache --update --virtual .build-deps \
+      build-base ruby-dev \
+      && gem install fluent-plugin-elasticsearch \
+      && gem install fluent-plugin-prometheus \
+      && gem sources --clear-all \
+      && apk del .build-deps \
+      && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \
+      && apk add --no-cache curl
+
+COPY fluent.conf /fluentd/etc/
+COPY entrypoint.sh /bin/
+
+USER fluent
+
+# environment variables that must be defined to point to the k8s api
+# these are set by default when running in k8s
+ENV KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT

--- a/services/logs-concentrator/entrypoint.sh
+++ b/services/logs-concentrator/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# https://github.com/fluent/fluentd-docker-image/blob/master/v1.10/alpine/entrypoint.sh
+
+#source vars if file exists
+DEFAULT=/etc/default/fluentd
+
+if [ -r $DEFAULT ]; then
+    set -o allexport
+    . $DEFAULT
+    set +o allexport
+fi
+
+# If the user has supplied only arguments append them to `fluentd` command
+if [ "${1#-}" != "$1" ]; then
+    set -- fluentd "$@"
+fi
+
+# If user does not supply config file or plugins, use the default
+if [ "$1" = "fluentd" ]; then
+    if ! echo "$@" | grep ' \-c' ; then
+       set -- "$@" -c "/fluentd/etc/${FLUENTD_CONF}"
+    fi
+
+    if ! echo "$@" | grep ' \-p' ; then
+       set -- "$@" -p /fluentd/plugins
+    fi
+fi
+
+exec "$@"

--- a/services/logs-concentrator/fluent.conf
+++ b/services/logs-concentrator/fluent.conf
@@ -1,0 +1,19 @@
+# vi: ft=fluentd
+
+# NOTE: this is just a placeholder. When running in k8s a configmap is mounted
+# over this file. That configmap is configured in the lagoon-logs-concentrator
+# helm chart.
+
+<system>
+  workers 2
+</system>
+
+<source>
+  @type forward
+  @id   in_forward
+  add_tag_prefix in_forward
+</source>
+
+<match in_forward.*>
+  @type stdout
+</match>

--- a/services/logs-dispatcher/Dockerfile
+++ b/services/logs-dispatcher/Dockerfile
@@ -1,0 +1,30 @@
+FROM fluent/fluentd:v1.11-1
+LABEL maintainer="support@amazee.io"
+
+USER root
+
+RUN apk add --no-cache --update --virtual .build-deps \
+      build-base ruby-dev \
+      && gem install fluent-plugin-cloudwatch-logs \
+      && gem install fluent-plugin-kubernetes_metadata_filter \
+      && gem install fluent-plugin-multi-format-parser \
+      && gem install fluent-plugin-prometheus \
+      && gem install fluent-plugin-rabbitmq \
+      && gem install fluent-plugin-record-modifier \
+      && gem install fluent-plugin-remote-syslog \
+      && gem install fluent-plugin-rewrite-tag-filter \
+      && gem install fluent-plugin-route \
+      && gem install fluent-plugin-s3 --no-document \
+      && gem sources --clear-all \
+      && apk del .build-deps \
+      && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \
+      && apk add --no-cache curl
+
+COPY fluent.conf /fluentd/etc/
+COPY entrypoint.sh /bin/
+
+USER fluent
+
+# environment variables that must be defined to point to the k8s api
+# these are set by default when running in k8s
+ENV KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT

--- a/services/logs-dispatcher/entrypoint.sh
+++ b/services/logs-dispatcher/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# https://github.com/fluent/fluentd-docker-image/blob/master/v1.10/alpine/entrypoint.sh
+
+#source vars if file exists
+DEFAULT=/etc/default/fluentd
+
+if [ -r $DEFAULT ]; then
+    set -o allexport
+    . $DEFAULT
+    set +o allexport
+fi
+
+# If the user has supplied only arguments append them to `fluentd` command
+if [ "${1#-}" != "$1" ]; then
+    set -- fluentd "$@"
+fi
+
+# If user does not supply config file or plugins, use the default
+if [ "$1" = "fluentd" ]; then
+    if ! echo "$@" | grep ' \-c' ; then
+       set -- "$@" -c "/fluentd/etc/${FLUENTD_CONF}"
+    fi
+
+    if ! echo "$@" | grep ' \-p' ; then
+       set -- "$@" -p /fluentd/plugins
+    fi
+fi
+
+exec "$@"

--- a/services/logs-dispatcher/fluent.conf
+++ b/services/logs-dispatcher/fluent.conf
@@ -1,0 +1,19 @@
+# vi: ft=fluentd
+
+# NOTE: this is just a placeholder. When running in k8s a configmap is mounted
+# over this file. That configmap is configured in the lagoon-logs-concentrator
+# helm chart.
+
+<system>
+  workers 2
+</system>
+
+<source>
+  @type forward
+  @id   in_forward
+  add_tag_prefix in_forward
+</source>
+
+<match in_forward.*>
+  @type stdout
+</match>

--- a/services/logs-tee/Dockerfile
+++ b/services/logs-tee/Dockerfile
@@ -1,0 +1,13 @@
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
+LABEL maintainer="support@amazee.io"
+
+RUN addgroup -g 1000 -S socat && \
+      adduser -u 1000 -S socat -G socat && \
+      apk add --no-cache socat bash
+
+COPY entrypoint.sh /
+
+USER socat
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/services/logs-tee/entrypoint.sh
+++ b/services/logs-tee/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# this script:
+# - listens on the UDP port given in the first argument (all interfaces)
+# - assumes the remaining arguments are UDP endpoints
+# - duplicates received traffic to each UDP endpoints
+# - ensures that each defined endpoint resolves before starting
+# - echoes to STDOUT if $DEBUG is set to "true"
+
+set -euo pipefail
+set -x
+
+socat -b 65507 -u "udp-recvfrom:$1,fork" udp-sendto:127.255.255.255:9999,broadcast &
+
+shift
+
+for endpoint in "$@"; do
+	while ! nslookup "${endpoint/:[0-9]*/}" &> /dev/null; do
+		echo "${endpoint/:[0-9]*/} doesn't resolve. retrying in 2 seconds.."
+		sleep 2
+	done
+	socat -b 65507 -u udp-recvfrom:9999,reuseaddr,fork udp-sendto:$endpoint &
+done
+
+if [[ ${DEBUG:-} = true ]]; then
+	socat -b 65507 -u udp-recvfrom:9999,reuseaddr,fork - &
+fi
+
+wait -n


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

It looks as though b6fe1631ef2c663bb67148d3162ba57f426401ed removed some services which are still used by the Lagoon logging infrastructure.

This PR just runs:
```
git checkout b6fe1631ef2c663bb67148d3162ba57f426401ed~ services/logs-{dispatcher,concentrator,tee}
```

# Closing issues

n/a
