### PR TITLE
Revert "harbor2 returns robotAccount tokens as "secret""

### DIFF
--- a/services/api/src/resources/project/harborSetup.ts
+++ b/services/api/src/resources/project/harborSetup.ts
@@ -69,7 +69,7 @@ async function createHarborProject(sqlClient: MariaClient, harborClient, lagoonP
     } else {
       results = res.body
     }
-
+    
     // Search array of objects for correct project
     for (let proj of results) {
       if (proj.name == lagoonProjectName) {
@@ -261,7 +261,7 @@ export const createHarborOperations = (sqlClient /* : MariaSQL */) => ({
     // Set required Lagoon env vars to enable Harbor on this project
     if (! await addEnvVar(sqlClient, lagoonProjectName, "INTERNAL_REGISTRY_URL", lagoonHarborRoute, "INTERNAL_CONTAINER_REGISTRY", projectID)) {return}
     if (! await addEnvVar(sqlClient, lagoonProjectName, "INTERNAL_REGISTRY_USERNAME", harborTokenInfo.name, "INTERNAL_CONTAINER_REGISTRY", projectID)) {return}
-    if (! await addEnvVar(sqlClient, lagoonProjectName, "INTERNAL_REGISTRY_PASSWORD", harborTokenInfo.secret, "INTERNAL_CONTAINER_REGISTRY", projectID)) {return}
+    if (! await addEnvVar(sqlClient, lagoonProjectName, "INTERNAL_REGISTRY_PASSWORD", harborTokenInfo.token, "INTERNAL_CONTAINER_REGISTRY", projectID)) {return}
 
     // Reset harbor project webhook to point to this Lagoon's Harbor
     if (! await resetHarborWebhook(sqlClient, harborClient, lagoonProjectName, lagoonWebhookAddress, harborProjectID)) {return}


### PR DESCRIPTION
This reverts commit ab6b71de5914620b55d9d358a84e38d02138109a.

Harbor 2.1 still uses `token` in the response, even though the documentation claims it's `secret` (which is the case in Harbor 2.2)