### PR TITLE
SQL results are not typecast to strings anymore

### DIFF
--- a/services/api/src/clients/pubSub.ts
+++ b/services/api/src/clients/pubSub.ts
@@ -49,8 +49,7 @@ const createSubscribe = (events): ResolverFn => async (
 
   const filtered = withFilter(
     () => pubSub.asyncIterator(events),
-    (payload, variables) =>
-      payload.environment === String(variables.environment)
+    (payload, variables) => payload.environment === variables.environment
   );
 
   return filtered(rootValue, args, context, info);

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -43,7 +43,7 @@ export const getTasksByEnvironmentId: ResolverFn = async (
         return true;
       }
 
-      return row.id === String(filterId);
+      return row.id === filterId;
     })
     .map((row: any) => {
       if (R.contains('logs', requestedFields)) {
@@ -73,10 +73,7 @@ export const getTaskByRemoteId: ResolverFn = async (
     return null;
   }
 
-  const rowsPerms = await query(
-    sqlClientPool,
-    Sql.selectPermsForTask(task.id)
-  );
+  const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
   await hasPermission('task', 'view', {
     project: R.path(['0', 'pid'], rowsPerms)
   });
@@ -100,10 +97,7 @@ export const getTaskById: ResolverFn = async (
     return null;
   }
 
-  const rowsPerms = await query(
-    sqlClientPool,
-    Sql.selectPermsForTask(task.id)
-  );
+  const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
   await hasPermission('task', 'view', {
     project: R.path(['0', 'pid'], rowsPerms)
   });
@@ -161,7 +155,7 @@ export const addTask: ResolverFn = async (
         service,
         command,
         remoteId,
-        execute: executeRequest,
+        execute: executeRequest
       }
     }
   });
@@ -198,7 +192,7 @@ export const deleteTask: ResolverFn = async (
   userActivityLogger.user_action(`User deleted task '${id}'`, {
     payload: {
       input: {
-        id,
+        id
       }
     }
   });
@@ -314,11 +308,14 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
 -F 0=@$file; rm -rf $file;
 `;
 
-  userActivityLogger.user_action(`User triggered a Drush Archive Dump task on environment '${environmentId}'`, {
-    payload: {
-      environment: environmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush Archive Dump task on environment '${environmentId}'`,
+    {
+      payload: {
+        environment: environmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush archive-dump',
@@ -356,11 +353,14 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
 -F 0=@$file.gz; rm -rf $file.gz
 `;
 
-  userActivityLogger.user_action(`User triggered a Drush SQL Dump task on environment '${environmentId}'`, {
-    payload: {
-      environment: environmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush SQL Dump task on environment '${environmentId}'`,
+    {
+      payload: {
+        environment: environmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush sql-dump',
@@ -401,11 +401,14 @@ export const taskDrushCacheClear: ResolverFn = async (
     exit 1; \
   fi';
 
-  userActivityLogger.user_action(`User triggered a Drush cache clear task on environment '${environmentId}'`, {
-    payload: {
-      environment: environmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush cache clear task on environment '${environmentId}'`,
+    {
+      payload: {
+        environment: environmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush cache-clear',
@@ -435,11 +438,14 @@ export const taskDrushCron: ResolverFn = async (
     project: envPerm.project
   });
 
-  userActivityLogger.user_action(`User triggered a Drush cron task on environment '${environmentId}'`, {
-    payload: {
-      environment: environmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush cron task on environment '${environmentId}'`,
+    {
+      payload: {
+        environment: environmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush cron',
@@ -495,12 +501,15 @@ export const taskDrushSqlSync: ResolverFn = async (
     }
   );
 
-  userActivityLogger.user_action(`User triggered a Drush SQL sync task from '${sourceEnvironmentId}' to '${destinationEnvironmentId}'`, {
-    payload: {
-      sourceEnvironment: sourceEnvironmentId,
-      destinationEnvironment: destinationEnvironmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush SQL sync task from '${sourceEnvironmentId}' to '${destinationEnvironmentId}'`,
+    {
+      payload: {
+        sourceEnvironment: sourceEnvironmentId,
+        destinationEnvironment: destinationEnvironmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: `Sync DB ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
@@ -556,12 +565,15 @@ export const taskDrushRsyncFiles: ResolverFn = async (
     }
   );
 
-  userActivityLogger.user_action(`User triggered an rsync sync task from '${sourceEnvironmentId}' to '${destinationEnvironmentId}'`, {
-    payload: {
-      sourceEnvironment: sourceEnvironmentId,
-      destinationEnvironment: destinationEnvironmentId
+  userActivityLogger.user_action(
+    `User triggered an rsync sync task from '${sourceEnvironmentId}' to '${destinationEnvironmentId}'`,
+    {
+      payload: {
+        sourceEnvironment: sourceEnvironmentId,
+        destinationEnvironment: destinationEnvironmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: `Sync files ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
@@ -591,11 +603,14 @@ export const taskDrushUserLogin: ResolverFn = async (
     project: envPerm.project
   });
 
-  userActivityLogger.user_action(`User triggered a Drush user login task on '${environmentId}'`, {
-    payload: {
-      environment: environmentId
+  userActivityLogger.user_action(
+    `User triggered a Drush user login task on '${environmentId}'`,
+    {
+      payload: {
+        environment: environmentId
+      }
     }
-  });
+  );
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush uli',


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

All result data was typecast to strings in mariasql. There were some places where the code assumed that was true, which was changed with the switch to mariadb.

This fixes #2724 and a similar bug in api subscriptions.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2724 
