### PR TITLE
fix wrong usage of object returned by selectProject()

### DIFF
--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -175,7 +175,7 @@ export const addRestore: ResolverFn = async (
     project: projectData
   };
 
-  userActivityLogger.user_action(`User restored a backup '${backupId}' for project ${projectData.project.name}`, {
+  userActivityLogger.user_action(`User restored a backup '${backupId}' for project ${projectData.name}`, {
     payload: {
       backupId,
       data


### PR DESCRIPTION
causing backup restores not being created
