### PR TITLE
Use the lastTransitionTime for failed kubernetes build jobs

### DIFF
--- a/services/kubernetesbuilddeploymonitor/src/index.ts
+++ b/services/kubernetesbuilddeploymonitor/src/index.ts
@@ -181,17 +181,18 @@ ${podLog}`;
       }
     })(jobInfo.status.active ? 'active' : jobInfo.status.conditions[0].type.toLowerCase());
 
+    let completedTime = jobInfo.status.completionTime
     if (status == 'failed') {
       // failed jobs in kubernetes don't have a completionTime in them
       // the status conditions will have a lastTransitionTime in them that will contain the state the job went into
       // since jobs only have 1 attempt, there shouldn't be any other conditions
-      jobInfo.status.completionTime = jobInfo.status.conditions[0].lastTransitionTime
+      completedTime = jobInfo.status.conditions[0].lastTransitionTime
     }
 
     await updateDeployment(deployment.deploymentByRemoteId.id, {
       status: status.toUpperCase(),
       started: dateOrNull(jobInfo.status.startTime),
-      completed: dateOrNull(jobInfo.status.completionTime),
+      completed: dateOrNull(completedTime),
     });
   } catch (error) {
     logger.error(`Could not update deployment ${projectName} ${jobName}. Message: ${error}`);

--- a/services/kubernetesbuilddeploymonitor/src/index.ts
+++ b/services/kubernetesbuilddeploymonitor/src/index.ts
@@ -181,6 +181,13 @@ ${podLog}`;
       }
     })(jobInfo.status.active ? 'active' : jobInfo.status.conditions[0].type.toLowerCase());
 
+    if (status == 'failed') {
+      // failed jobs in kubernetes don't have a completionTime in them
+      // the status conditions will have a lastTransitionTime in them that will contain the state the job went into
+      // since jobs only have 1 attempt, there shouldn't be any other conditions
+      jobInfo.status.completionTime = jobInfo.status.conditions[0].lastTransitionTime
+    }
+
     await updateDeployment(deployment.deploymentByRemoteId.id, {
       status: status.toUpperCase(),
       started: dateOrNull(jobInfo.status.startTime),


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues
closes #2046 