### PR TITLE
Changes async logic for writing Harbor problems to API

### DIFF
--- a/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
+++ b/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
@@ -14,6 +14,8 @@ import {
   getOpenShiftInfoForProject,
 } from '@lagoon/commons/dist/api';
 
+const PROBLEMS_HARBOR_FILTER_FLAG = process.env.PROBLEMS_HARBOR_FILTER_FLAG || null;
+
 const HARBOR_WEBHOOK_SUCCESSFUL_SCAN = "Success";
 
 const DEFAULT_REPO_DETAILS_REGEX = "^(?<lagoonProjectName>.+)\/(?<lagoonEnvironmentName>.+)\/(?<lagoonServiceName>.+)$";
@@ -59,7 +61,14 @@ const DEFAULT_REPO_DETAILS_MATCHER = {
     let vulnerabilities = [];
     vulnerabilities = await getVulnerabilitiesFromHarbor(harborScanId);
 
-    let { id: lagoonProjectId } = await getProjectByName(lagoonProjectName);
+    let { id: lagoonProjectId, problemsUi } = await getProjectByName(lagoonProjectName);
+
+    //Here, before we get any further, we only let through projects that have the problemsUI enabled
+    if(PROBLEMS_HARBOR_FILTER_FLAG && problemsUi == 0) {
+      console.log(`Filter enabled: skipping harbor processing for ${lagoonProjectName}:${lagoonEnvironmentName}:${lagoonServiceName}`)
+      return;
+    }
+
 
     const result = await getOpenShiftInfoForProject(lagoonProjectName);
     const projectOpenShift = result.project;

--- a/services/webhooks2tasks/src/handlers/problems/processHarborVulnerabilityList.ts
+++ b/services/webhooks2tasks/src/handlers/problems/processHarborVulnerabilityList.ts
@@ -41,8 +41,10 @@ export async function processHarborVulnerabilityList(
     );
 
     if (vulnerabilities) {
-      vulnerabilities.forEach((element) => {
-        addProblem({
+      for(let element of vulnerabilities) {
+        try {
+
+        await addProblem({
           environment: lagoonEnvironmentId,
           identifier: element.id,
           severity: element.severity.toUpperCase(),
@@ -56,8 +58,8 @@ export async function processHarborVulnerabilityList(
           service: lagoonServiceName,
           associatedPackage: element.package,
         })
-          .then(() => {
-            sendToLagoonLogs(
+
+        await sendToLagoonLogs(
               'info',
               lagoonProjectName,
               uuid,
@@ -76,9 +78,8 @@ export async function processHarborVulnerabilityList(
                 vulnerability: element,
               },
               `New problem found for ${lagoonProjectName}:${lagoonEnvironmentName}:${lagoonServiceName}. Severity: ${element.severity}. Description: ${element.description}`
-            );
-          })
-          .catch((error) =>
+          );
+        } catch (error) {
             sendToLagoonLogs(
               'error',
               '',
@@ -87,7 +88,7 @@ export async function processHarborVulnerabilityList(
               { data: body },
               `Error inserting problem id ${element.id} for ${lagoonProjectId}:${lagoonEnvironmentId} -- ${error.message}`
             )
-          );
-      });
+        }
+      }
     }
   }


### PR DESCRIPTION
Currently, when a Harbor scan is completed, we're spinning up multiple parallel calls to the API to write the new problem data to the backend. This change makes adding problems within a single processing session synchronous so that there is never more than a single API call running per problem set at a time.

This is a first pass at this - the next step is to make a change in the API, since there is a discrepancy in the problems delete mutation (it should have "service"). A second PR issue and PR will be issued that will address this.

# Checklist

- [*] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

# Closing issues

Addresses #2601 
