### PR TITLE
Normalize URI check retries in CI

### DIFF
--- a/tests/checks/check-json-content.yaml
+++ b/tests/checks/check-json-content.yaml
@@ -6,7 +6,7 @@
    body_format: json
   register: response
   until:  response.json is defined and response.json.number_of_nodes is defined and response.json.number_of_nodes == node_count
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} contains json {{ expected_key }}:{{ expected_value }}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-content-basic-auth-host.yaml
+++ b/tests/checks/check-url-content-basic-auth-host.yaml
@@ -10,6 +10,6 @@
   register: result
   until: result.content is search(expected_content)
   retries: 90
-  delay: 10
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} with sending Host: {{ host }} contains content {{ expected_content }}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-content-basic-auth.yaml
+++ b/tests/checks/check-url-content-basic-auth.yaml
@@ -9,6 +9,6 @@
   register: result
   until: result.content is search(expected_content)
   retries: 90
-  delay: 10
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} contains content {{ expected_content }}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-content-host.yaml
+++ b/tests/checks/check-url-content-host.yaml
@@ -8,6 +8,6 @@
   register: result
   until: result.content is search(expected_content)
   retries: 90
-  delay: 10
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} with sending Host: {{ host }} contains content {{ expected_content }}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-content.yaml
+++ b/tests/checks/check-url-content.yaml
@@ -7,6 +7,6 @@
   register: result
   until: result.content is search(expected_content)
   retries: 90
-  delay: 10
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} contains content {{ expected_content }}"
   debug: msg="Success!!!"

--- a/tests/checks/check-url-header.yaml
+++ b/tests/checks/check-url-header.yaml
@@ -10,8 +10,8 @@
   register: result
   until: result[expected_header] is defined
   failed_when: result[expected_header] != expected_header_value
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 
 - name: >-
     {{ testname }} - Check if URL {{ url }} returns with Header set to

--- a/tests/checks/check-url-redirect-host.yaml
+++ b/tests/checks/check-url-redirect-host.yaml
@@ -8,8 +8,8 @@
     validate_certs: no
   register: result
   until: result.location | default('') | regex_search(expected_redirect_location)
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} with sending Host: {{ host }} redirects to the location {{ expected_redirect_location }}"
   debug: msg="Success!!!"
 

--- a/tests/checks/check-url-redirect.yaml
+++ b/tests/checks/check-url-redirect.yaml
@@ -7,8 +7,8 @@
     validate_certs: no
   register: result
   until: result.location | default('') | regex_search(expected_redirect_location)
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} redirects to the location {{ expected_redirect_location }}"
   debug: msg="Success!!!"
 

--- a/tests/checks/check-url-returncode-host.yaml
+++ b/tests/checks/check-url-returncode-host.yaml
@@ -7,8 +7,8 @@
     validate_certs: no
   register: result
   until: result.status is defined and result.status == expected_returncode|int
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} with sending Host: {{ host }} returns with return code {{ expected_returncode }}"
   debug: msg="Success!!!"
 

--- a/tests/checks/check-url-returncode.yaml
+++ b/tests/checks/check-url-returncode.yaml
@@ -6,8 +6,7 @@
     validate_certs: no
   register: result
   until: result.status is defined and result.status == expected_returncode|int
-  retries: 30
-  delay: 10
+  retries: 90
+  delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} returns with return code {{ expected_returncode }}"
   debug: msg="Success!!!"
-

--- a/tests/checks/check-url-ts.yaml
+++ b/tests/checks/check-url-ts.yaml
@@ -7,7 +7,7 @@
   register: result
   until: ( lookup('pipe','date +%s')|int - result.content|int ) >= 90
   retries: 90
-  delay: 10
+  delay: 20
   failed_when: false
 - name: "{{ testname }} - Check if URL {{ url }} returns a timestamp that is more than 90 seconds less than the current time."
   debug: msg="Success!!!"


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Builds can occasionally take a long time in CI. This bumps the standard timeout to 30m, though most builds take far less time than that.

# Closing issues

n/a
