### PR TITLE
K8up schedule hotfix

### DIFF
--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -1245,7 +1245,7 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
   # Run Backups every day at 2200-0200
   BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(22-2) * * *")
 
-  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+  if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
     CHECK_SCHEDULE="@weekly-random"
   else
@@ -1253,7 +1253,7 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
     CHECK_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 0")
   fi
 
-  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+  if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
     PRUNE_SCHEDULE="@weekly-random"
   else

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -1219,7 +1219,6 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
   if [ -z $BAAS_BUCKET_NAME ]; then
     BAAS_BUCKET_NAME=baas-${PROJECT}
   fi
-  TEMPLATE_PARAMETERS+=(-p BAAS_BUCKET_NAME="${BAAS_BUCKET_NAME}")
 
   # Pull in .lagoon.yml variables
   PRODUCTION_MONTHLY_BACKUP_RETENTION=$(cat .lagoon.yml | shyaml get-value backup-retention.production.monthly "")
@@ -1245,13 +1244,22 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
 
   # Run Backups every day at 2200-0200
   BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(22-2) * * *")
-  TEMPLATE_PARAMETERS+=(-p BACKUP_SCHEDULE="${BACKUP_SCHEDULE}")
 
-  # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
-  CHECK_SCHEDULE="@weekly-random"
+  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+    # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
+    CHECK_SCHEDULE="@weekly-random"
+  else
+    # Run Checks on Sunday at 0300-0600
+    CHECK_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 0")
+  fi
 
-  # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
-  PRUNE_SCHEDULE="@weekly-random"
+  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+    # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
+    PRUNE_SCHEDULE="@weekly-random"
+  else
+    # Run Prune on Saturday at 0300-0600
+    PRUNE_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 6")
+  fi
 
   OPENSHIFT_TEMPLATE="/kubectl-build-deploy/openshift-templates/backup-schedule.yml"
   helm template k8up-lagoon-backup-schedule /kubectl-build-deploy/helmcharts/k8up-schedule \

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -867,23 +867,25 @@ if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get schedules.backup.ap
   BACKUP_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "M H(22-2) * * *")
   TEMPLATE_PARAMETERS+=(-p BACKUP_SCHEDULE="${BACKUP_SCHEDULE}")
 
+  # Checks
   if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
     CHECK_SCHEDULE="@weekly-random"
   else
     # Run Checks on Sunday at 0300-0600
-    CHECK_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 0")
-    TEMPLATE_PARAMETERS+=(-p CHECK_SCHEDULE="${CHECK_SCHEDULE}")
+    CHECK_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "M H(3-6) * * 0")
   fi
+  TEMPLATE_PARAMETERS+=(-p CHECK_SCHEDULE="${CHECK_SCHEDULE}")
 
+  # Prunes
   if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
     PRUNE_SCHEDULE="@weekly-random"
   else
     # Run Prune on Saturday at 0300-0600
-    PRUNE_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 6")
-    TEMPLATE_PARAMETERS+=(-p PRUNE_SCHEDULE="${PRUNE_SCHEDULE}")
+    PRUNE_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "M H(3-6) * * 6")
   fi
+  TEMPLATE_PARAMETERS+=(-p PRUNE_SCHEDULE="${PRUNE_SCHEDULE}")
 
   OPENSHIFT_TEMPLATE="/oc-build-deploy/openshift-templates/backup-schedule.yml"
   .  /oc-build-deploy/scripts/exec-openshift-resources.sh

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -867,7 +867,7 @@ if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get schedules.backup.ap
   BACKUP_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "M H(22-2) * * *")
   TEMPLATE_PARAMETERS+=(-p BACKUP_SCHEDULE="${BACKUP_SCHEDULE}")
 
-  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+  if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
     CHECK_SCHEDULE="@weekly-random"
   else
@@ -876,7 +876,7 @@ if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get schedules.backup.ap
     TEMPLATE_PARAMETERS+=(-p CHECK_SCHEDULE="${CHECK_SCHEDULE}")
   fi
 
-  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+  if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
     PRUNE_SCHEDULE="@weekly-random"
   else

--- a/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/oc-build-deploy-dind/build-deploy-docker-compose.sh
@@ -867,13 +867,23 @@ if oc --insecure-skip-tls-verify -n ${OPENSHIFT_PROJECT} get schedules.backup.ap
   BACKUP_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${OPENSHIFT_PROJECT}" "M H(22-2) * * *")
   TEMPLATE_PARAMETERS+=(-p BACKUP_SCHEDULE="${BACKUP_SCHEDULE}")
 
-  # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
-  CHECK_SCHEDULE="@weekly-random"
-  TEMPLATE_PARAMETERS+=(-p CHECK_SCHEDULE="${CHECK_SCHEDULE}")
+  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+    # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
+    CHECK_SCHEDULE="@weekly-random"
+  else
+    # Run Checks on Sunday at 0300-0600
+    CHECK_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 0")
+    TEMPLATE_PARAMETERS+=(-p CHECK_SCHEDULE="${CHECK_SCHEDULE}")
+  fi
 
