### PR TITLE
Add "description" key to opendistro-security tenant create call

### DIFF
--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -60,7 +60,7 @@ export const OpendistroSecurityOperations = (sqlClient: MariaClient, GroupModel)
 
     try {
       // Create a new Tenant for this Group
-      await opendistroSecurityClient.put(`tenants/${groupName}`, { body: {} });
+      await opendistroSecurityClient.put(`tenants/${groupName}`, { body: { description: 'Lagoon group tenant' } });
       logger.debug(`${groupName}: Created Tentant "${groupName}"`);
     } catch (err) {
       logger.error(`Opendistro-Security create tenant error: ${err}`);


### PR DESCRIPTION
Add `description` json body key to opendistro-security tenant create call used in the `sync:opendistro-security` command

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

[Opendistro-security's API endpoint for creating tenants](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/api/#request-29) has been updated (I couldn't find the change, maybe someone else can?) to require a `description` so this PR updates our API call to include a generic description. 

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2577 

