### PR TITLE
Add sumologic_output plugin to logs-dispatcher

### DIFF
--- a/services/logs-dispatcher/Dockerfile
+++ b/services/logs-dispatcher/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache --update --virtual .build-deps \
       && gem install fluent-plugin-rewrite-tag-filter \
       && gem install fluent-plugin-route \
       && gem install fluent-plugin-s3 --no-document \
+      && gem install fluent-plugin-sumologic_output \
       && gem sources --clear-all \
       && apk del .build-deps \
       && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR makes it possible to export cluster logs to sumologic.

# Closing issues

Closes #2210 for Lagoon 1.0.