### PR TITLE
Fix docs on skipping deployments

### DIFF
--- a/docs/using-lagoon-the-basics/build-and-deploy-process.md
+++ b/docs/using-lagoon-the-basics/build-and-deploy-process.md
@@ -114,5 +114,5 @@ If all went well and nothing threw any errors, Lagoon will mark this build as su
 
 ### Push without deploying
 
-There may be a case where you want to push without a deployment. Make sure your commit message contains "`skip deploy`" or "`deploy skip`" and Lagoon will not trigger a deployment from that commit. 
+There may be a case where you want to push without a deployment. Make sure your commit message contains "`[skip deploy]`" or "`[deploy skip]`" and Lagoon will not trigger a deployment from that commit. 
 


### PR DESCRIPTION
The regex for skip deploy requires it to be enclosed in square brackets:
https://github.com/amazeeio/lagoon/blob/47abca41f689f9af7ff5ce2d36dd4b3ec72b2fd5/services/webhooks2tasks/src/handlers/githubPush.ts#L21