### PR TITLE
Implement rootless build pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -948,7 +948,7 @@ KIND_VERSION = v0.10.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
 TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
-CHARTS_TREEISH = main
+CHARTS_TREEISH = rootless
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/Makefile
+++ b/Makefile
@@ -1047,6 +1047,7 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY=smlx/lagoon-builddeploy \
 			OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG=rootless \
+			BUILD_DEPLOY_CONTROLLER_ROOTLESS_BUILD_PODS=true \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 		&& sleep 30 \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -1045,6 +1045,8 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 			JQ=$$(realpath ../local-dev/jq) \
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
+			OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY=smlx/lagoon-builddeploy \
+			OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG=rootless \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 		&& sleep 30 \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \

--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -1,12 +1,10 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/kubectl
 
-# the kubectl image comes with an HOME=/home which is needed to run as unpriviledged, but kubectl-build-deploy-dind will run as root
-RUN rm -rf /root && ln -s /home /root
 ENV LAGOON=kubectl-build-deploy-dind
 
-RUN  mkdir -p /kubectl-build-deploy/git
-RUN  mkdir -p /kubectl-build-deploy/lagoon
+RUN mkdir -p /kubectl-build-deploy/git
+RUN mkdir -p /kubectl-build-deploy/lagoon
 
 WORKDIR /kubectl-build-deploy/git
 
@@ -19,5 +17,8 @@ COPY scripts /kubectl-build-deploy/scripts
 COPY helmcharts  /kubectl-build-deploy/helmcharts
 
 ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
+
+# enable running unprivileged
+RUN fix-permissions /home && fix-permissions /kubectl-build-deploy
 
 CMD ["/kubectl-build-deploy/build-deploy.sh"]


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR is complementary to uselagoon/lagoon#2481. It allows the build pods used during deployment to run as non-root.
It is a draft because:
* [ ] it depends on a new release of lagoon-build-deploy controller containing this PR: https://github.com/amazeeio/lagoon-kbd/pull/38
* [ ] it depends on this PR in lagoon-charts: https://github.com/uselagoon/lagoon-charts/pull/226, which also depends on a new release of lagoon-build-deploy controller.

Once those are merged I can remove the temporary CI override commits in this PR.

# Closing issues

Related: uselagoon/build-deploy-tool#159.
