### PR TITLE
re-add harbor problems connectivity to webhookURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -948,7 +948,7 @@ KIND_VERSION = v0.10.0
 GOJQ_VERSION = v0.11.2
 KIND_IMAGE = kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
 TESTS = [api,features-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
-CHARTS_TREEISH = main
+CHARTS_TREEISH = webhook_url
 
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -150,9 +150,7 @@ services:
     image: ${IMAGE_REPO:-lagoon}/tests
     environment:
       - CLUSTER_TYPE=control-k8s
-      - WEBHOOK_HOST=webhook-handler
-      - WEBHOOK_PORT=3000
-      - WEBHOOK_PROTOCOL=http
+      - WEBHOOK_URL=http://webhook-handler:3000
       - ROUTE_SUFFIX_HTTP=172.17.0.1.nip.io
       - ROUTE_SUFFIX_HTTP_PORT=18080
       - ROUTE_SUFFIX_HTTPS=172.17.0.1.nip.io
@@ -173,9 +171,7 @@ services:
     image: ${IMAGE_REPO:-lagoon}/tests
     environment:
       - CLUSTER_TYPE=openshift
-      - WEBHOOK_HOST=webhook-handler
-      - WEBHOOK_PORT=3000
-      - WEBHOOK_PROTOCOL=http
+      - WEBHOOK_URL=http://webhook-handler:3000
       - ROUTE_SUFFIX_HTTP=192.168.42.103.nip.io
       - ROUTE_SUFFIX_HTTP_PORT=80
       - ROUTE_SUFFIX_HTTPS=192.168.42.103.nip.io

--- a/services/api/src/resources/project/harborSetup.ts
+++ b/services/api/src/resources/project/harborSetup.ts
@@ -69,7 +69,7 @@ async function createHarborProject(sqlClient: MariaClient, harborClient, lagoonP
     } else {
       results = res.body
     }
-    
+
     // Search array of objects for correct project
     for (let proj of results) {
       if (proj.name == lagoonProjectName) {
@@ -230,8 +230,8 @@ async function resetHarborWebhook(sqlClient: MariaClient, harborClient, lagoonPr
           }
         ],
         event_types: [
-          "scanningFailed",
-          "scanningCompleted"
+          "SCANNING_FAILED",
+          "SCANNING_COMPLETED"
         ],
         name: "Lagoon Default Webhook",
         enabled: true

--- a/services/webhook-handler/src/extractWebhookData.ts
+++ b/services/webhook-handler/src/extractWebhookData.ts
@@ -90,7 +90,7 @@ export function extractWebhookData(req: IncomingMessage, body: string): WebhookR
       webhooktype = 'resticbackup';
       event = 'restore:finished';
       uuid = uuid4();
-    } else if (bodyObj.type && bodyObj.type == 'scanningCompleted') {
+    } else if (bodyObj.type && bodyObj.type == 'SCANNING_COMPLETED') {
       webhooktype = 'problems';
       event = 'harbor:scanningcompleted';
       uuid = uuid4();

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # inject variables from environment into the Ansible var template
-envsubst '$API_HOST $API_PORT $API_PROTOCOL $CLUSTER_TYPE $DELETED_STATUS_CODE $GIT_HOST $GIT_REPO_PREFIX $GIT_PORT $ROUTE_SUFFIX_HTTP $ROUTE_SUFFIX_HTTP_PORT $ROUTE_SUFFIX_HTTPS $ROUTE_SUFFIX_HTTPS_PORT $SSH_HOST $SSH_PORT $WEBHOOK_HOST $WEBHOOK_PORT $WEBHOOK_PROTOCOL $WEBHOOK_REPO_PREFIX' < /ansible/tests/vars/test_vars.yaml | sponge /ansible/tests/vars/test_vars.yaml
+envsubst '$API_HOST $API_PORT $API_PROTOCOL $CLUSTER_TYPE $DELETED_STATUS_CODE $GIT_HOST $GIT_REPO_PREFIX $GIT_PORT $ROUTE_SUFFIX_HTTP $ROUTE_SUFFIX_HTTP_PORT $ROUTE_SUFFIX_HTTPS $ROUTE_SUFFIX_HTTPS_PORT $SSH_HOST $SSH_PORT $WEBHOOK_URL $WEBHOOK_REPO_PREFIX' < /ansible/tests/vars/test_vars.yaml | sponge /ansible/tests/vars/test_vars.yaml
 
 if [ ! -z "$SSH_PRIVATE_KEY" ]; then
   mkdir -p ~/.ssh

--- a/tests/tests/vars/test_vars.yaml
+++ b/tests/tests/vars/test_vars.yaml
@@ -1,5 +1,5 @@
 ---
-webhook_url: "$WEBHOOK_PROTOCOL://$WEBHOOK_HOST:$WEBHOOK_PORT"
+webhook_url: "$WEBHOOK_URL"
 graphql_url: "$API_PROTOCOL://$API_HOST:$API_PORT/graphql"
 localgit_url: "ssh://git@$GIT_HOST:$GIT_PORT/git"
 ssh_host: "$SSH_HOST"


### PR DESCRIPTION
This PR makes minor modifications to the Harbor Webhook configuration to allow webhook notifications to flow again to Lagoon.

Because of the format change to the webhook (and the URL change to the API) - the ingestion of the data from the webhook will need more attention.

A sample webhook payload is as follows:
```
{
  "type": "SCANNING_COMPLETED",
  "occur_at": 1615880572,
  "operator": "auto",
  "event_data": {
    "resources": [
      {
        "digest": "sha256:6094a54444067d21929be0d741291b6eed82caa455be3a347c6e514f2794d803",
        "tag": "",
        "resource_url": "registry.172.27.0.2.nip.io:32080/ci-bitbucket-control-k8s/bitbucket-slash-branch/node:",
        "scan_overview": {
          "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
            "report_id": "c86fb19c-0168-4aca-9921-17ff04d53612",
            "scan_status": "Success",
            "severity": "High",
            "duration": 9,
            "summary": {
              "total": 4,
              "fixable": 4,
              "summary": {
                "High": 3,
                "Medium": 1
              }
            },
            "start_time": "2021-03-16T07:42:43.132206Z",
            "end_time": "2021-03-16T07:42:52.265765Z",
            "scanner": {
              "name": "Trivy",
              "vendor": "Aqua Security",
              "version": "v0.9.2"
            },
            "complete_percent": 100
          }
        }
      }
    ],
    "repository": {
      "name": "bitbucket-slash-branch/node",
      "namespace": "ci-bitbucket-control-k8s",
      "repo_full_name": "ci-bitbucket-control-k8s/bitbucket-slash-branch/node",
      "repo_type": "private"
    }
  }
}
```
There is also a 
`/projects/ci-bitbucket-control-k8s/repositories/bitbucket-slash-branch%252Fnode/artifacts/latest/additions/vulnerabilities` path to the vulnerabilities available
