### PR TITLE
Add option to mount local directories into lagoon-core pods for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -986,9 +986,9 @@ helm/repos: local-dev/helm
 	./local-dev/helm repo add bitnami https://charts.bitnami.com/bitnami
 	./local-dev/helm repo update
 
+# stand up a kind cluster configured appropriately for lagoon testing
 .PHONY: kind/cluster
 kind/cluster: local-dev/kind
-	# stand up a kind cluster configured appropriately for lagoon testing
 	./local-dev/kind get clusters | grep -q "$(CI_BUILD_TAG)" && exit; \
 		docker network create kind || true \
 		&& export KUBECONFIG=$$(mktemp) \
@@ -1033,9 +1033,9 @@ KIND_SERVICES = api api-db api-redis auth-server broker controllerhandler docker
 KIND_TESTS = local-api-data-watcher-pusher local-git tests
 KIND_TOOLS = kind helm kubectl jq
 
+# install lagoon charts and run lagoon test suites in a kind cluster
 .PHONY: kind/test
 kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addprefix build/,$(KIND_SERVICES))
-	# install lagoon charts and run lagoon test suites in a kind cluster
 	export CHARTSDIR=$$(mktemp -d ./lagoon-charts.XXX) \
 		&& ln -sfn "$$CHARTSDIR" lagoon-charts.kind.lagoon \
 		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
@@ -1061,9 +1061,13 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 
 LOCAL_DEV_SERVICES = api auth-server controllerhandler logs2email logs2microsoftteams logs2rocketchat logs2slack ui webhook-handler webhooks2tasks
 
+# kind/local-dev-patch will build the services in LOCAL_DEV_SERVICES on your machine, and then use kubectl patch to mount the folders into Kubernetes
+# the deployments should be restarted to trigger any updated code changes
+# `kubectl rollout undo deployment` can be used to rollback a deployment to before the annotated patch
+# ensure that the correct version of Node to build the services is set on your machine
 .PHONY: kind/local-dev-patch
 kind/local-dev-patch:
-		export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \
+	export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \
 		export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& for image in $(LOCAL_DEV_SERVICES); do \
 			echo "building $$image" \
@@ -1074,10 +1078,10 @@ kind/local-dev-patch:
 			&& ./local-dev/kubectl --namespace lagoon patch deployment lagoon-core-$$image --patch-file ./local-dev/kubectl-patches/$$image.yaml; \
 		done
 
-# kind/dev can only be run once a cluster is up and running (run kind/test first) - it doesn't rebuild the cluster at all, just the lagoon-core helm chart
+# kind/dev can only be run once a cluster is up and running (run kind/test first) - it doesn't rebuild the cluster at all, just pushes the built images
+# into the image registry and reinstalls the lagoon-core helm chart.
 .PHONY: kind/dev
 kind/dev: $(addprefix build/,$(KIND_SERVICES))
-	# install lagoon charts and run lagoon test suites in a kind cluster
 	export KUBECONFIG="$$(realpath ./kubeconfig.kind.$(CI_BUILD_TAG))" \
 		&& export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& $(MAKE) kind/push-images && cd lagoon-charts.kind.lagoon \
@@ -1089,7 +1093,7 @@ kind/dev: $(addprefix build/,$(KIND_SERVICES))
 
 .PHONY: kind/push-images
 kind/push-images:
-		export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \
+	export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \
 		export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& docker login -u admin -p Harbor12345 $$IMAGE_REGISTRY \
 		&& for image in $(KIND_SERVICES); do \

--- a/Makefile
+++ b/Makefile
@@ -948,7 +948,7 @@ KIND_VERSION = v0.10.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
 TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
-CHARTS_TREEISH =
+CHARTS_TREEISH = main
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/Makefile
+++ b/Makefile
@@ -1005,6 +1005,11 @@ kind/cluster: local-dev/kind
 		&& echo '  extraMounts:'                                                                      >> $$KINDCONFIG \
 		&& echo '  - containerPath: /var/lib/kubelet/config.json'                                     >> $$KINDCONFIG \
 		&& echo '    hostPath: $(HOME)/.docker/config.json'                                           >> $$KINDCONFIG \
+		&& if [ '$(INSECURE_HOST_MOUNT_API_SRC)' = true ]; then \
+		echo '  - containerPath: /lagoon/services/api/src'                                            >> $$KINDCONFIG \
+		&& echo '    hostPath: ./services/api/src'                                                    >> $$KINDCONFIG \
+		&& echo '    readOnly: true'                                                                  >> $$KINDCONFIG \
+		; fi \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind create cluster --config=$$KINDCONFIG \
 		&& cp $$KUBECONFIG "kubeconfig.kind.$(CI_BUILD_TAG)" \
 		&& echo -e 'Interact with the cluster during the test run in Jenkins like so:\n' \
