### PR TITLE
Add missing helm repos for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,6 +984,8 @@ helm/repos: local-dev/helm
 	./local-dev/helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 	./local-dev/helm repo add stable https://charts.helm.sh/stable
 	./local-dev/helm repo add bitnami https://charts.bitnami.com/bitnami
+	./local-dev/helm repo add amazeeio https://amazeeio.github.io/charts/
+	./local-dev/helm repo add lagoon https://uselagoon.github.io/lagoon-charts/
 	./local-dev/helm repo update
 
 .PHONY: kind/cluster


### PR DESCRIPTION


 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

A recent change in the lagoon-charts CI meant that these helm repos were not being added automatically.

See https://github.com/uselagoon/lagoon-charts/pull/231 for details.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
