### PR TITLE
Remove failing postgres-drupal tests from Openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,6 @@ $(push-local-registry-images):
 all-openshift-tests-list:=	features-openshift \
 														node \
 														drupal \
-														drupal-postgres \
 														github \
 														gitlab \
 														bitbucket \


### PR DESCRIPTION
The drupal-postgres tests are now built for the presence of the dbaas - however this isn't present on Minishift, and there is no logic in oc-build-deploy-dind to handle the multiple service names (postgres, postgres-single, postgres-dbaas).  As it's unlikely we'll add the dbaas into existing Lagoon 1.x clusters, I have removed these tests to avoid unnecessary failures.