### PR TITLE
Fix storage-calculator so it can be used for kubernetes and openshift projects

### DIFF
--- a/services/storage-calculator/Dockerfile
+++ b/services/storage-calculator/Dockerfile
@@ -4,6 +4,7 @@ FROM ${IMAGE_REPO:-lagoon}/oc
 ENV LAGOON=storage-calculator
 
 RUN apk add --no-cache tini jq bash curl py3-jwt
+RUN pip install yq
 
 COPY create_jwt.py calculate-storage.sh /
 

--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -45,7 +45,7 @@ do
   if [[ $PROJECT_NAME =~ $PROJECT_REGEX ]]; then
     STORAGE_CALC=$(echo "$project" | jq -r '.storageCalc')
     echo "$OPENSHIFT_URL: Handling project $PROJECT_NAME"
-    OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token')
+    OPENSHIFT_TOKEN=$(echo "$project" | jq -r '.openshift.token // empty')
     # loop through each environment of the current project
     echo "$project" | jq -c '.environments[]' | while read environment
     do


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The `storage-calculator` service relied on openshift specific resources so it wouldn't work for kubernetes based projects. This PR changes to use `Deployment` resources instead of `DeploymentConfig`.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
