### PR TITLE
Don't scan images by default in build/* Makefile targets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     }
     stage ('build images') {
       steps {
-        sh script: "make -O -j$NPROC build", label: "Building images"
+        sh script: "make -O -j$NPROC build SCAN_IMAGES=true", label: "Building images"
       }
     }
     stage ('show trivy scan results') {

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,8 @@ K3D_NAME := k3s-$(shell echo $(CI_BUILD_TAG) | sed -E 's/.*(.{31})$$/\1/')
 BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 SAFE_BRANCH_NAME := $(shell echo $(BRANCH_NAME) | sed -E 's/[^[:alnum:]_.-]//g' | cut -c 1-128)
 
-# Skip image scanning to make building images substantially faster
-SKIP_SCAN := false
+# Skip image scanning by default to make building images substantially faster
+SCAN_IMAGES := false
 
 # Init the file that is used to hold the image tag cross-reference table
 $(shell >build.txt)
@@ -109,7 +109,7 @@ docker_build = DOCKER_SCAN_SUGGEST=false docker build $(DOCKER_BUILD_PARAMS) --b
 
 scan_cmd = docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/root/.cache/ aquasec/trivy --timeout 5m0s $(CI_BUILD_TAG)/$(1) >> scan.txt
 
-ifeq ($(SKIP_SCAN),false)
+ifeq ($(SCAN_IMAGES),true)
 	scan_image = $(scan_cmd)
 else
 	scan_image =


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This speeds up the common case of running `make build/foo` locally without having to also add `SKIP_SCAN=true`.

We do want the scans in Jenkins, so add the parameter to enable that in the Jenkinsfile.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
