### PR TITLE
Small rejig of the test setup, streamline, local-dev, tidyup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ K3D_NAME := k3s-$(shell echo $(CI_BUILD_TAG) | sed -E 's/.*(.{31})$$/\1/')
 
 # Name of the Branch we are currently in
 BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
+SAFE_BRANCH_NAME := $(shell echo $(BRANCH_NAME) | sed -E 's:/:_:g')
 DEFAULT_ALPINE_VERSION := 3.11
 
 #######
@@ -1020,10 +1021,10 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 		&& export IMAGE_REGISTRY="registry.$$(../local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& $(MAKE) install-registry HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 		&& cd .. && $(MAKE) kind/push-images && cd "$$CHARTSDIR" \
-		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
+		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(SAFE_BRANCH_NAME) \
 			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 			JQ=$$(realpath ../local-dev/jq) \
-			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(BRANCH_NAME) \
+			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
@@ -1039,8 +1040,8 @@ kind/push-images:
 		export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& docker login -u admin -p Harbor12345 $$IMAGE_REGISTRY \
 		&& for image in $(KIND_SERVICES); do \
-			docker tag $(CI_BUILD_TAG)/$$image $$IMAGE_REGISTRY/$$image:$(BRANCH_NAME) \
-			&& docker push $$IMAGE_REGISTRY/$$image:$(BRANCH_NAME); \
+			docker tag $(CI_BUILD_TAG)/$$image $$IMAGE_REGISTRY/$$image:$(SAFE_BRANCH_NAME) \
+			&& docker push $$IMAGE_REGISTRY/$$image:$(SAFE_BRANCH_NAME); \
 		done
 
 ## Use kind/retest to only perform a push of the local-dev, or test images, and run the tests
@@ -1051,11 +1052,11 @@ kind/retest:
 		export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& docker login -u admin -p Harbor12345 $$IMAGE_REGISTRY \
 		&& for image in $(KIND_TESTS); do \
-			docker tag $(CI_BUILD_TAG)/$$image $$IMAGE_REGISTRY/$$image:$(BRANCH_NAME) \
-			&& docker push $$IMAGE_REGISTRY/$$image:$(BRANCH_NAME); \
+			docker tag $(CI_BUILD_TAG)/$$image $$IMAGE_REGISTRY/$$image:$(SAFE_BRANCH_NAME) \
+			&& docker push $$IMAGE_REGISTRY/$$image:$(SAFE_BRANCH_NAME); \
 		done \
 		&& cd lagoon-charts.kind.lagoon \
-		&& $(MAKE) install-tests TESTS=$(TESTS) IMAGE_TAG=$(BRANCH_NAME) \
+		&& $(MAKE) install-tests TESTS=$(TESTS) IMAGE_TAG=$(SAFE_BRANCH_NAME) \
 			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 			JQ=$$(realpath ../local-dev/jq) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \

--- a/Makefile
+++ b/Makefile
@@ -926,7 +926,7 @@ api-development: build/api build/api-db build/local-api-data-watcher-pusher buil
 KIND_VERSION = v0.9.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
-TESTS = [api,features-kubernetes,nginx,drupal-php72,drupal-php73,drupal-php74,drupal-postgres,python]
+TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python]
 CHARTS_TREEISH = main
 
 local-dev/kind:

--- a/tests/checks/check-api-request.yaml
+++ b/tests/checks/check-api-request.yaml
@@ -6,6 +6,6 @@
     headers:
       Authorization: "Bearer {{bearer_token}}"
   register: result
-  until: result.content | match(expected_content)
+  until: result.content is match(expected_content)
   retries: 1
   delay: 0

--- a/tests/checks/check-url-content-absent.yaml
+++ b/tests/checks/check-url-content-absent.yaml
@@ -5,6 +5,6 @@
     return_content: yes
     validate_certs: no
   register: result
-  failed_when: result.content | search(expected_content)
+  failed_when: result.content is search(expected_content)
 - name: "{{ testname }} - Check if URL {{url}} doesn't contain content {{expected_content}}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-content-basic-auth-host.yaml
+++ b/tests/checks/check-url-content-basic-auth-host.yaml
@@ -8,7 +8,7 @@
     HEADER_Host: "{{ host }}"
     validate_certs: no
   register: result
-  until: result.content | search(expected_content)
+  until: result.content is search(expected_content)
   retries: 90
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} with sending Host: {{ host }} contains content {{expected_content}}"

--- a/tests/checks/check-url-content-basic-auth.yaml
+++ b/tests/checks/check-url-content-basic-auth.yaml
@@ -7,7 +7,7 @@
     password: "{{ password }}"
     validate_certs: no
   register: result
-  until: result.content | search(expected_content)
+  until: result.content is search(expected_content)
   retries: 90
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} contains content {{expected_content}}"

--- a/tests/checks/check-url-content-host.yaml
+++ b/tests/checks/check-url-content-host.yaml
@@ -6,7 +6,7 @@
     HEADER_Host: "{{ host }}"
     validate_certs: no
   register: result
-  until: result.content | search(expected_content)
+  until: result.content is search(expected_content)
   retries: 90
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} with sending Host: {{ host }} contains content {{expected_content}}"

