### PR TITLE
Set StorageClass properly for node-persistent pvc

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/pvc.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/pvc.yaml
@@ -9,7 +9,8 @@ metadata:
     {{- include "node-persistent.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
+  storageClassName: bulk
   resources:
     requests:
       storage: {{ .Values.persistentStorage.size | quote }}


### PR DESCRIPTION
This correctly allocates the correct storageclass in the correct accessmode for node-persistent deployment pvcs (as per nginx-php-persistent) for k8s deployments