### PR TITLE
fact category field to api and facts ui changes

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -525,20 +525,20 @@ mutation PopulateApi {
     input: {
       facts: [
           {
-            name: "fact-1"
+            name: "interesting-package"
             value: "1.0.0"
             environment: 3
             source: "local-dev"
-            description: "Description of fact-1"
-            category: "application"
+            description: "Description of interesting php package"
+            category: "Composer package (php)"
           },
           {
-            name: "fact-2"
+            name: "npm-module"
             value: "2.0.0"
             environment: 3
             source: "local-dev"
-            description: "Description of fact-2"
-            category: "web framework"
+            description: "Description of node module"
+            category: "Node package (npm)"
           }
       ]
     }

--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -305,6 +305,8 @@ mutation PopulateApi {
       openshift: 4
       gitUrl: "ssh://git@172.17.0.1:2222/git/project18.git"
       productionEnvironment: "Master"
+      problemsUi: 1
+      factsUi: 1
     }
   ) {
     id
@@ -499,7 +501,6 @@ mutation PopulateApi {
     id
   }
 
-
   UIProject1Environment1addTask3: addTask(
     input: {
       name: "Drupal Archive"
@@ -517,6 +518,31 @@ mutation PopulateApi {
   }
 
   UIProject1Environment1addServices: setEnvironmentServices(input:{environment:3, services:["cli", "nginx", "mariadb"]}) {
+    id
+  }
+
+  UIProject1Environment1addFacts: addFacts(
+    input: {
+      facts: [
+          {
+            name: "fact-1"
+            value: "1.0.0"
+            environment: 3
+            source: "local-dev"
+            description: "Description of fact-1"
+            category: "application"
+          },
+          {
+            name: "fact-2"
+            value: "2.0.0"
+            environment: 3
+            source: "local-dev"
+            description: "Description of fact-2"
+            category: "web framework"
+          }
+      ]
+    }
+  ) {
     id
   }
 

--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -284,5 +284,6 @@ CREATE TABLE IF NOT EXISTS environment_fact (
   source                   varchar(300) DEFAULT '',
   description              TEXT NULL    DEFAULT '',
   created                  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  category                 TEXT NULL    DEFAULT '',
   UNIQUE(environment, name)
 );

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1149,6 +1149,24 @@ CREATE OR REPLACE PROCEDURE
 $$
 
 CREATE OR REPLACE PROCEDURE
+  add_fact_category_to_environment_fact()
+
+  BEGIN
+    IF NOT EXISTS(
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_fact'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'category'
+    ) THEN
+        ALTER TABLE `environment_fact`
+        ADD `category` TEXT NULL DEFAULT '';
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
   update_user_password()
 
   BEGIN
@@ -1309,6 +1327,7 @@ CALL update_user_password();
 CALL add_problems_ui_to_project();
 CALL add_facts_ui_to_project();
 CALL add_fact_source_and_description_to_environment_fact();
+CALL add_fact_category_to_environment_fact();
 CALL add_metadata_to_project();
 CALL add_min_max_to_billing_modifier();
 CALL add_content_type_to_project_notification();

--- a/services/api/src/mocks.js
+++ b/services/api/src/mocks.js
@@ -233,8 +233,8 @@ MIIJKQIBAAKCAgEA+o[...]P0yoL8BoQQG2jCvYfWh6vyglQdrDYx/o6/8ecTwXokKKh6fg1q
     productionEnvironment: 'master',
     autoIdle: faker.random.arrayElement([0, 1]),
     storageCalc: faker.random.arrayElement([0, 1]),
-    problemsUi: faker.random.arrayElement([0, 1]),
-    factsUi: faker.random.arrayElement([0, 1]),
+    problemsUi: 1,
+    factsUi: 1,
     openshift: mocks.Openshift(),
     openshiftProjectPattern: '${project}-${name}',
     developmentEnvironmentsLimit: 10,
@@ -302,6 +302,14 @@ mocks.Environment = (parent, args = {}, context, info) => {
       mocks.Problem()
     ],
     facts: [
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
+      mocks.Fact(),
       mocks.Fact(),
       mocks.Fact()
     ],

--- a/services/api/src/mocks.js
+++ b/services/api/src/mocks.js
@@ -514,7 +514,7 @@ mocks.Query = () => ({
   userCanSshToEnvironment: () => mocks.Environment(),
   deploymentByRemoteId: () => mocks.Deployment(),
   taskByRemoteId: () => mocks.Task(),
-  allProjects: () => new MockList(100),
+  allProjects: () => new MockList(50),
   allOpenshifts: () => new MockList(9),
   allProblems: () => new MockList(20),
   allEnvironments: (parent, args = {}, context, info) => {

--- a/services/api/src/mocks.js
+++ b/services/api/src/mocks.js
@@ -301,6 +301,10 @@ mocks.Environment = (parent, args = {}, context, info) => {
       mocks.Problem(),
       mocks.Problem()
     ],
+    facts: [
+      mocks.Fact(),
+      mocks.Fact()
+    ],
     services: [ mocks.EnvironmentService() ],
   };
   environment.project.environments.push(environment);
@@ -478,6 +482,22 @@ mocks.ProblemMutation = (schema) => {
             `problem${faker.random.number(1000000)}: addProblem(input: ${JSON.stringify(temp, 2, null)}) { identifier }`
         );
     });
+};
+
+mocks.Fact = (parent, args = {}) => {
+  const name = `fact-${faker.random.number({min: 1, max: 100})}`;
+  const value = `${faker.random.number({min: 1, max: 9})}.${faker.random.number({min: 0, max: 9})}.${faker.random.number({min: 0, max: 9})}`;
+  const source = faker.random.arrayElement(['drush_pml', 'drush_status', 'php-details', 'env', 'http_header']);
+  const category = faker.random.arrayElement(['application', 'hosting', 'cms', 'drupal-module', 'drupal-theme']);
+  const description = faker.lorem.paragraph();
+
+  return {
+    name,
+    value,
+    source,
+    category,
+    description
+  };
 };
 
 //

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -43,7 +43,7 @@ export const addFact = async (
   root,
   {
     input: {
-      id, environment: environmentId, name, value, source, description
+      id, environment: environmentId, name, value, source, description, category
     },
   },
   { sqlClient, hasPermission },
@@ -64,7 +64,8 @@ export const addFact = async (
       name,
       value,
       source,
-      description
+      description,
+      category
     }),
   );
 
@@ -93,7 +94,9 @@ export const addFacts = async (
   });
 
   return await facts.map(async (fact) => {
-    const { environment, name, value, source, description } = fact;
+    const { environment, name, value, source, description, category } = fact;
+
+
 
     const {
       info: { insertId },
@@ -104,7 +107,8 @@ export const addFacts = async (
         name,
         value,
         source,
-        description
+        description,
+        category
       }),
     );
 

--- a/services/api/src/resources/fact/sql.ts
+++ b/services/api/src/resources/fact/sql.ts
@@ -14,7 +14,8 @@ const standardFactReturn = {
     name: 'name',
     value: 'value',
     source: 'source',
-    description: 'description'
+    description: 'description',
+    category: 'category'
 };
 
 export const Sql /* : SqlObj */ = {
@@ -25,8 +26,8 @@ export const Sql /* : SqlObj */ = {
   }) => {
     return knex('environment_fact').select(standardFactReturn).where('environment', environmentId).toString();
   },
-  insertFact: ({ environment, name, value, source, description }) =>
-    knex('environment_fact').insert({environment, name, value, source, description}).toString(),
+  insertFact: ({ environment, name, value, source, description, category }) =>
+    knex('environment_fact').insert({environment, name, value, source, description, category }).toString(),
   deleteFact: (environment, name) =>
     knex('environment_fact')
       .where({

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -202,6 +202,7 @@ const typeDefs = gql`
     value: String
     source: String
     description: String
+    category: String
   }
 
   input AddFactInput {
@@ -211,6 +212,7 @@ const typeDefs = gql`
     value: String!
     source: String!
     description: String!
+    category: String
   }
 
   input AddFactsInput {
@@ -223,6 +225,7 @@ const typeDefs = gql`
     value: String!
     source: String!
     description: String
+    category: String
   }
 
   input UpdateFactInput {

--- a/services/ui/src/components/Facts/index.js
+++ b/services/ui/src/components/Facts/index.js
@@ -1,13 +1,29 @@
 import React, { useState } from 'react';
 import { bp, color, fontSize } from 'lib/variables';
 import useSortableData from '../../lib/withSortedItems';
+import SelectFilter from 'components/Filters';
+
+const getOptionsFromFacts = (facts, key) => {
+    let uniqueOptions= facts &&
+      new Set(facts.filter(f => f[key]).map(f => f[key]));
+
+    return [...uniqueOptions].sort();
+};
 
 const Facts = ({ facts }) => {
     const { sortedItems, getClassNamesFor, requestSort } = useSortableData(facts, {key: 'name', direction: 'ascending'});
+    const [nameSelected, setName] = useState([]);
+    const [sourceSelected, setSource] = useState([]);
+    const [categorySelected, setCategory] = useState([]);
 
     const [factTerm, setFactTerm] = useState('');
     const [hasFilter, setHasFilter] = React.useState(false);
 
+    const names = getOptionsFromFacts(facts, 'name');
+    const sources = getOptionsFromFacts(facts, 'source');
+    const categories = getOptionsFromFacts(facts, 'category');
+
+    // Handlers
     const handleFactFilterChange = (event) => {
         setHasFilter(false);
 
@@ -21,22 +37,111 @@ const Facts = ({ facts }) => {
         return requestSort(key);
     };
 
-    const filterResults = (item) => {
-        const lowercasedFilter = factTerm.toLowerCase();
+    const handleNameChange = (name) => {
+        let values = name && name.map(n => n.value) || [];
+        setName(values);
+    };
 
-        if (factTerm == null || factTerm === '') {
-            return facts;
-        }
+    const handleSourceChange = (source) => {
+        let values = source && source.map(s => s.value) || [];
+        setSource(values);
+    };
 
-        return Object.keys(item).some(key => {
-            if (item[key] !== null) {
-                return item[key].toString().toLowerCase().includes(lowercasedFilter);
-            }
-        });
+    const handleCategoryChange = (category) => {
+        let values = category && category.map(c => c.value) || [];
+        setCategory(values);
+    };
+
+    // Options
+    const nameOptions = (name) => {
+        return name && name.map(n => ({ value: n, label: n}));
+    };
+
+    const sourceOptions = (sources) => {
+        return sources && sources.map(s => ({ value: s, label: s}));
+    };
+
+    const categoryOptions = (category) => {
+        return category && category.map(c => ({ value: c, label: c}));
+    };
+
+    // Selector filtering
+    const matchesNameSelector = (item) => {
+        return (nameSelected.length > 0) ?
+          Object.keys(item).some(key => {
+              if (item[key] !== null) {
+                  return nameSelected.indexOf(item['name'].toString()) > -1;
+              };
+          })
+          : true;
+    }
+
+    const matchesSourceSelector = (item) => {
+        return (sourceSelected.length > 0) ?
+          Object.keys(item).some(key => {
+              if (item[key] !== null) {
+                  return sourceSelected.indexOf(item['source'].toString()) > -1;
+              };
+          })
+          : true;
+    }
+
+    const matchesCategorySelector = (item) => {
+        return (categorySelected.length > 0) ?
+          Object.keys(item).some(key => {
+              if (item[key] !== null) {
+                  return categorySelected.indexOf(item['category'].toString()) > -1;
+              };
+          })
+          : true;
+    }
+
+    const matchesTextFilter = (item) => {
+        return (factTerm != null || factTerm !== '') ?
+          Object.keys(item).some(key => {
+              if (item[key] !== null) {
+                  return item[key].toString().toLowerCase().includes(factTerm.toLowerCase());
+              }
+          })
+          : true;
+    }
+
+    const shouldItemBeShown = (item) => {
+        return (matchesNameSelector(item) && matchesSourceSelector(item) && matchesCategorySelector(item)  && matchesTextFilter(item));
     };
 
     return (
         <div className="facts">
+            <div className="overview">
+                <ul className="overview-list">
+                    <li className="result"><label>Facts </label><span className="text-large">{Object.keys(sortedItems).length}</span></li>
+                </ul>
+            </div>
+            <div className="filters-wrapper">
+                <div className="select-filters">
+                    <SelectFilter
+                      title="Name"
+                      loading={!names}
+                      options={names && nameOptions(names)}
+                      onFilterChange={handleNameChange}
+                      isMulti
+                    />
+                    <SelectFilter
+                      title="Source"
+                      loading={!sources}
+                      options={sources && sourceOptions(sources)}
+                      onFilterChange={handleSourceChange}
+                      isMulti
+                    />
+                    <SelectFilter
+                      title="Category"
+                      loading={!categories}
+                      options={categories && categoryOptions(categories)}
+                      onFilterChange={handleCategoryChange}
+                      isMulti
+                    />
+                </div>
+            </div>
             <div className="filters">
                 <input type="text" id="filter" placeholder="Filter facts e.g. PHP version"
                        value={factTerm}
@@ -59,6 +164,13 @@ const Facts = ({ facts }) => {
                     Source
                 </button>
                 <button
+                  type="button"
+                  onClick={() => handleSort('category')}
+                  className={`button-sort value ${getClassNamesFor('category')}`}
+                >
+                    Category
+                </button>
+                <button
                     type="button"
                     onClick={() => handleSort('value')}
                     className={`button-sort value ${getClassNamesFor('value')}`}
@@ -66,9 +178,17 @@ const Facts = ({ facts }) => {
                     Value
                 </button>
             </div>
-            <div className="data-table">
-                {!sortedItems.filter(fact => filterResults(fact)).length && <div className="data-none">No Facts</div>}
-                {sortedItems.filter(fact => filterResults(fact)).map((fact) => {
+            <div className="facts-container">
+                {sortedItems.filter(item => shouldItemBeShown(item)).length == 0 &&
+                <div className="data-table">
+                    <div className="data-none">
+                        No Facts
+                    </div>
+                </div>
+                }
+                {sortedItems
+                  .filter(item => shouldItemBeShown(item))
+                  .map((fact) => {
                     return (
                         <div className="data-row row-heading" key={fact.id}>
                             <div className="col col-1">
@@ -76,6 +196,7 @@ const Facts = ({ facts }) => {
                                 <div className="description">{fact.description}</div>
                             </div>
                             <div className="col col-2">{fact.source}</div>
+                            <div className="col col-2">{fact.category}</div>
                             <div className="col col-3">{fact.value}</div>
                         </div>
                     );
@@ -101,6 +222,40 @@ const Facts = ({ facts }) => {
                   padding-left: 20px;
                   @media ${bp.wideUp} {
                     display: block;
+                  }
+                }
+              }
+              
+              .text-large {
+                font-size: 1.4em;
+              }
+                
+              .overview {
+                .overview-list {
+                  display: flex;
+                  justify-content: space-between;
+                  padding: 10px 20px;
+                  margin: 0 0 20px;
+                  background: #f3f3f3;
+            
+                  li.result {
+                    display: flex;
+                    flex-direction: column;
+                    margin: 0;
+                  }
+                }
+              }
+              
+              .filters-wrapper { 
+                .select-filters {
+                  display: flex;
+                  flex-direction: column;
+                  @media ${bp.wideUp} {
+                    flex-flow: row;
+                  }
+        
+                  &:first-child {
+                    padding-bottom: 1em;
                   }
                 }
               }
@@ -204,6 +359,15 @@ const Facts = ({ facts }) => {
                   font-style: italic;
                   font-size: 12px;
                 }
+              }
+
+              .data-none {
+                border: 1px solid ${color.white};
+                border-bottom: 1px solid ${color.lightestGrey};
+                border-radius: 3px;
+                line-height: 1.5rem;
+                padding: 8px 0 7px 0;
+                text-align: center;
               }
 
               .row-heading {

--- a/services/ui/src/components/Facts/index.stories.js
+++ b/services/ui/src/components/Facts/index.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Facts from './index';
+import mocks, { generator } from 'api/src/mocks';
+
+export default {
+  component: Facts,
+  title: 'Components/Facts',
+}
+
+export const Default = () => (
+  <Facts facts={generator(mocks.Fact, 1, 20)} />
+);
+
+export const NoFacts = () => (
+  <Facts facts={[]} />
+);

--- a/services/ui/src/components/Problems/index.js
+++ b/services/ui/src/components/Problems/index.js
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery } from "@apollo/react-hooks";
-import getSeverityEnumQuery, {getProjectOptions, getSourceOptions} from 'components/Filters/helpers';
 import { bp, color, fontSize } from 'lib/variables';
 import useSortableProblemsData from './sortedItems';
 import Problem from "components/Problem";

--- a/services/ui/src/lib/fragment/Fact.js
+++ b/services/ui/src/lib/fragment/Fact.js
@@ -7,5 +7,6 @@ export default gql`
     value
     source
     description
+    category
   }
 `;

--- a/services/ui/src/pages/stories/facts.stories.js
+++ b/services/ui/src/pages/stories/facts.stories.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { PageFacts as Facts } from '../facts';
+
+export default {
+  component: Facts,
+  title: 'Pages/Facts',
+}
+
+export const Default = () => (
+  <Facts
+    router={{
+      query: {
+        openshiftProjectName: 'Example',
+        taskId: 42,
+      },
+    }}
+  />
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "ES6",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "jsx": "react"
   }
 }


### PR DESCRIPTION
This PR adds an additional 'category' field to the environment_fact table, and updates the facts tab within the UI to have better filtering of facts.

![image](https://user-images.githubusercontent.com/2339381/116044864-53a48580-a669-11eb-86a9-566911f7dc22.png)

UI Changes (Storybook)
https://60769903564d9a0021321655-tgwpdhwlld.chromatic.com/?path=/story/components-facts--default

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
