### PR TITLE
fix persistentStorage.name in prebackuppods

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/prebackuppod.yaml
@@ -39,10 +39,10 @@ spec:
           imagePullPolicy: Always
           name: {{ include "redis-persistent.fullname" . }}-prebackuppod
           volumeMounts:
-            - name: {{ .Values.persistentStorage.name }}
+            - name: {{ include "redis-persistent.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}
       volumes:
-        - name: {{ .Values.persistentStorage.name }}
+        - name: {{ include "redis-persistent.persistentStorageName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentStorage.name }}
+            claimName: {{ include "redis-persistent.persistentStorageName" . }}
 {{ end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/prebackuppod.yaml
@@ -39,10 +39,10 @@ spec:
           imagePullPolicy: Always
           name: {{ include "solr.fullname" . }}-prebackuppod
           volumeMounts:
-            - name: {{ .Values.persistentStorage.name }}
+            - name: {{ include "solr.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}
       volumes:
-        - name: {{ .Values.persistentStorage.name }}
+        - name: {{ include "solr.persistentStorageName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentStorage.name }}
+            claimName: {{ include "solr.persistentStorageName" . }}
 {{ end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/prebackuppod.yaml
@@ -39,10 +39,10 @@ spec:
           imagePullPolicy: Always
           name: {{ include "varnish-persistent.fullname" . }}-prebackuppod
           volumeMounts:
-            - name: {{ .Values.persistentStorage.name }}
+            - name: {{ include "varnish-persistent.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}
       volumes:
-        - name: {{ .Values.persistentStorage.name }}
+        - name: {{ include "varnish-persistent.persistentStorageName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentStorage.name }}
+            claimName: {{ include "varnish-persistent.persistentStorageName" . }}
 {{ end }}


### PR DESCRIPTION
basically kubernetes 1.18 does not allow "null" as a name anymore in yamls, while k8s 1.17 does.
So deploying any application on 1.18 fails with:

```
* spec.pod.spec.containers.volumeMounts.name: Invalid value: "null": spec.pod.spec.containers.volumeMounts.name in body must be of type string: "null"
* spec.pod.spec.volumes.name: Invalid value: "null": spec.pod.spec.volumes.name in body must be of type string: "null"
* spec.pod.spec.volumes.persistentVolumeClaim.claimName: Invalid value: "null": spec.pod.spec.volumes.persistentVolumeClaim.claimName in body must be of type string: "null"
```
this fixes this.