### PR TITLE
Adds webhook notification to resolver type

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -270,6 +270,7 @@ const resolvers = {
     ROCKETCHAT: 'rocketchat',
     MICROSOFTTEAMS: 'microsoftteams',
     EMAIL: 'email',
+    WEBHOOK: 'webhook',
   },
   NotificationContentType: {
     DEPLOYMENT: 'deployment',

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -112,9 +112,6 @@ export const addNotificationToProject: ResolverFn = async (
     unformattedInput
   );
 
-    console.log(unformattedInput);
-    console.log(input);
-
   const pid = await projectHelpers(sqlClientPool).getProjectIdByName(
     input.project
   );


### PR DESCRIPTION
Currently there's a table name resolution issue because of the way that knex converts names to snake_case, this was happening because the new webhook service wasn't part of the NotificationType resolver type.

This PR remedies this.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

