### PR TITLE
update docker used in Lagoon from 19.03 to 20.10

### DIFF
--- a/images/docker-host/Dockerfile
+++ b/images/docker-host/Dockerfile
@@ -1,7 +1,7 @@
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest} as commons
-FROM docker:19.03.15-dind
+FROM docker:20.10.7-dind
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=docker-host

--- a/images/kubectl/Dockerfile
+++ b/images/kubectl/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.16-alpine3.13 as golang
 RUN apk add --no-cache git
 RUN go get github.com/a8m/envsubst/cmd/envsubst
 
-FROM docker:19.03.15
+FROM docker:20.10.7
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=oc

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.16-alpine3.13 as golang
 RUN apk add --no-cache git
 RUN go get github.com/a8m/envsubst/cmd/envsubst
 
-FROM docker:19.03.15
+FROM docker:20.10.7
 
 LABEL maintainer="amazee.io"
 ENV LAGOON=oc


### PR DESCRIPTION
closes #2714 #2458 