### PR TITLE
Custom Backup Schedules and Hourly Backup Retention Support

### DIFF
--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -183,25 +183,25 @@ Drupal & Drush 9: Sync database & files from master environment:
 
 ### `backup-retention.production.monthly`
 
-Specify the number of monthly backups our system should retain for your project's production environment(s).
+Specify the number of monthly backups Lagoon should retain for your project's production environment(s).
 
 The global default is `1` if this value is not specified.
 
 ### `backup-retention.production.weekly`
 
-Specify the number of weekly backups our system should retain for your project's production environment(s).
+Specify the number of weekly backups Lagoon should retain for your project's production environment(s).
 
 The global default is `6` if this value is not specified.
 
 ### `backup-retention.production.daily`
 
-Specify the number of daily backups our system should retain for your project's production environment(s).
+Specify the number of daily backups Lagoon should retain for your project's production environment(s).
 
 The global default is `7` if this value is not specified.
 
 ### `backup-retention.production.hourly`
 
-Specify the number of hourly backups our system should retain for your project's production environment(s).
+Specify the number of hourly backups Lagoon should retain for your project's production environment(s).
 
 The global default is `0` if this value is not specified.
 

--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -179,6 +179,26 @@ Drupal & Drush 9: Sync database & files from master environment:
         service: cli
 ```
 
+## Backup Retention
+
+### `backup-retention.production.monthly`
+
+Specify the number of monthly backups our system should retain for your project's production environment(s). The default is `1` if this value is not specified.
+
+### `backup-retention.production.weekly`
+
+Specify the number of weekly backups our system should retain for your project's production environment(s). The default is `6` if this value is not specified.
+
+### `backup-retention.production.daily`
+
+Specify the number of daily backups our system should retain for your project's production environment(s). The default is `7` if this value is not specified.
+
+## Backup Schedule
+
+### `backup-schedule.production`
+
+Specify the schedule for which backups will be ran for this project. Accepts cron compatible syntax with the notable exception that the `Minute` block must be the letter `M`. This allows Lagoon to randomly choose a specific minute for these backups to happen, while users can specify the remainder of the schedule down to the hour.
+
 ## Routes
 
 {% embed url="https://www.youtube.com/watch?v=vQxh87F3fW4&list=PLOM3iGqJj\_UdTtl4eVDszI9VgGW9Dcefd&index=4" caption="" %}

--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -183,21 +183,35 @@ Drupal & Drush 9: Sync database & files from master environment:
 
 ### `backup-retention.production.monthly`
 
-Specify the number of monthly backups our system should retain for your project's production environment(s). The default is `1` if this value is not specified.
+Specify the number of monthly backups our system should retain for your project's production environment(s).
+
+The global default is `1` if this value is not specified.
 
 ### `backup-retention.production.weekly`
 
-Specify the number of weekly backups our system should retain for your project's production environment(s). The default is `6` if this value is not specified.
+Specify the number of weekly backups our system should retain for your project's production environment(s).
+
+The global default is `6` if this value is not specified.
 
 ### `backup-retention.production.daily`
 
-Specify the number of daily backups our system should retain for your project's production environment(s). The default is `7` if this value is not specified.
+Specify the number of daily backups our system should retain for your project's production environment(s).
+
+The global default is `7` if this value is not specified.
+
+### `backup-retention.production.hourly`
+
+Specify the number of hourly backups our system should retain for your project's production environment(s).
+
+The global default is `0` if this value is not specified.
 
 ## Backup Schedule
 
 ### `backup-schedule.production`
 
-Specify the schedule for which backups will be ran for this project. Accepts cron compatible syntax with the notable exception that the `Minute` block must be the letter `M`. This allows Lagoon to randomly choose a specific minute for these backups to happen, while users can specify the remainder of the schedule down to the hour.
+Specify the schedule for which backups will be ran for this project. Accepts cron compatible syntax with the notable exception that the `Minute` block must be the letter `M`. Any other value in the `Minute` block will cause the Lagoon build to fail. This allows Lagoon to randomly choose a specific minute for these backups to happen, while users can specify the remainder of the schedule down to the hour.
+
+The global default is `M H(22-2) * * *` if this value is not specified. Take note that these backups will use the cluster's local timezone.
 
 ## Routes
 

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -1331,9 +1331,6 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
     BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "${DEFAULT_BACKUP_SCHEDULE}")
   fi
 
-  # Convert magic cron definition to crontab
-  BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "${DEFAULT_BACKUP_SCHEDULE}")
-
   if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
     CHECK_SCHEDULE="@weekly-random"

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -64,6 +64,30 @@ for CAPABILITIES in "${CAPABILITIES[@]}"; do
   HELM_ARGUMENTS+=(-a "${CAPABILITIES}")
 done
 
+# Implement global default values for backup retention periods
+if [ -z "$MONTHLY_BACKUP_DEFAULT_RETENTION" ]
+then
+  MONTHLY_BACKUP_DEFAULT_RETENTION=1
+fi
+if [ -z "$WEEKLY_BACKUP_DEFAULT_RETENTION" ]
+then
+  WEEKLY_BACKUP_DEFAULT_RETENTION=6
+fi
+if [ -z "$DAILY_BACKUP_DEFAULT_RETENTION" ]
+then
+  DAILY_BACKUP_DEFAULT_RETENTION=7
+fi
+if [ -z "$HOURLY_BACKUP_DEFAULT_RETENTION" ]
+then
+  HOURLY_BACKUP_DEFAULT_RETENTION=0
+fi
+
+# Implement global default value for backup schedule
+if [ -z "$DEFAULT_BACKUP_SCHEDULE" ]
+then
+  DEFAULT_BACKUP_SCHEDULE="M H(22-2) * * *"
+fi
+
 set -x
 
 set +x # reduce noise in build logs
@@ -1242,6 +1266,10 @@ else
   done
 fi
 
+##############################################
+### Backup Settings
+##############################################
+
 # If k8up is supported by this cluster we create the schedule definition
 if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
 
@@ -1266,26 +1294,45 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
   PRODUCTION_MONTHLY_BACKUP_RETENTION=$(cat .lagoon.yml | shyaml get-value backup-retention.production.monthly "")
   PRODUCTION_WEEKLY_BACKUP_RETENTION=$(cat .lagoon.yml | shyaml get-value backup-retention.production.weekly "")
   PRODUCTION_DAILY_BACKUP_RETENTION=$(cat .lagoon.yml | shyaml get-value backup-retention.production.daily "")
+  PRODUCTION_HOURLY_BACKUP_RETENTION=$(cat .lagoon.yml | shyaml get-value backup-retention.production.hourly "")
 
   # Set template parameters for retention values (prefer .lagoon.yml values over supplied defaults after ensuring they are valid integers via "-eq" comparison)
-  if [ ! -z $PRODUCTION_MONTHLY_BACKUP_RETENTION ] && [ "$PRODUCTION_MONTHLY_BACKUP_RETENTION" -eq "$PRODUCTION_MONTHLY_BACKUP_RETENTION" ] && [ $ENVIRONMENT_TYPE = 'production' ]; then
+  if [[ ! -z $PRODUCTION_MONTHLY_BACKUP_RETENTION ]] && [[ "$PRODUCTION_MONTHLY_BACKUP_RETENTION" -eq "$PRODUCTION_MONTHLY_BACKUP_RETENTION" ]] && [[ $ENVIRONMENT_TYPE = 'production' ]]; then
     MONTHLY_BACKUP_RETENTION=${PRODUCTION_MONTHLY_BACKUP_RETENTION}
   else
     MONTHLY_BACKUP_RETENTION=${MONTHLY_BACKUP_DEFAULT_RETENTION}
   fi
-  if [ ! -z $PRODUCTION_WEEKLY_BACKUP_RETENTION ] && [ "$PRODUCTION_WEEKLY_BACKUP_RETENTION" -eq "$PRODUCTION_WEEKLY_BACKUP_RETENTION" ] && [ $ENVIRONMENT_TYPE = 'production' ]; then
+  if [[ ! -z $PRODUCTION_WEEKLY_BACKUP_RETENTION ]] && [[ "$PRODUCTION_WEEKLY_BACKUP_RETENTION" -eq "$PRODUCTION_WEEKLY_BACKUP_RETENTION" ]] && [[ $ENVIRONMENT_TYPE = 'production' ]]; then
     WEEKLY_BACKUP_RETENTION=${PRODUCTION_WEEKLY_BACKUP_RETENTION}
   else
     WEEKLY_BACKUP_RETENTION=${WEEKLY_BACKUP_DEFAULT_RETENTION}
   fi
-  if [ ! -z $PRODUCTION_DAILY_BACKUP_RETENTION ] && [ "$PRODUCTION_DAILY_BACKUP_RETENTION" -eq "$PRODUCTION_DAILY_BACKUP_RETENTION" ] && [ $ENVIRONMENT_TYPE = 'production' ]; then
+  if [[ ! -z $PRODUCTION_DAILY_BACKUP_RETENTION ]] && [[ "$PRODUCTION_DAILY_BACKUP_RETENTION" -eq "$PRODUCTION_DAILY_BACKUP_RETENTION" ]] && [[ $ENVIRONMENT_TYPE = 'production' ]]; then
     DAILY_BACKUP_RETENTION=${PRODUCTION_DAILY_BACKUP_RETENTION}
   else
     DAILY_BACKUP_RETENTION=${DAILY_BACKUP_DEFAULT_RETENTION}
   fi
+  if [[ ! -z $PRODUCTION_HOURLY_BACKUP_RETENTION ]] && [[ "$PRODUCTION_HOURLY_BACKUP_RETENTION" -eq "$PRODUCTION_HOURLY_BACKUP_RETENTION" ]] && [[ $ENVIRONMENT_TYPE = 'production' ]]; then
+    HOURLY_BACKUP_RETENTION=${PRODUCTION_HOURLY_BACKUP_RETENTION}
+  else
+    HOURLY_BACKUP_RETENTION=${HOURLY_BACKUP_DEFAULT_RETENTION}
+  fi
 
-  # Run Backups every day at 2200-0200
-  BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "M H(22-2) * * *")
+  # Set template parameters for backup schedule value (prefer .lagoon.yml values over supplied defaults after ensuring they are valid)
+  PRODUCTION_BACKUP_SCHEDULE=$(cat .lagoon.yml | shyaml get-value backup-schedule.production "")
+
+  if [[ ! -z $PRODUCTION_BACKUP_SCHEDULE ]] && [[ $ENVIRONMENT_TYPE = 'production' ]]; then
+    if [[ "$PRODUCTION_BACKUP_SCHEDULE" =~ ^M\  ]]; then
+      BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "${PRODUCTION_BACKUP_SCHEDULE}")
+    else
+      echo "Error parsing custom backup schedule: '$PRODUCTION_BACKUP_SCHEDULE'"; exit 1
+    fi
+  else
+    BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "${DEFAULT_BACKUP_SCHEDULE}")
+  fi
+
+  # Convert magic cron definition to crontab
+  BACKUP_SCHEDULE=$( /kubectl-build-deploy/scripts/convert-crontab.sh "${NAMESPACE}" "${DEFAULT_BACKUP_SCHEDULE}")
 
   if [ ! -z $K8UP_WEEKLY_RANDOM_FEATURE_FLAG ] && [ $K8UP_WEEKLY_RANDOM_FEATURE_FLAG = 'enabled' ]; then
     # Let the controller deduplicate checks (will run weekly at a random time throughout the week)
@@ -1312,7 +1359,8 @@ if [[ "${CAPABILITIES[@]}" =~ "backup.appuio.ch/v1alpha1/Schedule" ]]; then
     --set baasBucketName="${BAAS_BUCKET_NAME}" > $YAML_FOLDER/k8up-lagoon-backup-schedule.yaml \
     --set prune.retention.keepMonthly=$MONTHLY_BACKUP_RETENTION \
     --set prune.retention.keepWeekly=$WEEKLY_BACKUP_RETENTION \
-    --set prune.retention.keepDaily=$DAILY_BACKUP_RETENTION
+    --set prune.retention.keepDaily=$DAILY_BACKUP_RETENTION \
+    --set prune.retention.keepHourly=$HOURLY_BACKUP_RETENTION
 fi
 
 if [ "$(ls -A $YAML_FOLDER/)" ]; then

--- a/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/templates/schedule.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/templates/schedule.yaml
@@ -19,6 +19,7 @@ spec:
     schedule: '{{ .Values.check.schedule }}'
   prune:
     retention:
+      keepHourly: {{ .Values.prune.retention.keepHourly }}
       keepDaily: {{ .Values.prune.retention.keepDaily }}
       keepWeekly: {{ .Values.prune.retention.keepWeekly }}
       keepMonthly: {{ .Values.prune.retention.keepMonthly }}

--- a/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/k8up-schedule/values.yaml
@@ -12,6 +12,7 @@ check:
 
 prune:
   retention:
+    keepHourly: 0
     keepDaily: 7
     keepWeekly: 6
     keepMonthly: 1


### PR DESCRIPTION
 # Checklist

- [X] Affected Issues have been mentioned in the Closing issues section
- [X] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR:
- Adds support for custom backup schedules to be specified via `.lagoon.yml`
- Adds support for custom hourly backup retention settings to be specified via `.lagoon.yml`
- Adds support for a cluster specific backup schedule

# Closing issues

Closes #2679 and #2303 
