### PR TITLE
Removes verbose details from error logging in Problems

### DIFF
--- a/services/webhooks2tasks/src/handlers/problems/processDrutinyResults.ts
+++ b/services/webhooks2tasks/src/handlers/problems/processDrutinyResults.ts
@@ -141,7 +141,7 @@ export async function processDrutinyResultset(
                     '',
                     uuid,
                     `${webhooktype}:${event}:problem_insert_error`,
-                    { data: body },
+                    {},
                     `Error inserting problem id ${element.id} for ${lagoonProjectId}:${environmentDetails.id} -- ${error.message}`
                   )
                 );
@@ -153,7 +153,7 @@ export async function processDrutinyResultset(
       '',
       uuid,
       `${webhooktype}:${event}:unhandled`,
-      { data: body },
+      {},
       `Could not process incoming Drutiny scan results, reason: ${error}`
     );
   }

--- a/services/webhooks2tasks/src/handlers/problems/processHarborVulnerabilityList.ts
+++ b/services/webhooks2tasks/src/handlers/problems/processHarborVulnerabilityList.ts
@@ -84,7 +84,7 @@ export async function processHarborVulnerabilityList(
               '',
               uuid,
               `${webhooktype}:${event}:problem_insert_error`,
-              { data: body },
+              {},
               `Error inserting problem id ${element.id} for ${lagoonProjectId}:${lagoonEnvironmentId} -- ${error.message}`
             )
           );


### PR DESCRIPTION
As described in #2357, the logging for the Problems DB (particularly the Drutiny scan) is far too verbose. Essentially we were sending along the entire request into the logs (which can be json objects with hundreds of fields or nested objects).

This PR simply removes the metadata that delivers the entire webhook through to the logs.


# Checklist

- [*] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

closes #2357
