### PR TITLE
Harbor 1.x Registry HA Support

### DIFF
--- a/services/harborregistry/harborregistry.yml
+++ b/services/harborregistry/harborregistry.yml
@@ -188,6 +188,12 @@ objects:
             initialDelaySeconds: 1
             periodSeconds: 10
           args: ["serve", "/etc/registry/config.yml"]
+          env:
+            - name: REGISTRY_HTTP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: HARBOR_REGISTRY_SECRET
+                  name: harborregistry-secret
           envFrom:
           - secretRef:
               name: ${SERVICE_NAME} # harborregistry
@@ -199,7 +205,7 @@ objects:
           volumeMounts:
           - name: registry-data
             mountPath: /storage
-            subPath: 
+            subPath:
           - name: registry-root-certificate
             mountPath: /etc/registry/root.crt
             subPath: tls.crt
@@ -248,7 +254,7 @@ objects:
           volumeMounts:
           - name: registry-data
             mountPath: /storage
-            subPath: 
+            subPath:
           - name: registry-config
             mountPath: /etc/registry/pre_config.yml
             subPath: config.yml


### PR DESCRIPTION
# Checklist

- [X] Affected Issues have been mentioned in the Closing issues section
- [] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR adds an environment variable to Harbor's registry container, `REGISTRY_HTTP_SECRET`, which allows for multiple copies of the Harbor registry pod to run behind a load balancer.