@@ -1044,6 +1049,7 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			JQ=$$(realpath ../local-dev/jq) \
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
+			INSECURE_HOST_MOUNT_API_SRC=$(INSECURE_HOST_MOUNT_API_SRC) \
 		&& sleep 30 \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \

--- a/Makefile
+++ b/Makefile
@@ -1061,7 +1061,7 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			ct install
 
 .PHONY: kind/dev
-kind/up: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addprefix build/,$(KIND_SERVICES))
+kind/dev: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addprefix build/,$(KIND_SERVICES))
 	# install lagoon charts and run lagoon test suites in a kind cluster
 	export CHARTSDIR=$$(mktemp -d ./lagoon-charts.XXX) \
 		&& ln -sfn "$$CHARTSDIR" lagoon-charts.kind.lagoon \

--- a/Makefile
+++ b/Makefile
@@ -1059,6 +1059,25 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			"quay.io/helmpack/chart-testing:v3.3.1" \
 			ct install
 
+.PHONY: kind/up
+kind/up: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addprefix build/,$(KIND_SERVICES))
+	# install lagoon charts and run lagoon test suites in a kind cluster
+	export CHARTSDIR=$$(mktemp -d ./lagoon-charts.XXX) \
+		&& ln -sfn "$$CHARTSDIR" lagoon-charts.kind.lagoon \
+		&& git clone https://github.com/uselagoon/lagoon-charts.git "$$CHARTSDIR" \
+		&& cd "$$CHARTSDIR" \
+		&& git checkout $(CHARTS_TREEISH) \
+		&& export KUBECONFIG="$$(realpath ../kubeconfig.kind.$(CI_BUILD_TAG))" \
+		&& export IMAGE_REGISTRY="registry.$$(../local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
+		&& $(MAKE) install-registry HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
+		&& cd .. && $(MAKE) kind/push-images && cd "$$CHARTSDIR" \
+		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(SAFE_BRANCH_NAME) \
+			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
+			JQ=$$(realpath ../local-dev/jq) \
+			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
+			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
+			INSECURE_HOST_MOUNT_API_SRC=$(INSECURE_HOST_MOUNT_API_SRC)
+
 .PHONY: kind/push-images
 kind/push-images:
 		export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \

--- a/Makefile
+++ b/Makefile
@@ -1062,21 +1062,33 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			"quay.io/helmpack/chart-testing:v3.3.1" \
 			ct install
 
+LOCAL_DEV_SERVICES = api auth-server controllerhandler logs2email logs2microsoftteams logs2rocketchat logs2slack ui webhook-handler webhooks2tasks
+
+.PHONY: kind/local-dev-patch
+kind/local-dev-patch:
+		export KUBECONFIG="$$(pwd)/kubeconfig.kind.$(CI_BUILD_TAG)" && \
+		export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
+		&& for image in $(LOCAL_DEV_SERVICES); do \
+			echo "building $$image" \
+			&& cd services/$$image && yarn install && yarn build && cd ../..; \
+		done \
+		&& for image in $(LOCAL_DEV_SERVICES); do \
+			echo "patching lagoon-core-$$image" \
+			&& ./local-dev/kubectl --namespace lagoon patch deployment lagoon-core-$$image --patch-file ./local-dev/kubectl-patches/$$image.yaml; \
+		done
 
 # kind/dev can only be run once a cluster is up and running (run kind/test first) - it doesn't rebuild the cluster at all, just the lagoon-core helm chart
 .PHONY: kind/dev
 kind/dev: $(addprefix build/,$(KIND_SERVICES))
 	# install lagoon charts and run lagoon test suites in a kind cluster
-	export INSECURE_HOST_MOUNT_SERVICES=true \
-		&& export KUBECONFIG="$$(realpath ./kubeconfig.kind.$(CI_BUILD_TAG))" \
+	export KUBECONFIG="$$(realpath ./kubeconfig.kind.$(CI_BUILD_TAG))" \
 		&& export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& $(MAKE) kind/push-images && cd lagoon-charts.kind.lagoon \
 		&& $(MAKE) install-lagoon-core IMAGE_TAG=$(SAFE_BRANCH_NAME) \
 			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
 			JQ=$$(realpath ../local-dev/jq) \
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
-			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
-			INSECURE_HOST_MOUNT_SERVICES=true
+			IMAGE_REGISTRY=$$IMAGE_REGISTRY
 
 .PHONY: kind/push-images
 kind/push-images:

