### PR TITLE
Allow Drush Cache Clear task for Drupal 9

### DIFF
--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -345,10 +345,10 @@ export const taskDrushCacheClear: ResolverFn = async (
 
   const command =
     'drupal_version=$(drush status drupal-version --format=list) && \
-  if [ ${drupal_version%.*.*} == "8" ] || [ ${drupal_version%.*.*} == "9" ]; then \
-    drush cr; \
-  elif [ ${drupal_version%.*} == "7" ]; then \
+  if [ ${drupal_version%.*} == "7" ]; then \
     drush cc all; \
+  elif [ ${drupal_version%.*.*} -ge "8" ] ; then \
+    drush cr; \
   else \
     echo "could not clear cache for found Drupal Version ${drupal_version}"; \
     exit 1; \

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -345,7 +345,7 @@ export const taskDrushCacheClear: ResolverFn = async (
 
   const command =
     'drupal_version=$(drush status drupal-version --format=list) && \
-  if [ ${drupal_version%.*.*} == "8" ]; then \
+  if [ ${drupal_version%.*.*} == "8" ] || [ ${drupal_version%.*.*} == "9" ]; then \
     drush cr; \
   elif [ ${drupal_version%.*} == "7" ]; then \
     drush cc all; \


### PR DESCRIPTION
The Drush cache clear task is hardcoded to check for Drupal 7 or 8 - this PR just adds D9 to trigger the `drush cr` task.