### PR TITLE
Run in-pod cronjobs in /app

### DIFF
--- a/tests/files/features/.lagoon.yml
+++ b/tests/files/features/.lagoon.yml
@@ -43,6 +43,10 @@ environments:
       schedule: "* * * * *"
       command: printf '%s_%s' "CRONJOB" "SINGLE" >> /files/cron.txt
       service: node
+    - name: echo /files/cron.txt pwd
+      schedule: "* * * * *"
+      command: printf '%s_%s_%s' "CRONJOB" "PWD" "$(pwd)" >> /files/cron.txt
+      service: node
     - name: test H/1
       schedule: "H/1 * * * *"
       command: printf '%s_%s' "CRONJOB" "H1" >> /files/cron.txt

--- a/tests/tests/features/cronjobs.yaml
+++ b/tests/tests/features/cronjobs.yaml
@@ -17,6 +17,15 @@
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
+- name: "{{ testname }} - check if {{ project }} is deployed with searching for 'CRONJOB_PWD_/app' which is added via a cronjob"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "{{ check_url }}"
+    expected_content: "CRONJOB_PWD_/app"
+  tasks:
+  - include: ../../checks/check-url-content.yaml
+
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for 'CRONJOB_SINGLE' which is added via a cronjob"
   hosts: localhost
   serial: 1


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR adds tests to ensure that cronjobs inside pods use `/app` as the working directory by default.

This PR is a draft because it currently patches the test suite to point to a different lagoon-images tag. Once the related lagoon-images PR is merged I can update this PR.

See https://github.com/uselagoon/lagoon-images/pull/91.

# Closing issues

Closes: #1124 
