### PR TITLE
Set default strategy to RollingUpdate for Redis in Kubernetes

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/redis/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
   selector:
     matchLabels:
       {{- include "redis.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR changes the default deployment strategy for `Redis` in kubernetes.
From `Recreate` to `RollingUpdate`.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2371 
