### PR TITLE
Unconditionally refresh api token in test suite

### DIFF
--- a/tests/tasks/api/refresh_token.py
+++ b/tests/tasks/api/refresh_token.py
@@ -17,16 +17,10 @@ grant = json.loads(grant_raw)
 
 access_token = jwt.decode(grant['access_token'], verify=False)
 
-current_time = int(time.time())
+data = {'client_id': 'auth-server',
+        'client_secret': auth_server_client_secret,
+        'grant_type': 'refresh_token',
+        'refresh_token': grant['refresh_token']}
 
-if current_time < access_token['exp']:
-  print(grant_raw)
-else:
-  data = {'client_id': 'auth-server',
-          'client_secret': auth_server_client_secret,
-          'grant_type': 'refresh_token',
-          'refresh_token': grant['refresh_token']}
-
-  r = requests.post(url = os.environ['KEYCLOAK_URL'] + "/auth/realms/lagoon/protocol/openid-connect/token", data = data)
-  print(r.text)
-
+r = requests.post(url = os.environ['KEYCLOAK_URL'] + "/auth/realms/lagoon/protocol/openid-connect/token", data = data)
+print(r.text)


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR makes the refresh token logic unconditionally get a new token instead of checking if it has expired. Hopefully this fixes a race condition where the token expires after the check but before use.

# Closing issues

:crossed_fingers: this closes: #2393 
