### PR TITLE
K8p schedule quote fix

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/templates/schedule.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/templates/schedule.yaml
@@ -19,7 +19,7 @@ spec:
     schedule: '{{ .Values.check.schedule }}'
   prune:
     retention:
-      keepDaily: '{{ .Values.prune.retention.keepDaily }}'
-      keepWeekly: '{{ .Values.prune.retention.keepWeekly }}'
-      keepMonthly: '{{ .Values.prune.retention.keepMonthly }}'
+      keepDaily: {{ .Values.prune.retention.keepDaily }}
+      keepWeekly: {{ .Values.prune.retention.keepWeekly }}
+      keepMonthly: {{ .Values.prune.retention.keepMonthly }}
     schedule: '{{ .Values.prune.schedule }}'

--- a/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
+++ b/images/oc-build-deploy-dind/openshift-templates/backup-schedule.yml
@@ -77,7 +77,7 @@ objects:
       schedule: '${CHECK_SCHEDULE}'
     prune:
       retention:
-        keepDaily: ${DAILY_BACKUP_RETENTION}
-        keepWeekly: ${WEEKLY_BACKUP_RETENTION}
-        keepMonthly: ${MONTHLY_BACKUP_RETENTION}
+        keepDaily: ${{DAILY_BACKUP_RETENTION}}
+        keepWeekly: ${{WEEKLY_BACKUP_RETENTION}}
+        keepMonthly: ${{MONTHLY_BACKUP_RETENTION}}
       schedule: '${PRUNE_SCHEDULE}'


### PR DESCRIPTION
the v1.13.4 release brought a new way to inject the prune specs into the k8up schedule objects, unfortunately this is created with quotes and therefore it's interpreted as strings, while the k8up operator needs integers.
this PR fixes this