### PR TITLE
Lagoon 2 - Changes permission check logic for AddFacts

### DIFF
--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -66,21 +66,23 @@ export const addFacts: ResolverFn = async (
 
   const environments = facts.reduce((environmentList, fact) => {
     let { environment } = fact;
-    if(!environmentList.includes(environment)) {
-      environmentList.push(environment)
+    if (!environmentList.includes(environment)) {
+      environmentList.push(environment);
     }
-    return environmentList
+    return environmentList;
   }, []);
 
-  for(let i = 0; i < environments.length; i++) {
-    const env = await environmentHelpers(sqlClientPool).getEnvironmentById(environments[i]);
+  for (let i = 0; i < environments.length; i++) {
+    const env = await environmentHelpers(sqlClientPool).getEnvironmentById(
+      environments[i]
+    );
     await hasPermission('fact', 'add', {
       project: env.project
     });
   }
 
-  const returnFacts = []
-  for(let i = 0; i < facts.length; i++) {
+  const returnFacts = [];
+  for (let i = 0; i < facts.length; i++) {
     const { environment, name, value, source, description } = facts[i];
     const {
       insertId

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -63,22 +63,28 @@ export const addFacts: ResolverFn = async (
   { input: { facts } },
   { sqlClientPool, hasPermission }
 ) => {
-  // We first check that the user has access to all of the environments, so this is an atomic operation.
-  await facts.map(async fact => {
-    const { environment } = fact;
-    const env = await environmentHelpers(sqlClientPool).getEnvironmentById(
-      environment
-    );
 
+  const environments = facts.reduce((environmentList, fact) => {
+    let { environment } = fact;
+    if(!environmentList.includes(environment)) {
+      environmentList.push(environment)
+    }
+    return environmentList
+  }, []);
+
+  for(let i = 0; i < environments.length; i++) {
+    const env = await environmentHelpers(sqlClientPool).getEnvironmentById(environments[i]);
     await hasPermission('fact', 'add', {
       project: env.project
     });
-  });
+  }
 
-  return await facts.map(async fact => {
-    const { environment, name, value, source, description } = fact;
-
-    const { insertId } = await query(
+  const returnFacts = []
+  for(let i = 0; i < facts.length; i++) {
+    const { environment, name, value, source, description } = facts[i];
+    const {
+      insertId
+    } = await query(
       sqlClientPool,
       Sql.insertFact({
         environment,
@@ -89,12 +95,11 @@ export const addFacts: ResolverFn = async (
       })
     );
 
-    const rows = await query(
-      sqlClientPool,
-      Sql.selectFactByDatabaseId(insertId)
-    );
-    return R.prop(0, rows);
-  });
+    const rows =  await query(sqlClientPool, Sql.selectFactByDatabaseId(insertId));
+    returnFacts.push(R.prop(0, rows));
+  }
+
+  return returnFacts;
 };
 
 export const deleteFact: ResolverFn = async (


### PR DESCRIPTION
DUPLICATING WORK ALREADY MERGED INTO `master`

Currently, the AddFacts resolver is doing a keycloak call for every fact pushed through to it. This is potentially overwhelming the API and keycloak.

This PR simplifies this to only check keycloak once per environment per call. It also serializes writes to the DB for facts.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied


# Closing issues

closes #2663
