### PR TITLE
Fix logs2rocketchat routes check

### DIFF
--- a/services/logs2rocketchat/src/readFromRabbitMQ.ts
+++ b/services/logs2rocketchat/src/readFromRabbitMQ.ts
@@ -124,7 +124,10 @@ export async function readFromRabbitMQ (msg: ConsumeMessage, channelWrapperLogs:
       if (meta.logLink){
         text = `${text} [Logs](${meta.logLink})\n`
       }
-      text = `\n${text}${meta.route}\n ${meta.routes.join("\n")}`
+      text = `${text}\n ${meta.route}\n`
+      if (meta.routes) {
+       text = `${text}\n ${meta.routes.join("\n")}`
+      }
       sendToRocketChat(project, text, 'lawngreen', ':white_check_mark:', channelWrapperLogs, msg, appId)
       break;
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

There is an edge case if a message comes through to logs2rocketchat that if is undefined causes the queue to not process any further. This checks if the routes are defined before attempting the join operation on the value.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->