--- a/Makefile
+++ b/Makefile
@@ -948,7 +948,7 @@ KIND_VERSION = v0.10.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
 TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
-CHARTS_TREEISH = insecure-host-mounts
+CHARTS_TREEISH =
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/Makefile
+++ b/Makefile
@@ -1005,14 +1005,12 @@ kind/cluster: local-dev/kind
 		&& echo '  extraMounts:'                                                                      >> $$KINDCONFIG \
 		&& echo '  - containerPath: /var/lib/kubelet/config.json'                                     >> $$KINDCONFIG \
 		&& echo '    hostPath: $(HOME)/.docker/config.json'                                           >> $$KINDCONFIG \
-		&& if [ '$(INSECURE_HOST_MOUNT_SERVICES)' = true ]; then \
-		echo '  - containerPath: /lagoon/services'                                                    >> $$KINDCONFIG \
+		&& echo '  - containerPath: /lagoon/services'                                                 >> $$KINDCONFIG \
 		&& echo '    hostPath: ./services'                                                            >> $$KINDCONFIG \
-		&& echo '    readOnly: false'                                                                  >> $$KINDCONFIG \
+		&& echo '    readOnly: false'                                                                 >> $$KINDCONFIG \
 		&& echo '  - containerPath: /lagoon/node-packages'                                            >> $$KINDCONFIG \
 		&& echo '    hostPath: ./node-packages'                                                       >> $$KINDCONFIG \
-		&& echo '    readOnly: false'                                                                  >> $$KINDCONFIG \
-		; fi \
+		&& echo '    readOnly: false'                                                                 >> $$KINDCONFIG \
 		&& KIND_CLUSTER_NAME="$(CI_BUILD_TAG)" ./local-dev/kind create cluster --config=$$KINDCONFIG \
 		&& cp $$KUBECONFIG "kubeconfig.kind.$(CI_BUILD_TAG)" \
 		&& echo -e 'Interact with the cluster during the test run in Jenkins like so:\n' \
