### PR TITLE
Set an error so active-standby task retries

### DIFF
--- a/taskimages/activestandby/main.go
+++ b/taskimages/activestandby/main.go
@@ -211,6 +211,7 @@ Provide a copy of this entire log to the team.`, err)
 		}
 		// sleep for 5 seconds up to a maximum of 60 times (5 minutes) before finally giving up
 		time.Sleep(5 * time.Second)
+		err = fmt.Errorf("checking again")
 		return attempt < 60, err
 	})
 	if err != nil {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Minor fix to the active/standby task image so that it actually tries to get the resource until it has a status condition.

Will need to update the tests to also ensure that after we run the active/standby, in addition to checking the routes actually moved, we need to check that the API actually updates with the production/standbyProduction environments changing.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
