### PR TITLE
Update remaining templates to use securityContext value

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: {{ include "elasticsearch.lagoonPriority" . }}
       enableServiceLinks: false
       securityContext:
-        fsGroup: 0
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - image: {{ .Values.image | quote }}
           name: {{ .Chart.Name }}
@@ -51,8 +51,6 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
             initialDelaySeconds: 120
-          securityContext:
-            runAsGroup: 0
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/deployment.yaml
@@ -32,11 +32,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "mariadb-single.fullname" . }}
       securityContext:
-        fsGroup: 0
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            runAsGroup: 0
           image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
@@ -32,11 +32,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "mongodb-single.fullname" . }}
       securityContext:
-        fsGroup: 0
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            runAsGroup: 0
           image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
@@ -32,11 +32,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "postgres-single.fullname" . }}
       securityContext:
-        fsGroup: 0
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            runAsGroup: 0
           image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: {{ include "solr.lagoonPriority" . }}
       enableServiceLinks: false
       securityContext:
-        fsGroup: 0
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - image: {{ .Values.image | quote }}
           name: {{ .Chart.Name }}
@@ -54,8 +54,6 @@ spec:
             initialDelaySeconds: 90
             timeoutSeconds: 3
             failureThreshold: 5
-          securityContext:
-            runAsGroup: 0
           envFrom:
             - configMapRef:
                 name: lagoon-env


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

As part of work on checking Red Hat Openshift 4 compatibility, some templates had hardcoded security contexts which prevented the pods from starting.

This brings them in line with the other templates.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->
