### PR TITLE
replace all underscores with dashes, not just the first one

### DIFF
--- a/services/api/src/models/environment.ts
+++ b/services/api/src/models/environment.ts
@@ -524,7 +524,7 @@ export const EnvironmentModel = (clients) => {
     interestedDateEnd.setUTCMilliseconds(999);
     const interestedDateEndString = interestedDateEnd.toISOString();
 
-    const {newResult, legacyResult} = await fetchElasticSearchHitsData(project.replace('_', '-'), openshiftProjectName, interestedYearMonth, interestedDateBeginString, interestedDateEndString)
+    const {newResult, legacyResult} = await fetchElasticSearchHitsData(project.replaceAll('_', '-'), openshiftProjectName, interestedYearMonth, interestedDateBeginString, interestedDateEndString)
 
     if ( newResult === null || legacyResult === null ){
       return { total: 0 }


### PR DESCRIPTION
fixes an issue where `replace()` only replaces the first occurrence of an underline to dashes, but we have projects that have multiple underlines.