### PR TITLE
Document project default users and SSH keys

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 * [Backups](using-lagoon-advanced/backups.md)
 * [Remote Shell](using-lagoon-advanced/remote-shell.md)
 * [GraphQL](using-lagoon-advanced/graphql.md)
+* [Project Default Users and SSH keys](using-lagoon-advanced/project-default-users-keys.md)
 * [Node.js Graceful Shutdown](using-lagoon-advanced/nodejs.md)
 * [Setting up Xdebug with Lagoon](using-lagoon-advanced/setting-up-xdebug-with-lagoon.md)
 

--- a/docs/using-lagoon-advanced/project-default-users-keys.md
+++ b/docs/using-lagoon-advanced/project-default-users-keys.md
@@ -2,7 +2,7 @@
 
 When a Lagoon project is created, by default an associated SSH "project key" is generated and the private key made available inside the CLI pods of the project. A service account `default-user@project` is also created and given `MAINTAINER` access to the project. The SSH "project key" is attached to that `default-user@project`.
 
-The upshot is that from inside the CLI pod of any environment it is possible to SSH to any other environment within the same project. This access is used for running tasks from the command line such as synchronising databases between environments (e.g. drush `sql-sync`).
+The result of this is that from inside the CLI pod of any environment it is possible to SSH to any other environment within the same project. This access is used for running tasks from the command line such as synchronising databases between environments (e.g. drush `sql-sync`).
 
 There is more information on the `MAINTAINER` role available in the [RBAC](https://docs.lagoon.sh/lagoon/administering-lagoon/rbac) documentation.
 

--- a/docs/using-lagoon-advanced/project-default-users-keys.md
+++ b/docs/using-lagoon-advanced/project-default-users-keys.md
@@ -1,0 +1,11 @@
+# Project default users and SSH keys
+
+When a Lagoon project is created, by default an associated SSH "project key" is generated and the private key made available inside the CLI pods of the project. A service account `default-user@project` is also created and given `MAINTAINER` access to the project. The SSH "project key" is attached to that `default-user@project`.
+
+The upshot is that from inside the CLI pod of any environment it is possible to SSH to any other environment within the same project. This access is used for running tasks from the command line such as synchronising databases between environments (e.g. drush `sql-sync`).
+
+There is more information on the `MAINTAINER` role available in the [RBAC](https://docs.lagoon.sh/lagoon/administering-lagoon/rbac) documentation.
+
+## Specifying the project key
+
+It is possible to specify an SSH private key when creating a project, but this is not recommended as it has security implications.


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR adds some basic documentation about Lagoon project default users and SSH keys.

Let me know if this is the wrong place for a documentation PR.

# Closing issues

n/a
