### PR TITLE
Improved backupcommands for solr, postgres-single, and mongodb-single

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "mariadb-single.labels" . | nindent 8 }}
       annotations:
         {{- include "mariadb-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
+        k8up.syn.tools/backupcommand: /bin/sh -c 'mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases'
         k8up.syn.tools/file-extension: .{{ include "mariadb-single.fullname" . }}.sql
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "mongodb-single.labels" . | nindent 8 }}
       annotations:
         {{- include "mongodb-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude='lost\+found'"
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude="lost\+found"'
         k8up.syn.tools/file-extension: .{{ include "mongodb-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "mongodb-single.labels" . | nindent 8 }}
       annotations:
         {{- include "mongodb-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
+        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude='lost\+found'"
         k8up.syn.tools/file-extension: .{{ include "mongodb-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "postgres-single.labels" . | nindent 8 }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
+        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude='lost\+found'"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "postgres-single.labels" . | nindent 8 }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude='lost\+found'"
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .  --exclude="lost\+found"'
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "solr.datadogLabels" . | nindent 8 }}
       annotations:
         {{- include "solr.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} .'
+        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path }} . --exclude='lost\+found'"
         k8up.syn.tools/file-extension: .{{ include "solr.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "solr.datadogLabels" . | nindent 8 }}
       annotations:
         {{- include "solr.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path }} . --exclude='lost\+found'"
+        k8up.syn.tools/backupcommand: /bin/sh -c '/bin/busybox tar -cf - -C {{ .Values.persistentStorage.path | quote }} . --exclude="lost\+found"'
         k8up.syn.tools/file-extension: .{{ include "solr.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
 # Checklist

- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR cherry-picks the improvements in backupcommands from #2592 into `master`.

# Closing issues
