### PR TITLE
readd  install-tests routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1150,6 +1150,10 @@ kind/retest:
 			&& docker push $$IMAGE_REGISTRY/$$image:$(SAFE_BRANCH_NAME); \
 		done \
 		&& cd lagoon-charts.kind.lagoon \
+		&& $(MAKE) install-tests TESTS=$(TESTS) IMAGE_TAG=$(SAFE_BRANCH_NAME) \
+			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
+			JQ=$$(realpath ../local-dev/jq) \
+			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \


### PR DESCRIPTION
without the install-tests routine in the middle of `kind/retest`, each subsequent retest will only run the originally specified $TESTS from `kind/test`

the install-tests routine updates the helm values template to ensure that only the specified tests are run.  We can probably tighten this, but readding functionality for now.

Fixes error introduced in #2713 