### PR TITLE
add EndpointMonitor if CRD is present

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/custom-ingress/templates/monitor.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/custom-ingress/templates/monitor.yaml
@@ -1,0 +1,17 @@
+{{ if .Capabilities.APIVersions.Has "endpointmonitor.stakater.com/v1alpha1/EndpointMonitor" }}
+{{- if .Values.ingressmonitorcontroller.enabled }}
+apiVersion: endpointmonitor.stakater.com/v1alpha1
+kind: EndpointMonitor
+metadata:
+  name: {{ include "custom-ingress.fullname" . }}
+spec:
+  forceHttps: true
+  url: "{{ .Values.host }}{{ .Values.ingressmonitorcontroller.path }}"
+  uptimeRobotConfig:
+    alertContacts: "{{ .Values.ingressmonitorcontroller.alertContacts }}"
+    interval: 60
+    monitorType: "http"
+    statusPages: "{{ .Values.ingressmonitorcontroller.statuspageId }}"
+    customHTTPStatuses: "401:1_403:1" #accept 401 and 403 as UP
+{{- end }}
+{{- end }}


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Changelog Entry
When the EndpointMonitor CRD is present on a cluster, we will create a new EndpointMonitor to be ready for the coming update to IngressMonitorController

Closes #2488 