-  # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
-  PRUNE_SCHEDULE="@weekly-random"
-  TEMPLATE_PARAMETERS+=(-p PRUNE_SCHEDULE="${PRUNE_SCHEDULE}")
+  if [ ! -z $K8UP_FEATURE_FLAG ] && [ $K8UP_FEATURE_FLAG = 'enabled' ]; then
+    # Let the controller deduplicate prunes (will run weekly at a random time throughout the week)
+    PRUNE_SCHEDULE="@weekly-random"
+  else
+    # Run Prune on Saturday at 0300-0600
+    PRUNE_SCHEDULE=$( /oc-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(3-6) * * 6")
+    TEMPLATE_PARAMETERS+=(-p PRUNE_SCHEDULE="${PRUNE_SCHEDULE}")
+  fi
 
   OPENSHIFT_TEMPLATE="/oc-build-deploy/openshift-templates/backup-schedule.yml"
   .  /oc-build-deploy/scripts/exec-openshift-resources.sh

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -24,6 +24,7 @@ const weeklyBackupRetention = process.env.WEEKLY_BACKUP_DEFAULT_RETENTION || "6"
 const dailyBackupRetention = process.env.DAILY_BACKUP_DEFAULT_RETENTION || "7"
 const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
 const jwtSecret = process.env.JWTSECRET || "super-secret-string"
+const k8upFeatureFlag = process.env.K8UP_FEATURE_FLAG || ""
 
 const messageConsumer = async msg => {
   const {
@@ -279,6 +280,10 @@ const messageConsumer = async msg => {
                   {
                     "name": "DAILY_BACKUP_DEFAULT_RETENTION",
                     "value": dailyBackupRetention
+                  },
+                  {
+                    "name": "K8UP_FEATURE_FLAG",
+                    "value": k8upFeatureFlag
                   }
                 ],
                 "volumeMounts": [

--- a/services/kubernetesbuilddeploy/src/index.ts
+++ b/services/kubernetesbuilddeploy/src/index.ts
@@ -24,7 +24,7 @@ const weeklyBackupRetention = process.env.WEEKLY_BACKUP_DEFAULT_RETENTION || "6"
 const dailyBackupRetention = process.env.DAILY_BACKUP_DEFAULT_RETENTION || "7"
 const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
 const jwtSecret = process.env.JWTSECRET || "super-secret-string"
-const k8upFeatureFlag = process.env.K8UP_FEATURE_FLAG || ""
+const k8upWeeklyRandomFeatureFlag = process.env.K8UP_WEEKLY_RANDOM_FEATURE_FLAG || ""
 
 const messageConsumer = async msg => {
   const {
@@ -282,8 +282,8 @@ const messageConsumer = async msg => {
                     "value": dailyBackupRetention
                   },
                   {
-                    "name": "K8UP_FEATURE_FLAG",
-                    "value": k8upFeatureFlag
+                    "name": "K8UP_WEEKLY_RANDOM_FEATURE_FLAG",
+                    "value": k8upWeeklyRandomFeatureFlag
                   }
                 ],
                 "volumeMounts": [

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -23,6 +23,7 @@ const weeklyBackupRetention = process.env.WEEKLY_BACKUP_DEFAULT_RETENTION || "4"
 const dailyBackupRetention = process.env.DAILY_BACKUP_DEFAULT_RETENTION || "7"
 const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
 const jwtSecret = process.env.JWTSECRET || "super-secret-string"
+const k8upFeatureFlag = process.env.K8UP_FEATURE_FLAG || ""
 
 const messageConsumer = async msg => {
   const {
@@ -282,6 +283,10 @@ const messageConsumer = async msg => {
                       {
                         "name": "DAILY_BACKUP_DEFAULT_RETENTION",
                         "value": dailyBackupRetention
+                      },
+                      {
+                        "name": "K8UP_FEATURE_FLAG",
+                        "value": k8upFeatureFlag
                       }
                   ],
                   "forcePull": true,

--- a/services/openshiftbuilddeploy/src/index.ts
+++ b/services/openshiftbuilddeploy/src/index.ts
@@ -23,7 +23,7 @@ const weeklyBackupRetention = process.env.WEEKLY_BACKUP_DEFAULT_RETENTION || "4"
 const dailyBackupRetention = process.env.DAILY_BACKUP_DEFAULT_RETENTION || "7"
 const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
 const jwtSecret = process.env.JWTSECRET || "super-secret-string"
-const k8upFeatureFlag = process.env.K8UP_FEATURE_FLAG || ""
+const k8upWeeklyRandomFeatureFlag = process.env.K8UP_WEEKLY_RANDOM_FEATURE_FLAG || ""
 
 const messageConsumer = async msg => {
   const {
@@ -285,8 +285,8 @@ const messageConsumer = async msg => {
                         "value": dailyBackupRetention
                       },
                       {
-                        "name": "K8UP_FEATURE_FLAG",
-                        "value": k8upFeatureFlag
+                        "name": "K8UP_WEEKLY_RANDOM_FEATURE_FLAG",
+                        "value": k8upWeeklyRandomFeatureFlag
                       }
                   ],
                   "forcePull": true,


### PR DESCRIPTION
 # Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR hotfixes support for a new build-deploy system switch which enables simultaneous support for k8up v0.1.10 and v1.0.0 with a single codebase, via an environment variable.
