### PR TITLE
new dev command for api

### DIFF
--- a/local-dev/kubectl-patches/api.yaml
+++ b/local-dev/kubectl-patches/api.yaml
@@ -9,8 +9,10 @@ spec:
         runAsUser: 1000
       containers:
       - name: api
-        command: ["yarn"]
-        args: ["run", "dev"]
+        command:
+          - sh
+          - -c
+          - './node_modules/.bin/tsc-watch --build --incremental --onSuccess "node -r dotenv-extended/config dist/index"'
         volumeMounts:
         - mountPath: "/app/services/api/src"
           name: api-src


### PR DESCRIPTION
https://github.com/uselagoon/lagoon/pull/2763 removed `yarn dev` and introduced a new way to run the api with autoreload, this also brings it into the kind cluster