### PR TITLE
Fix some of the residual OpenDistro Group/Tenant issues

### DIFF
--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -215,6 +215,9 @@ export const OpendistroSecurityOperations = (
     }
   },
   deleteGroup: async function(groupName) {
+    await this.deleteGroupWithSpecificTenant(groupName, groupName);
+  },
+  deleteGroupWithSpecificTenant: async function(groupName, tenantName) {
     // delete groups that have no Projects assigned to them
     try {
       await opendistroSecurityClient.delete(`roles/${groupName}`);
@@ -234,6 +237,6 @@ export const OpendistroSecurityOperations = (
       }
     }
 
-    await this.deleteTenant(groupName);
+    await this.deleteTenant(tenantName);
   }
 });

--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -87,7 +87,7 @@ export const OpendistroSecurityOperations = (
     try {
       // Create a new Tenant for this Group
       await opendistroSecurityClient.put(`tenants/${tenantName}`, { body: { description: `${tenantName}` } });
-      logger.debug(`${groupName}: Created Tentant "${tenantName}"`);
+      logger.debug(`${groupName}: Created Tenant "${tenantName}"`);
     } catch (err) {
       logger.error(`Opendistro-Security create tenant error: ${err}`);
     }
@@ -199,7 +199,7 @@ export const OpendistroSecurityOperations = (
       // Delete the Tenant for this Group
       await opendistroSecurityClient.delete(`tenants/${tenantName}`);
       logger.debug(
-        `${tenantName}: Deleted Opendistro-Security Tentant "${tenantName}"`
+        `${tenantName}: Deleted Opendistro-Security Tenant "${tenantName}"`
       );
     } catch (err) {
       // 404 Errors are expected and mean that the role does not exist

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -451,7 +451,8 @@ export const deleteProject: ResolverFn = async (
       `project-${project.name}`
     );
     await models.GroupModel.deleteGroup(group.id);
-    OpendistroSecurityOperations(sqlClientPool, models.GroupModel).deleteGroup(
+    OpendistroSecurityOperations(sqlClientPool, models.GroupModel).deleteGroupWithSpecificTenant(
+      `p${pid}`,
       group.name
     );
   } catch (err) {

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -342,7 +342,7 @@ export const addProject = async (
   OpendistroSecurityOperations(sqlClientPool, models.GroupModel).syncGroupWithSpecificTenant(
     `p${project.id}`,
     `project-${project.name}`,
-    project.id
+    `${project.id}`
   );
 
   // Find or create a user that has the public key linked to them


### PR DESCRIPTION
1. Tenant spelt without a "t" in the middle :facepalm: 
2. We were seeing an issue in the OpenDistro logs about `groupProjectIDs.split` not being a function - this stringifies the project.id to allow a neat unsplit to remove this error breaking Tenant syncing
```
(node:60) UnhandledPromiseRejectionWarning: TypeError: groupProjectIDs.split is not a function
at /app/services/api/dist/resources/group/opendistroSecurity.js:24:14
at Generator.next (<anonymous>)
at /app/services/api/dist/resources/group/opendistroSecurity.js:8:71
at new Promise (<anonymous>)
at __awaiter (/app/services/api/dist/resources/group/opendistroSecurity.js:4:12)
at Object.syncGroup (/app/services/api/dist/resources/group/opendistroSecurity.js:20:48)
at /app/services/api/dist/resources/project/resolvers.js:258:89
at Generator.next (<anonymous>)
at fulfilled (/app/services/api/dist/resources/project/resolvers.js:5:58)
at process._tickCallback (internal/process/next_tick.js:68:7)
(node:60) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 27)
```
3. After #2768 we changed the name of the roles in OpenDistroSecurity. This PR correctly removes these roles and associated tenants on Project Delete.

Thanks to @bomoko for the pair assist!