### PR TITLE
Trim trailing periods in custom route shortening logic

### DIFF
--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -860,7 +860,8 @@ if [ "${ENVIRONMENT_TYPE}" == "production" ]; then
           if [[ ${#ROUTE_DOMAIN} -gt 53 ]] ; then
             # Trim the route domain to 47 characters, and add an 5 character hash of the domain at the end
             # this gives a total of 53 characters
-            INGRESS_NAME=${ROUTE_DOMAIN:0:47}-$(echo ${ROUTE_DOMAIN} | md5sum | cut -f 1 -d " " | cut -c 1-5)
+            INGRESS_NAME="${ROUTE_DOMAIN:0:47}"
+            INGRESS_NAME="${INGRESS_NAME%%.*}-$(echo "${ROUTE_DOMAIN}" | md5sum | cut -f 1 -d " " | cut -c 1-5)"
           else
             INGRESS_NAME=${ROUTE_DOMAIN}
           fi
@@ -980,7 +981,8 @@ if [ "${ENVIRONMENT_TYPE}" == "production" ]; then
           if [[ ${#ROUTE_DOMAIN} -gt 53 ]] ; then
             # Trim the route domain to 47 characters, and add an 5 character hash of the domain at the end
             # this gives a total of 53 characters
-            INGRESS_NAME=${ROUTE_DOMAIN:0:47}-$(echo ${ROUTE_DOMAIN} | md5sum | cut -f 1 -d " " | cut -c 1-5)
+            INGRESS_NAME="${ROUTE_DOMAIN:0:47}"
+            INGRESS_NAME="${INGRESS_NAME%%.*}-$(echo "${ROUTE_DOMAIN}" | md5sum | cut -f 1 -d " " | cut -c 1-5)"
           else
             INGRESS_NAME=${ROUTE_DOMAIN}
           fi
@@ -1102,7 +1104,8 @@ if [ -n "$(cat .lagoon.yml | shyaml keys ${PROJECT}.environments.${BRANCH//./\\.
       if [[ ${#ROUTE_DOMAIN} -gt 53 ]] ; then
         # Trim the route domain to 47 characters, and add an 5 character hash of the domain at the end
         # this gives a total of 53 characters
-        INGRESS_NAME=${ROUTE_DOMAIN:0:47}-$(echo ${ROUTE_DOMAIN} | md5sum | cut -f 1 -d " " | cut -c 1-5)
+        INGRESS_NAME="${ROUTE_DOMAIN:0:47}"
+        INGRESS_NAME="${INGRESS_NAME%%.*}-$(echo "${ROUTE_DOMAIN}" | md5sum | cut -f 1 -d " " | cut -c 1-5)"
       else
         INGRESS_NAME=${ROUTE_DOMAIN}
       fi
@@ -1222,7 +1225,8 @@ else
       if [[ ${#ROUTE_DOMAIN} -gt 53 ]] ; then
         # Trim the route domain to 47 characters, and add an 5 character hash of the domain at the end
         # this gives a total of 53 characters
-        INGRESS_NAME=${ROUTE_DOMAIN:0:47}-$(echo ${ROUTE_DOMAIN} | md5sum | cut -f 1 -d " " | cut -c 1-5)
+        INGRESS_NAME="${ROUTE_DOMAIN:0:47}"
+        INGRESS_NAME="${INGRESS_NAME%%.*}-$(echo "${ROUTE_DOMAIN}" | md5sum | cut -f 1 -d " " | cut -c 1-5)"
       else
         INGRESS_NAME=${ROUTE_DOMAIN}
       fi


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

We need to trim trailing periods (.) from the shortened ROUTE_DOMAIN
because otherwise we can end up with "foo.-xyz", which is an invalid
subdomain as per RFC 1123.

The old logic could produce an invalid name:
```bash
$ ROUTE_DOMAIN='my-very-long-custom-ingress-domain.uat.example.com'
$ INGRESS_NAME=${ROUTE_DOMAIN:0:47}-$(echo ${ROUTE_DOMAIN} | md5sum | cut -f 1 -d " " | cut -c 1-5); echo $INGRESS_NAME
my-very-long-custom-ingress-domain.uat.example.-0e654
```

The new logic produces a valid name:
```bash
$ ROUTE_DOMAIN='my-very-long-custom-ingress-domain.uat.example.com'
$ INGRESS_NAME="${ROUTE_DOMAIN:0:47}"; echo $INGRESS_NAME; INGRESS_NAME="${INGRESS_NAME%%.*}-$(echo "${ROUTE_DOMAIN}" | md5sum | cut -f 1 -d " " | cut -c 1-5)"; echo $INGRESS_NAME
my-very-long-custom-ingress-domain.uat.example.
my-very-long-custom-ingress-domain-0e654
```

# Closing issues

n/a
