### PR TITLE
Split out some more of the features-kubernetes tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -954,7 +954,7 @@ KIND_VERSION = v0.11.1
 GOJQ_VERSION = v0.12.3
 CHART_TESTING_VERSION = v3.4.0
 KIND_IMAGE = kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
-TESTS = [api,features-kubernetes,features-kubernetes-2,active-standby-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
+TESTS = [api,features-kubernetes,features-kubernetes-2,features-api-variables,active-standby-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch]
 CHARTS_TREEISH = main
 
 local-dev/kind:

--- a/tests/tests/features-api-variables.yaml
+++ b/tests/tests/features-api-variables.yaml
@@ -1,0 +1,58 @@
+---
+- include: features/random-wait.yaml
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}
+    git_repo_name: features.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: api/add-environment.yaml
+  vars:
+    name: lagoon-api-variables
+    project: ci-features-api-variables-{{ cluster_type }}
+    environmentType: PRODUCTION
+
+- include: api/add-project-variable.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}
+    envName: "LAGOON_API_VARIABLE_PROJECT"
+    envValue: "4A65DC68F2"
+    envScope: "GLOBAL"
+
+- include: api/add-project-variable.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}
+    envName: "LAGOON_API_VARIABLE_OVERRIDE"
+    envValue: "74B3E42B54"
+    envScope: "GLOBAL"
+
+- include: api/add-project-variable.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}
+    envName: "LAGOON_API_VARIABLE_BUILD"
+    envValue: "AEF177FCF4"
+    envScope: "BUILD"
+
+- include: api/add-project-variable.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}
+    envName: "LAGOON_API_VARIABLE_RUNTIME"
+    envValue: "90AEC657F8"
+    envScope: "RUNTIME"
+
+- include: features/lagoon-api-variables.yaml
+  vars:
+    testname: "LAGOON API VARIABLES {{ cluster_type|upper }}"
+    git_repo_name: features.git
+    project: ci-features-api-variables-{{ cluster_type }}
+    branch: lagoon-api-variables
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-features-api-variables-{{ cluster_type }}

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -11,61 +11,6 @@
     git_repo_name: features.git
     git_url: "{{ localgit_url }}/{{ git_repo_name }}"
 
-- include: api/add-environment.yaml
-  vars:
-    name: lagoon-api-variables
-    project: ci-features-{{ cluster_type }}
-    environmentType: PRODUCTION
-
-- include: api/add-project-variable.yaml
-  vars:
-    project: ci-features-{{ cluster_type }}
-    envName: "LAGOON_API_VARIABLE_PROJECT"
-    envValue: "4A65DC68F2"
-    envScope: "GLOBAL"
-
-- include: api/add-project-variable.yaml
-  vars:
-    project: ci-features-{{ cluster_type }}
-    envName: "LAGOON_API_VARIABLE_OVERRIDE"
-    envValue: "74B3E42B54"
-    envScope: "GLOBAL"
-
-- include: api/add-project-variable.yaml
-  vars:
-    project: ci-features-{{ cluster_type }}
-    envName: "LAGOON_API_VARIABLE_BUILD"
-    envValue: "AEF177FCF4"
-    envScope: "BUILD"
-
-- include: api/add-project-variable.yaml
-  vars:
-    project: ci-features-{{ cluster_type }}
-    envName: "LAGOON_API_VARIABLE_RUNTIME"
-    envValue: "90AEC657F8"
-    envScope: "RUNTIME"
-
-# - include: api/add-project-variable.yaml
-#   vars:
-#     project: ci-features-{{ cluster_type }}
-#     envName: "LAGOON_API_VARIABLE_MULTILINE_SPACED"
-#     envValue: "-----BEGIN PUBLIC KEY-----\\\\nB10B03D8DB7F\\\\n-----END PUBLIC KEY-----"
-#     envScope: "GLOBAL"
-
-# - include: api/add-environment-variable.yaml
-#   vars:
-#     project: ci-features-{{ cluster_type }}
-#     envName:"LAGOON_API_VARIABLE_ENVIRONMENT"
-#     envValue: "EA2AFAE09B"
-#     envScope: "GLOBAL"
-
-# - include: api/add-environment-variable.yaml
-#   vars:
-#     project: ci-features-{{ cluster_type }}
-#     envName: "LAGOON_API_VARIABLE_OVERRIDE"
-#     envValue: "D0CE76D4C9"
-#     envScope: "GLOBAL"
-
 - include: features/fastly-annotations.yaml
   vars:
     testname: "FASTLY ANNOTATIONS {{ cluster_type|upper }}"
@@ -222,14 +167,6 @@
 # #     git_repo_name: node.git
 # #     project: ci-env-limit
 # #     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
-
-- include: features/lagoon-api-variables.yaml
-  vars:
-    testname: "LAGOON API VARIABLES {{ cluster_type|upper }}"
-    git_repo_name: features.git
-    project: ci-features-{{ cluster_type }}
-    branch: lagoon-api-variables
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
 
 - include: api/delete-project.yaml
   vars:


### PR DESCRIPTION

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

I was trying to understand how the tests have been made self-contained and so tried to split them up a bit more to see how it worked. To my surprise the branch went green in CI, so here's the patch.

I really like this method of splitting up the tests! :tada: 

This change makes it easier to run tests concurrently, and therefore faster.

# Closing issues

n/a
