### PR TITLE
allow kibana URL to be injected via env variable - Part 2

### DIFF
--- a/services/api/src/clients/kibanaClient.js
+++ b/services/api/src/clients/kibanaClient.js
@@ -1,15 +1,16 @@
 const got = require('got');
+const r = require('ramda')
 
 const { LOGSDB_ADMIN_PASSWORD } = process.env;
 
-const KIBANA_URL = propOr(
-  'http://logs-db-ui:5601/api/',
+const KIBANA_URL = r.propOr(
+  'http://logs-db-ui:5601',
   'KIBANA_URL',
   process.env
 );
 
 const kibanaClient = got.extend({
-  baseUrl: KIBANA_URL,
+  baseUrl: `${KIBANA_URL}/api/`,
   auth: `admin:${LOGSDB_ADMIN_PASSWORD || '<password not set>'}`,
   json: true,
   headers: {


### PR DESCRIPTION
also allows to inject a regex to match groups that should be resynced via `sync:opendistro-security`

use like:

```
GROUP_REGEX='^myproject$' yarn sync:opendistro-security 
```