### PR TITLE
fix dist directory created by root:

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -275,6 +275,7 @@ services:
     volumes:
       - ./services/api/src:/app/services/api/src
       - ./node-packages:/app/node-packages:delegated
+      - /app/node-packages/commons/dist
     environment:
       - CI=${CI:-true}
       - REGISTRY=172.17.0.1:8084 # Docker network bridge and forwarded port for harbor-nginx

--- a/node-packages/commons/.gitignore
+++ b/node-packages/commons/.gitignore
@@ -1,2 +1,3 @@
 node_modules
-dist
+dist/*
+!dist/.gitkeep

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -13,7 +13,7 @@
     "test:watch": "jest --forceExit --detectOpenHandles --maxWorkers=10 --watch",
     "build": "tsc --build",
     "start": "node -r dotenv-extended/config dist/index",
-    "dev": "mkdir -p ../../node-packages/commons/dist && NODE_ENV=development nodemon",
+    "dev": "NODE_ENV=development nodemon",
     "sync:gitlab:users": "node dist/gitlab-sync/users",
     "sync:gitlab:groups": "node dist/gitlab-sync/groups",
     "sync:gitlab:projects": "node dist/gitlab-sync/projects",


### PR DESCRIPTION
- with creating a volume inside the container the files are never mounted into the host
- .gitkeep makes sure the folder already exists


