### PR TITLE
Add default kubernetes network policy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1077,6 +1077,8 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_INSTALL_REGISTRY=true \
+			LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY=enabled \
+			USE_CALICO_CNI=true \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
@@ -1198,6 +1200,8 @@ kind/retest:
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_ALL_DEPS=true \
+			LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY=enabled \
+			USE_CALICO_CNI=true \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \

--- a/Makefile
+++ b/Makefile
@@ -961,7 +961,7 @@ STERN_VERSION = 2.1.17
 CHART_TESTING_VERSION = v3.4.0
 KIND_IMAGE = kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 TESTS = [api,features-kubernetes,features-kubernetes-2,features-api-variables,active-standby-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch,tasks]
-CHARTS_TREEISH = logs2s3
+CHARTS_TREEISH = main
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -25,6 +25,52 @@ function contains() {
     [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && return 0 || return 1
 }
 
+# featureFlag searches for feature flag variables in the following locations
+# and order:
+#
+# 1. The cluster-force feature flag, prefixed with LAGOON_FEATURE_FLAG_FORCE_,
+#    in the build environment. This is set via a flag on the build-deploy
+#    controller. This overrides the other variables and allows policy
+#    enforcement at the cluster level.
+#
+# 2. The regular feature flag, prefixed with LAGOON_FEATURE_FLAG_, in the
+#    Lagoon environment env-vars. This allows policy control at the environment
+#    level.
+#
+# 3. The regular feature flag, prefixed with LAGOON_FEATURE_FLAG_, in the
+#    Lagoon project env-vars. This allows policy control at the project level.
+#
+# 4. The cluster-default feature flag, prefixed with
+#    LAGOON_FEATURE_FLAG_DEFAULT_, in the build environment. This is set via a
+#    flag on the build-deploy controller. This allows default policy to be set
+#    at the cluster level, but maintains the ability to selectively override at
+#    the project or environment level.
+#
+# The value of the first variable found is printed to stdout. If the variable
+# is not found, print an empty string. Additional arguments are ignored.
+function featureFlag() {
+	# check for argument
+	[ "$1" ] || return
+
+	local forceFlagVar defaultFlagVar flagVar
+
+	# check build environment for the force policy first
+	forceFlagVar="LAGOON_FEATURE_FLAG_FORCE_$1"
+	[ "${!forceFlagVar}" ] && echo "${!forceFlagVar}" && return
+
+	flagVar="LAGOON_FEATURE_FLAG_$1"
+	# check Lagoon environment variables
+	flagValue=$(jq -r '.[] | select((.scope as $scope | ["build", "global"] | index($scope)) and .name == "'"$flagVar"'") | .value' <<<"$LAGOON_ENVIRONMENT_VARIABLES")
+	[ "$flagValue" ] && echo "$flagValue" && return
+	# check Lagoon project variables
+	flagValue=$(jq -r '.[] | select((.scope as $scope | ["build", "global"] | index($scope)) and .name == "'"$flagVar"'") | .value' <<<"$LAGOON_PROJECT_VARIABLES")
+	[ "$flagValue" ] && echo "$flagValue" && return
+
+	# fall back to the default, if set.
+	defaultFlagVar="LAGOON_FEATURE_FLAG_DEFAULT_$1"
+	echo "${!defaultFlagVar}"
+}
+
 ##############################################
 ### PREPARATION
 ##############################################

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -1469,6 +1469,14 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
     --set customBackupLocation.secretKey="${BAAS_CUSTOM_BACKUP_SECRET_KEY}" "${HELM_ARGUMENTS[@]}" > $YAML_FOLDER/k8up-lagoon-backup-schedule.yaml
 fi
 
+# check for ISOLATION_NETWORK_POLICY feature flag, disabled by default
+if [ "$(featureFlag ISOLATION_NETWORK_POLICY)" = enabled ]; then
+	# add namespace isolation network policy to deployment
+	helm template isolation-network-policy /kubectl-build-deploy/helmcharts/isolation-network-policy \
+		-f /kubectl-build-deploy/values.yaml \
+		> $YAML_FOLDER/isolation-network-policy.yaml
+fi
+
 if [ "$(ls -A $YAML_FOLDER/)" ]; then
   find $YAML_FOLDER -type f -exec cat {} \;
   kubectl apply --insecure-skip-tls-verify -n ${NAMESPACE} -f $YAML_FOLDER/

--- a/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/.helmignore
+++ b/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/Chart.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: isolation-network-policy
+description: A Helm chart for Kubernetes creating a namespace isolation network policy.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/templates/_helpers.tpl
+++ b/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "isolation-network-policy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "isolation-network-policy.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "isolation-network-policy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "isolation-network-policy.labels" -}}
+helm.sh/chart: {{ include "isolation-network-policy.chart" . }}
+{{ include "isolation-network-policy.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "isolation-network-policy.lagoonLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "isolation-network-policy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "isolation-network-policy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Lagoon Labels
+*/}}
+{{- define "isolation-network-policy.lagoonLabels" -}}
+lagoon.sh/service: {{ .Release.Name }}
+lagoon.sh/service-type: {{ .Chart.Name }}
+lagoon.sh/project: {{ .Values.project }}
+lagoon.sh/environment: {{ .Values.environment }}
+lagoon.sh/environmentType: {{ .Values.environmentType }}
+lagoon.sh/buildType: {{ .Values.buildType }}
+{{- end }}
+
+{{/*
+Lagoon Annotations
+*/}}
+{{- define "isolation-network-policy.annotations" -}}
+lagoon.sh/version: {{ .Values.lagoonVersion | quote }}
+{{- if .Values.branch }}
+lagoon.sh/branch: {{ .Values.branch | quote }}
+{{- end }}
+{{- if .Values.prNumber }}
+lagoon.sh/prNumber: {{ .Values.prNumber | quote }}
+lagoon.sh/prHeadBranch: {{ .Values.prHeadBranch | quote }}
+lagoon.sh/prBaseBranch: {{ .Values.prBaseBranch | quote }}
+{{- end }}
+{{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/templates/networkpolicy.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "isolation-network-policy.fullname" . }}
+  labels:
+    {{- include "isolation-network-policy.labels" . | nindent 4 }}
+  annotations:
+    {{- include "isolation-network-policy.annotations" . | nindent 4 }}
+spec:
+  # empty podSelector applies this policy to _all_ pods in the current
+  # namespace.
+  podSelector: {}
+  ingress:
+  - from:
+    # empty ingress podSelector means traffic from _all_ pods in the current
+    # namespace are allowed ingress.
+    - podSelector: {}
+    # allow network traffic from cluster services
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/environment
+          operator: DoesNotExist

--- a/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/isolation-network-policy/values.yaml
@@ -1,0 +1,1 @@
+nameOverride: ""


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated See #2541.
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR adds a network policy which is applied to Lagoon environment namespaces. It is disabled by default and controlled via a feature flag as documented in #2541.

The default policy currently implements namespace isolation by filtering Ingress traffic. Egress traffic is not filtered.

Because Egress traffic is not filtered, internal cluster services can still be consumed by Lagoon project workloads with this network policy applied. This is required for logging to `application-logs.lagoon.svc`, and is also common in dedicated Lagoon clusters (e.g. shared Elasticsearch).

Network policies only affects internal cluster traffic. Traffic which routes between Lagoon projects via a public URL (e.g. via an ingress) is not affected. This is the case with e.g. decoupled projects where a frontend consumes a backend API via a public URL.

Similarly to #2481, this depends on uselagoon/lagoon-charts#235. Once that lands, we can remove https://github.com/amazeeio/lagoon/pull/2536/commits/83be81f61536ebc45aeebb85890669692cb4b65c from this PR.

# Closing issues

n/a