--- a/tests/checks/check-url-content.yaml
+++ b/tests/checks/check-url-content.yaml
@@ -5,7 +5,7 @@
     return_content: yes
     validate_certs: no
   register: result
-  until: result.content | search(expected_content)
+  until: result.content is search(expected_content)
   retries: 90
   delay: 10
 - name: "{{ testname }} - Check if URL {{url}} contains content {{expected_content}}"

--- a/tests/tasks/api/refresh_token.py
+++ b/tests/tasks/api/refresh_token.py
@@ -20,7 +20,7 @@ access_token = jwt.decode(grant['access_token'], verify=False)
 current_time = int(time.time())
 
 if current_time < access_token['exp']:
-  print grant_raw
+  print(grant_raw)
 else:
   data = {'client_id': 'auth-server',
           'client_secret': auth_server_client_secret,
@@ -28,5 +28,5 @@ else:
           'refresh_token': grant['refresh_token']}
 
   r = requests.post(url = os.environ['KEYCLOAK_URL'] + "/auth/realms/lagoon/protocol/openid-connect/token", data = data)
-  print r.text
+  print(r.text)
 

--- a/tests/tasks/ssh/ssh-command.yaml
+++ b/tests/tasks/ssh/ssh-command.yaml
@@ -1,6 +1,6 @@
 - name: "{{ testname }} - running {{command}} on {{username}}@{{ lookup('env','SSH_HOST') }} on port {{ lookup('env','SSH_PORT') }}, searching for '{{ expected_content }}'"
   shell: ssh {{username}}@{{ lookup('env','SSH_HOST') }} -p {{ lookup('env','SSH_PORT') }} {{command}}
   register: result
-  until: result.stdout | search(expected_content)
+  until: result.stdout is search(expected_content)
   retries: 30
   delay: 10

--- a/tests/tests/drupal-php72.yaml
+++ b/tests/tests/drupal-php72.yaml
@@ -16,7 +16,7 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.2 - MARIADB DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.2 - MARIADB DBAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
     db: mariadb
     php_version: 7.2

--- a/tests/tests/drupal-php73.yaml
+++ b/tests/tests/drupal-php73.yaml
@@ -6,13 +6,13 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.3 - MARIADB DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.3 - MARIADB SINGLE {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
-    db: mariadb
+    db: mariadb-single
     php_version: 7.3
     git_repo_name: drupal.git
     project: ci-drupal-{{ lookup('env','CLUSTER_TYPE') }}
-    branch: drupal8-composer-73-mariadb-dbaas
+    branch: drupal8-composer-73-mariadb-single
 
 - include: drupal/drush.yaml
   vars:

--- a/tests/tests/drupal-php74.yaml
+++ b/tests/tests/drupal-php74.yaml
@@ -6,7 +6,7 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.4 - MARIADB DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.4 - MARIADB DBAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
     db: mariadb
     php_version: 7.4
@@ -16,7 +16,7 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 9 composer PHP 7.4 - MARIADB DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 9 composer PHP 7.4 - MARIADB DBAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 9
     db: mariadb
     php_version: 7.4

--- a/tests/tests/drupal-postgres.yaml
+++ b/tests/tests/drupal-postgres.yaml
@@ -6,20 +6,20 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.2 - POSTGRES SINGLE {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.4 - POSTGRES SINGLE {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
     db: postgres-single
-    php_version: 7.2
+    php_version: 7.4
     git_repo_name: drupal-postgres.git
     project: ci-drupal-postgres-{{ lookup('env','CLUSTER_TYPE') }}
-    branch: d8-php72-psql-single
+    branch: d8-php74-psql-single
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.2 - POSTGRES DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.4 - POSTGRES DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
     db: postgres
-    php_version: 7.2
+    php_version: 7.4
     git_repo_name: drupal-postgres.git
     project: ci-drupal-postgres-{{ lookup('env','CLUSTER_TYPE') }}
-    branch: d8-php72-psql-dbaas
+    branch: d8-php74-psql-dbaas

--- a/tests/tests/drupal-postgres.yaml
+++ b/tests/tests/drupal-postgres.yaml
@@ -16,7 +16,7 @@
 
 - include: drupal/drupal.yaml
   vars:
-    testname: "Drupal 8 composer PHP 7.4 - POSTGRES DBAAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
+    testname: "Drupal 8 composer PHP 7.4 - POSTGRES DBAAS {{ lookup('env','CLUSTER_TYPE')|upper }}"
     drupal_version: 8
     db: postgres
     php_version: 7.4


### PR DESCRIPTION
This PR:
- removes the PHP7.2 Drupal tests
- updates the Postgres Drupal tests to PHP 7.4
- adds in a PHP7.3 MariaDB Single test
- adds a kind/retest routine into the makefile to facilitate easy retesting locally (no need to push all images, only local-dev and test ones)
- sets a SAFE_BRANCH_NAME for image tagging when building `testing/*` branch names
- Replaces a couple of soon-to-be-deprecated Ansible filters in the playbooks
- Updates the refresh-token script for Python 3 print syntax