### PR TITLE
revert fsGroup:0 for persistent services template

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/values.yaml
@@ -17,7 +17,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-podSecurityContext: {}
+podSecurityContext:
   fsGroup: 0
 
 securityContext: {}

--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 podSecurityContext: {}
-  # fsGroup: 2000
+  fsGroup: 0
 
 securityContext: {}
   # capabilities:

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/values.yaml
@@ -23,8 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 0
 
 securityContext: {}
   # capabilities:

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/values.yaml
@@ -23,8 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 0
 
 securityContext: {}
   # capabilities:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/values.yaml
@@ -23,8 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 0
 
 securityContext: {}
   # capabilities:


### PR DESCRIPTION
 # Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR solves the Elasticsearch issue because of missing permissions
revert fsGroup:0 for elasticsearch template

# Closing issues

closes #2609 