### PR TITLE
Bump kubectl and helm versions in the Lagoon kubectl base image

### DIFF
--- a/images/kubectl/Dockerfile
+++ b/images/kubectl/Dockerfile
@@ -35,9 +35,9 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 # Defining Versions
-ENV KUBECTL_VERSION=v1.16.2 \
-    HELM_VERSION=v3.0.0-rc.2 \
-    HELM_SHA256=b6fff8e01aa6cd9a4541bd48172bb53b9a0ae38d7e7783a8e0fcc1db63802aaa
+ENV KUBECTL_VERSION=v1.20.4 \
+    HELM_VERSION=v3.5.2 \
+    HELM_SHA256=01b317c506f8b6ad60b11b1dc3f093276bb703281cb1ae01132752253ec706a2
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util \
     && apk add --update openssl curl jq parallel \


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR updates `kubectl` and `helm` in the Lagoon `kubectl` base image to the latest releases.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

Closes: #2533 
