### PR TITLE
Openshift monitoringConfig error handling

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -317,7 +317,7 @@ const getControllerBuildData = async function(deployData: any) {
   var alertContactHA = ""
   var alertContactSA = ""
   var uptimeRobotStatusPageIds = []
-  var monitoringConfig = ""
+  var monitoringConfig: any = {};
   try {
     monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
   } catch (e) {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -317,7 +317,13 @@ const getControllerBuildData = async function(deployData: any) {
   var alertContactHA = ""
   var alertContactSA = ""
   var uptimeRobotStatusPageIds = []
-  var monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
+  var monitoringConfig = ""
+  try {
+    monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+  } catch (e) {
+    logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
+    monitoringConfig = "invalid"
+  }
   if (monitoringConfig != "invalid"){
     alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
     alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -324,7 +324,7 @@ const getControllerBuildData = async function(deployData: any) {
     logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
     monitoringConfig = "invalid"
   }
-  if (monitoringConfig != "invalid"){
+  if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
     alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
     alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
     if (monitoringConfig.uptimerobot.statusPageId) {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -319,12 +319,12 @@ const getControllerBuildData = async function(deployData: any) {
   var uptimeRobotStatusPageIds = []
   var monitoringConfig: any = {};
   try {
-    monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+    monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
   } catch (e) {
     logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
     monitoringConfig = "invalid"
   }
-  if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
+  if (monitoringConfig != "invalid"){
     alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
     alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
     if (monitoringConfig.uptimerobot.statusPageId) {

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -581,9 +581,10 @@ export const deployEnvironmentBranch: ResolverFn = async (
           meta,
           `*[${deployData.projectName}]* Error deploying \`${
             deployData.branchName
-          }\`: ${error.message}`,
+          }\`: ${error}`,
         );
-        return `Error: ${error.message}`;
+        console.log(error);
+        return `Error: ${error}`;
     }
   }
 };

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -92,12 +92,12 @@ const messageConsumer = async msg => {
     var uptimeRobotStatusPageIds = []
     var monitoringConfig: any = {};
     try {
-      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
     } catch (e) {
       logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
       monitoringConfig = "invalid"
     }
-    if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
+    if (monitoringConfig != "invalid"){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
       if (monitoringConfig.uptimerobot.statusPageId) {

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -90,7 +90,13 @@ const messageConsumer = async msg => {
     var alertContactHA = ""
     var alertContactSA = ""
     var uptimeRobotStatusPageIds = []
-    var monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
+    var monitoringConfig = ""
+    try {
+      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+    } catch (e) {
+      logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
+      monitoringConfig = "invalid"
+    }
     if (monitoringConfig != "invalid"){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -97,7 +97,7 @@ const messageConsumer = async msg => {
       logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
       monitoringConfig = "invalid"
     }
-    if (monitoringConfig != "invalid"){
+    if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
       if (monitoringConfig.uptimerobot.statusPageId) {

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -90,7 +90,7 @@ const messageConsumer = async msg => {
     var alertContactHA = ""
     var alertContactSA = ""
     var uptimeRobotStatusPageIds = []
-    var monitoringConfig = ""
+    var monitoringConfig: any = {};
     try {
       monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
     } catch (e) {

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -94,12 +94,12 @@ const messageConsumer = async msg => {
     var uptimeRobotStatusPageIds = []
     var monitoringConfig: any = {};
     try {
-      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
     } catch (e) {
       logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
       monitoringConfig = "invalid"
     }
-    if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
+    if (monitoringConfig != "invalid"){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
       if (monitoringConfig.uptimerobot.statusPageId) {

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -92,7 +92,13 @@ const messageConsumer = async msg => {
     var alertContactHA = ""
     var alertContactSA = ""
     var uptimeRobotStatusPageIds = []
-    var monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig) || "invalid"
+    var monitoringConfig = ""
+    try {
+      monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
+    } catch (e) {
+      logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
+      monitoringConfig = "invalid"
+    }
     if (monitoringConfig != "invalid"){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -92,7 +92,7 @@ const messageConsumer = async msg => {
     var alertContactHA = ""
     var alertContactSA = ""
     var uptimeRobotStatusPageIds = []
-    var monitoringConfig = ""
+    var monitoringConfig: any = {};
     try {
       monitoringConfig = JSON.parse(projectOpenShift.openshift.monitoringConfig)
     } catch (e) {

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -99,7 +99,7 @@ const messageConsumer = async msg => {
       logger.error('Error parsing openshift.monitoringConfig from openshift: %s, continuing with "invalid"', projectOpenShift.openshift.name, { error: e })
       monitoringConfig = "invalid"
     }
-    if (monitoringConfig != "invalid"){
+    if (monitoringConfig != "invalid" && monitoringConfig.uptimerobot){
       alertContactHA = monitoringConfig.uptimerobot.alertContactHA || ""
       alertContactSA = monitoringConfig.uptimerobot.alertContactSA || ""
       if (monitoringConfig.uptimerobot.statusPageId) {


### PR DESCRIPTION
Lagoon tries to parse the json defined in `monitoringConfig` for an `OpenShift` Object, if that is a non-parseable json, lagoon fails to do anything with that cluster.
this code does two things:
1. it logs better errors (we needed this to find it)
2. it uses a `try/catch` to catch the errors and continue.