### PR TITLE
fix S3_FILES_HOST variable name 

### DIFF
--- a/services/api/src/clients/aws.js
+++ b/services/api/src/clients/aws.js
@@ -1,7 +1,7 @@
 const R = require('ramda');
 const S3 = require('aws-sdk/clients/s3');
 
-const s3Host = R.propOr('http://docker.for.mac.localhost:9000', 'S3_HOST', process.env);
+const s3Host = R.propOr('http://docker.for.mac.localhost:9000', 'S3_FILES_HOST', process.env);
 const accessKeyId = R.propOr('minio', 'S3_FILES_ACCESS_KEY_ID', process.env);
 const secretAccessKey = R.propOr('minio123', 'S3_FILES_SECRET_ACCESS_KEY', process.env);
 const bucket = R.propOr('lagoon-files', 'S3_FILES_BUCKET', process.env);


### PR DESCRIPTION
was called `S3_HOST` before, but the lagoon-charts use S3_FILES_HOST: 
https://github.com/uselagoon/lagoon-charts/blob/3d2ad1019a9dc9b7f1afda392ba32583d0405cde/charts/lagoon-core/templates/api.deployment.yaml#L112