### PR TITLE
Add Environment and Project IDs to controller builds

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -866,6 +866,36 @@ export async function getEnvironmentByName(
   return result;
 }
 
+
+export async function getEnvironmentById(
+  id: number
+): Promise<any> {
+  const result = await graphqlapi.query(`
+    {
+      environmentById(id: ${id}") {
+        id,
+        name,
+        route,
+        routes,
+        deployType,
+        environmentType,
+        openshiftProjectName,
+        updated,
+        created,
+        deleted,
+      }
+    }
+  `);
+
+  if (!result || !result.environmentById) {
+    throw new EnvironmentNotFound(
+      `Cannot find environment for id ${id}\n${result.environmentById}`
+    );
+  }
+
+  return result;
+}
+
 export async function getDeploymentByName(
   openshiftProjectName: string,
   deploymentName: string,
@@ -1436,7 +1466,7 @@ fragment on Problem {
   data
   created
   deleted
-} 
+}
 `);
 
 export const getProblemsforProjectEnvironment = async (

--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -872,7 +872,7 @@ export async function getEnvironmentById(
 ): Promise<any> {
   const result = await graphqlapi.query(`
     {
-      environmentById(id: ${id}") {
+      environmentById(id: ${id}) {
         id,
         name,
         route,

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -449,6 +449,7 @@ const getControllerBuildData = async function(deployData: any) {
         gitUrl: gitUrl,
         uiLink: deployment.addDeployment.uiLink,
         environment: environmentName,
+        environmentType: environmentType,
         environmentId: environmentId,
         productionEnvironment: projectProductionEnvironment,
         standbyEnvironment: projectStandbyEnvironment,

--- a/services/controllerhandler/src/index.ts
+++ b/services/controllerhandler/src/index.ts
@@ -159,8 +159,9 @@ const messageConsumer = async function(msg) {
         environment = projectEnv.environment
       } catch (err) {
         // if the project or environment can't be determined, give up trying to do anything for it
-        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Will not continue`)
-        throw new Error
+        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Giving up updating environment`)
+        // break so the controllerhandler doesn't stop processing
+        break;
       }
 
       try {
@@ -209,8 +210,9 @@ const messageConsumer = async function(msg) {
         environment = projectEnv.environment
       } catch (err) {
         // if the project or environment can't be determined, give up trying to do anything for it
-        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Will not continue`)
-        throw new Error
+        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Giving up removing environment`)
+        // break so the controllerhandler doesn't stop processing
+        break;
       }
       try {
         await deleteEnvironment(environment.name, meta.project, false);
@@ -244,8 +246,9 @@ const messageConsumer = async function(msg) {
         environment = projectEnv.environment
       } catch (err) {
         // if the project or environment can't be determined, give up trying to do anything for it
-        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Will not continue`)
-        throw new Error
+        logger.error(`${namespace} ${meta.buildName}: Error while getting project or environment information, Error: ${err}. Giving up updating task result`)
+        // break so the controllerhandler doesn't stop processing
+        break;
       }
       // if we want to be able to do something else when a task result comes through,
       // we can use the task key


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Somewhat related to #2322, Lagoon sends a DNS compliant version of the environment name to the build deploy controller. When a build is completed, it responds to Lagoon with this modified environment name. In the event that the original environment name contained slashes or other special characters, Lagoon would not actually update the API with the information required.

Lagoon will prefer to use the environment ID if it is present, but will fall back to using the environment name if no ID is found.

This is a partner to https://github.com/amazeeio/lagoon-kbd/pull/41 , which adds the support for these IDs into the build deploy controller.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closes

closed #2568 