### PR TITLE
Fix SSH check for scaling CLI deployments in kubernetes

### DIFF
--- a/services/ssh/home/rsh.sh
+++ b/services/ssh/home/rsh.sh
@@ -122,7 +122,8 @@ fi
 if [[ $($OC get deployment -l "lagoon.sh/service=${SERVICE}" 2> /dev/null) ]]; then
   DEPLOYMENT=$($OC get deployment -l "lagoon.sh/service=${SERVICE}" -o name)
   # If the deployment is scaled to 0, scale to 1
-  if [[ $($OC get ${DEPLOYMENT} -o go-template --template='{{.status.replicas}}') == "0" ]]; then
+  # .status.replicas doesn't exist on a scaled to 0 deployment in k8s so assume it is 0 if nothing is returned
+  if [[ $($OC get ${DEPLOYMENT} -o json | jq -r '.status.replicas // 0') == "0" ]]; then
 
     $OC scale --replicas=1 ${DEPLOYMENT} >/dev/null 2>&1
 
@@ -139,7 +140,8 @@ fi
 if [[ $($OC get deployment -l lagoon/service=${SERVICE} 2> /dev/null) ]]; then
   DEPLOYMENT=$($OC get deployment -l lagoon/service=${SERVICE} -o name)
   # If the deployment is scaled to 0, scale to 1
-  if [[ $($OC get ${DEPLOYMENT} -o go-template --template='{{.status.replicas}}') == "0" ]]; then
+  # .status.replicas doesn't exist on a scaled to 0 deployment in k8s so assume it is 0 if nothing is returned
+  if [[ $($OC get ${DEPLOYMENT} -o json | jq -r '.status.replicas // 0') == "0" ]]; then
 
     $OC scale --replicas=1 ${DEPLOYMENT} >/dev/null 2>&1
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

As part of working on idling in Kubernetes, I uncovered that there is an issue with how we check if a CLI pod is scaled in Kubernetes.

Previously we would use this check, but it appears that Kubernetes doesn't set `.status.replicas` at all when a deployment is scaled to 0
```
if [[ $($OC get ${DEPLOYMENT} -o go-template --template='{{.status.replicas}}') == "0" ]]; then
```
The returned value is actually `<no value>` as it doesn't exist.

This PR changes the check to the following, which assumes a 0 value if `.status.replicas` returns null by jq
```
if [[ $($OC get ${DEPLOYMENT} -o json | jq -r '.status.replicas // 0') == "0" ]]; then
```

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->