@@ -1052,7 +1050,6 @@ kind/test: kind/cluster helm/repos $(addprefix local-dev/,$(KIND_TOOLS)) $(addpr
 			JQ=$$(realpath ../local-dev/jq) \
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
-			INSECURE_HOST_MOUNT_SERVICES=$(INSECURE_HOST_MOUNT_SERVICES) \
 		&& sleep 30 \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \

--- a/Makefile
+++ b/Makefile
@@ -948,7 +948,7 @@ KIND_VERSION = v0.10.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
 TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
-CHARTS_TREEISH = main
+CHARTS_TREEISH = insecure-host-mounts
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/local-dev/kubectl-patches/api.yaml
+++ b/local-dev/kubectl-patches/api.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        volumeMounts:
+        - mountPath: "/app/services/api/src"
+          name: api-src
+        - mountPath: "/app/services/api/dist"
+          name: api-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: api-src
+        hostPath:
+          path: "/lagoon/services/api/src"
+          type: Directory
+      - name: api-dist
+        hostPath:
+          path: "/lagoon/services/api/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/auth-server.yaml
+++ b/local-dev/kubectl-patches/auth-server.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: auth-server
+        volumeMounts:
+        - mountPath: "/app/services/auth-server/src"
+          name: auth-server-src
+        - mountPath: "/app/services/auth-server/dist"
+          name: auth-server-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: auth-server-src
+        hostPath:
+          path: "/lagoon/services/auth-server/src"
+          type: Directory
+      - name: auth-server-dist
+        hostPath:
+          path: "/lagoon/services/auth-server/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/controllerhandler.yaml
+++ b/local-dev/kubectl-patches/controllerhandler.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: controllerhandler
+        volumeMounts:
+        - mountPath: "/app/services/controllerhandler/src"
+          name: controllerhandler-src
+        - mountPath: "/app/services/controllerhandler/dist"
+          name: controllerhandler-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: controllerhandler-src
+        hostPath:
+          path: "/lagoon/services/controllerhandler/src"
+          type: Directory
+      - name: controllerhandler-dist
+        hostPath:
+          path: "/lagoon/services/controllerhandler/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/logs2email.yaml
+++ b/local-dev/kubectl-patches/logs2email.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: logs2email
+        volumeMounts:
+        - mountPath: "/app/services/logs2email/src"
+          name: logs2email-src
+        - mountPath: "/app/services/logs2email/dist"
+          name: logs2email-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: logs2email-src
+        hostPath:
+          path: "/lagoon/services/logs2email/src"
+          type: Directory
+      - name: logs2email-dist
+        hostPath:
+          path: "/lagoon/services/logs2email/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/logs2microsoftteams.yaml
+++ b/local-dev/kubectl-patches/logs2microsoftteams.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: logs2microsoftteams
+        volumeMounts:
+        - mountPath: "/app/services/logs2microsoftteams/src"
+          name: logs2microsoftteams-src
+        - mountPath: "/app/services/logs2microsoftteams/dist"
+          name: logs2microsoftteams-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: logs2microsoftteams-src
+        hostPath:
+          path: "/lagoon/services/logs2microsoftteams/src"
+          type: Directory
+      - name: logs2microsoftteams-dist
+        hostPath:
+          path: "/lagoon/services/logs2microsoftteams/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/logs2rocketchat.yaml
+++ b/local-dev/kubectl-patches/logs2rocketchat.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: logs2rocketchat
+        volumeMounts:
+        - mountPath: "/app/services/logs2rocketchat/src"
+          name: logs2rocketchat-src
+        - mountPath: "/app/services/logs2rocketchat/dist"
+          name: logs2rocketchat-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: logs2rocketchat-src
+        hostPath:
+          path: "/lagoon/services/logs2rocketchat/src"
+          type: Directory
+      - name: logs2rocketchat-dist
+        hostPath:
+          path: "/lagoon/services/logs2rocketchat/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/logs2slack.yaml
+++ b/local-dev/kubectl-patches/logs2slack.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: logs2slack
+        volumeMounts:
+        - mountPath: "/app/services/logs2slack/src"
+          name: logs2slack-src
+        - mountPath: "/app/services/logs2slack/dist"
+          name: logs2slack-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: logs2slack-src
+        hostPath:
+          path: "/lagoon/services/logs2slack/src"
+          type: Directory
+      - name: logs2slack-dist
+        hostPath:
+          path: "/lagoon/services/logs2slack/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/ui.yaml
+++ b/local-dev/kubectl-patches/ui.yaml
@@ -1,0 +1,17 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: ui
+        volumeMounts:
+        - name: services-ui
+          mountPath: /app/services/ui
+      volumes:
+      - name: services-ui
+        hostPath:
+          path: /lagoon/services/ui
+          type: Directory

--- a/local-dev/kubectl-patches/webhook-handler.yaml
+++ b/local-dev/kubectl-patches/webhook-handler.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: webhook-handler
+        volumeMounts:
+        - mountPath: "/app/services/webhook-handler/src"
+          name: webhook-handler-src
+        - mountPath: "/app/services/webhook-handler/dist"
+          name: webhook-handler-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: webhook-handler-src
+        hostPath:
+          path: "/lagoon/services/webhook-handler/src"
+          type: Directory
+      - name: webhook-handler-dist
+        hostPath:
+          path: "/lagoon/services/webhook-handler/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory

--- a/local-dev/kubectl-patches/webhooks2tasks.yaml
+++ b/local-dev/kubectl-patches/webhooks2tasks.yaml
@@ -1,0 +1,29 @@
+---
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "Add local-dev volume mounts"
+spec:
+  template:
+    spec:
+      containers:
+      - name: webhooks2tasks
+        volumeMounts:
+        - mountPath: "/app/services/webhooks2tasks/src"
+          name: webhooks2tasks-src
+        - mountPath: "/app/services/webhooks2tasks/dist"
+          name: webhooks2tasks-dist
+        - mountPath: "/app/node-packages"
+          name: node-packages
+      volumes:
+      - name: webhooks2tasks-src
+        hostPath:
+          path: "/lagoon/services/webhooks2tasks/src"
+          type: Directory
+      - name: webhooks2tasks-dist
+        hostPath:
+          path: "/lagoon/services/webhooks2tasks/dist"
+          type: Directory
+      - name: node-packages
+        hostPath:
+          path: "/lagoon/node-packages"
+          type: Directory


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR is a PoC for local development using `kind` that tries to approximate the experience using the existing `docker-compose` workflow. It mounts your local `./services/api/src` into the `api` pod running in the local cluster so that code is hot-reloadable.

It currently relies on [a branch](https://github.com/uselagoon/lagoon-charts/tree/insecure-host-mounts) in the `lagoon-charts` repository.

Test this by running `make -j8 -O kind/up INSECURE_HOST_MOUNT_API_SRC=true`. Then when the `api` pod appears you can `kubectl exec` into it and see that changes made to your local `./services/api/src` are reflected inside the pod.

# Closing issues

n/a
