### PR TITLE
Use consistent quoting for file-based backup annotations

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "mongodb-single.labels" . | nindent 8 }}
       annotations:
         {{- include "mongodb-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} ."
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
         k8up.syn.tools/file-extension: .{{ include "mongodb-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "postgres-single.labels" . | nindent 8 }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} ."
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "solr.datadogLabels" . | nindent 8 }}
       annotations:
         {{- include "solr.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path }} ."
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
         k8up.syn.tools/file-extension: .{{ include "solr.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The old quoting was causing backup breakage.

Before we had:

```
annotations:
  k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} ."
```

After templating this will have invalid quoting (`"` inside `"`):

```
annotations:
  k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C "/my/path/example" ."
```

This PR changes the template to:

```
annotations:
  k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
```

After templating the quoting is valid for the shell command:

```
annotations:
  k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C "/my/path/example" .'
```

# Closing issues

n/a
