### PR TITLE
Allow historical storage data to be recorded - For use during migrations

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
@@ -212,7 +212,8 @@ CREATE OR REPLACE PROCEDURE
   (
     IN environment              int,
     IN persistent_storage_claim varchar(100),
-    IN bytes_used               bigint
+    IN bytes_used               bigint,
+    IN updated                  date
   )
   BEGIN
     INSERT INTO environment_storage (
@@ -224,7 +225,7 @@ CREATE OR REPLACE PROCEDURE
         environment,
         persistent_storage_claim,
         bytes_used,
-        DATE(NOW())
+        updated
     )
     ON DUPLICATE KEY UPDATE
         bytes_used=bytes_used;
@@ -234,7 +235,7 @@ CREATE OR REPLACE PROCEDURE
     FROM environment_storage es
     WHERE es.environment = environment AND
           es.persistent_storage_claim = persistent_storage_claim AND
-          es.updated = DATE(NOW());
+          es.updated = updated;
   END;
 $$
 

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -3,6 +3,7 @@ import { sendToLagoonLogs } from '@lagoon/commons/dist/logs';
 import { createRemoveTask } from '@lagoon/commons/dist/tasks';
 import { ResolverFn } from '../';
 import { isPatchEmpty, prepare, query, whereAnd } from '../../util/db';
+import convertDateToMYSQLDateTimeFormat from '../../util/convertDateToMYSQLDateTimeFormat'
 import { Helpers } from './helpers';
 import { Sql } from './sql';
 import { Sql as projectSql } from '../project/sql';
@@ -344,10 +345,15 @@ export const addOrUpdateEnvironment: ResolverFn = async (
 
 export const addOrUpdateEnvironmentStorage: ResolverFn = async (
   root,
-  { input },
+  { input: unformattedInput },
   { sqlClient, hasPermission },
 ) => {
   await hasPermission('environment', 'storage');
+
+  const input = {
+    ...unformattedInput,
+    updated: unformattedInput.updated ? unformattedInput.updated: convertDateToMYSQLDateTimeFormat(new Date().toISOString())
+  };
 
   const prep = prepare(
     sqlClient,
@@ -355,7 +361,8 @@ export const addOrUpdateEnvironmentStorage: ResolverFn = async (
       CALL CreateOrUpdateEnvironmentStorage(
         :environment,
         :persistent_storage_claim,
-        :bytes_used
+        :bytes_used,
+        :updated
       );
     `,
   );

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -905,6 +905,7 @@ const typeDefs = gql`
     environment: Int!
     persistentStorageClaim: String!
     bytesUsed: Int!
+    updated: String
   }
 
   input AddBackupInput {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -905,6 +905,9 @@ const typeDefs = gql`
     environment: Int!
     persistentStorageClaim: String!
     bytesUsed: Int!
+    """
+    Date in format 'YYYY-MM-DD'
+    """
     updated: String
   }
 


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
-->

This PR adds the ability to allow for historical storage data to be recorded. This is useful during migrations. Adds an additional `updated` field on the mutation. 

```
mutation {
  addOrUpdateEnvironmentStorage(input:{
    environment:20013, 
    persistentStorageClaim:"BananaSmoothiesRule", 
    bytesUsed:1234,
    updated:"2020-12-10"
  }){
    id
    environment{
      name
    }
    persistentStorageClaim
    bytesUsed
    updated
  }
  ```



# Closing issues

Put `closes #2451`