### PR TITLE
Add official fluentd output plugin for Datadog to logs-dispatcher

### DIFF
--- a/services/logs-dispatcher/Dockerfile
+++ b/services/logs-dispatcher/Dockerfile
@@ -9,6 +9,7 @@ USER root
 RUN apk add --no-cache --update --virtual .build-deps \
       build-base ruby-dev \
       && gem install fluent-plugin-cloudwatch-logs \
+      && gem install fluent-plugin-datadog \
       && gem install fluent-plugin-kubernetes_metadata_filter \
       && gem install fluent-plugin-multi-format-parser \
       && gem install fluent-plugin-prometheus \


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR makes it possible to use the officially supported fluentd output plugin to export logs to Datadog.

This is a backport of #2512 to the 1.x branch

# Closing issues

n/a
