### PR TITLE
set vm.max_map_count in elasticsearch template

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/deployment.yaml
@@ -34,6 +34,18 @@ spec:
       enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        # This init container sets the appropriate limits for mmap counts on the hosting node.
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+        - name: set-max-map-count
+          image: ubuntu:20.04
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            privileged: true
+          command:
+          - /bin/bash
+          - -c
+          - 'if [[ "$(sysctl vm.max_map_count --values)" -lt 262144 ]]; then sysctl -w vm.max_map_count=262144; fi'
       containers:
         - image: {{ .Values.image | quote }}
           name: {{ .Chart.Name }}


### PR DESCRIPTION
Signed-off-by: Salvo Pappalardo <x4ntrix@gmail.com>

 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Add initContainer to increase `vm.max_map_count` on the hosting node

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2588
