### PR TITLE
Changes permission check logic for AddFacts

### DIFF
--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -82,19 +82,24 @@ export const addFacts = async (
   { sqlClient, hasPermission }
 ) => {
 
-  // We first check that the user has access to all of the environments, so this is an atomic operation.
-  await facts.map(async (fact) => {
-    const { environment } = fact;
-    const env = await environmentHelpers(sqlClient).getEnvironmentById(environment);
+  const environments = facts.reduce((environmentList, fact) => {
+    let { environment } = fact;
+    if(!environmentList.includes(environment)) {
+      environmentList.push(environment)
+    }
+    return environmentList
+  }, []);
 
+  for(let i = 0; i < environments.length; i++) {
+    const env = await environmentHelpers(sqlClient).getEnvironmentById(environments[i]);
     await hasPermission('fact', 'add', {
       project: env.project,
     });
-  });
+  }
 
-  return await facts.map(async (fact) => {
-    const { environment, name, value, source, description } = fact;
-
+  const returnFacts = []
+  for(let i = 0; i < facts.length; i++) {
+    const { environment, name, value, source, description } = facts[i];
     const {
       info: { insertId },
     } = await query(
@@ -109,8 +114,10 @@ export const addFacts = async (
     );
 
     const rows =  await query(sqlClient, Sql.selectFactByDatabaseId(insertId));
-    return R.prop(0, rows);
-  });
+    returnFacts.push(R.prop(0, rows));
+  }
+
+  return returnFacts;
 };
 
 export const deleteFact = async (

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -84,24 +84,26 @@ export const addFacts = async (
 
   const environments = facts.reduce((environmentList, fact) => {
     let { environment } = fact;
-    if(!environmentList.includes(environment)) {
-      environmentList.push(environment)
+    if (!environmentList.includes(environment)) {
+      environmentList.push(environment);
     }
-    return environmentList
+    return environmentList;
   }, []);
 
-  for(let i = 0; i < environments.length; i++) {
-    const env = await environmentHelpers(sqlClient).getEnvironmentById(environments[i]);
+  for (let i = 0; i < environments.length; i++) {
+    const env = await environmentHelpers(sqlClient).getEnvironmentById(
+      environments[i]
+    );
     await hasPermission('fact', 'add', {
-      project: env.project,
+      project: env.project
     });
   }
 
-  const returnFacts = []
-  for(let i = 0; i < facts.length; i++) {
+  const returnFacts = [];
+  for (let i = 0; i < facts.length; i++) {
     const { environment, name, value, source, description } = facts[i];
     const {
-      info: { insertId },
+      info: { insertId }
     } = await query(
       sqlClient,
       Sql.insertFact({
@@ -110,10 +112,10 @@ export const addFacts = async (
         value,
         source,
         description
-      }),
+      })
     );
 
-    const rows =  await query(sqlClient, Sql.selectFactByDatabaseId(insertId));
+    const rows = await query(sqlClient, Sql.selectFactByDatabaseId(insertId));
     returnFacts.push(R.prop(0, rows));
   }
 


### PR DESCRIPTION
Currently, the `AddFacts` resolver is doing a keycloak call for every fact pushed through to it. This is potentially overwhelming the API and keycloak.

This PR simplifies this to only check keycloak once per environment per call. It also serializes writes to the DB for facts.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

closes #2663 
