### PR TITLE
readd logs-concentrator, dispatcher, tee images to makefile and build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ services :=	api \
 			drush-alias \
 			keycloak \
 			keycloak-db \
+			logs-concentrator \
+			logs-dispatcher \
+			logs-tee \
 			logs2email \
 			logs2microsoftteams \
 			logs2rocketchat \
@@ -235,6 +238,9 @@ build/broker: build/rabbitmq-cluster build/broker-single
 build/drush-alias: services/drush-alias/Dockerfile
 build/keycloak-db: services/keycloak-db/Dockerfile
 build/keycloak: services/keycloak/Dockerfile
+build/logs-concentrator: services/logs-concentrator/Dockerfile
+build/logs-dispatcher: services/logs-dispatcher/Dockerfile
+build/logs-tee: services/logs-tee/Dockerfile
 build/storage-calculator: build/oc
 build/tests-controller-kubernetes: build/tests
 build/tests-kubernetes: build/tests

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ services :=	api \
 			keycloak \
 			keycloak-db \
 			logs-concentrator \
+			logs-db-curator \
 			logs-dispatcher \
 			logs-tee \
 			logs2email \
@@ -239,6 +240,7 @@ build/drush-alias: services/drush-alias/Dockerfile
 build/keycloak-db: services/keycloak-db/Dockerfile
 build/keycloak: services/keycloak/Dockerfile
 build/logs-concentrator: services/logs-concentrator/Dockerfile
+build/logs-db-curator: build/curator
 build/logs-dispatcher: services/logs-dispatcher/Dockerfile
 build/logs-tee: services/logs-tee/Dockerfile
 build/storage-calculator: build/oc


### PR DESCRIPTION
In https://github.com/amazeeio/lagoon/pull/2369 we re-added the service images for
* logs-concentrator
* logs-dispatcher
* logs-tee
But they were never re-added to the makefile, so the images don't build - and they aren't used locally, so weren't picked up in testing.

I've readded them here, pending a decision about lagoon-helper images - ones that are not dependent on lagoon releases - so should live outside of the main repo.