### PR TITLE
Bump base image of logs-dispatcher

### DIFF
--- a/services/logs-dispatcher/Dockerfile
+++ b/services/logs-dispatcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.11-1
+FROM fluent/fluentd:v1.12-1
 LABEL maintainer="support@amazee.io"
 
 ARG LAGOON_VERSION


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

I just noticed that we are behind the latest stable release of fluentd.

# Closing issues

n/a
