### PR TITLE
update chromatic action node version to 16

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '16'
       - name: Install dependencies
         run: yarn && yarn --cwd services/api install && yarn --cwd services/api build
       - name: Build storybook

--- a/services/ui/README.md
+++ b/services/ui/README.md
@@ -1,0 +1,1 @@
+# Lagoon UI


### PR DESCRIPTION
Now that Lagoon uses Node16, we can update the node version used in Chromatic's GitHub Action