### PR TITLE
Adding check for double dashes in new project names

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -223,6 +223,11 @@ export const addProject = async (
       'Only lowercase characters, numbers and dashes allowed for name!'
     );
   }
+  if (validator.matches(input.name, /--/)) {
+    throw new Error(
+      'Multiple consecutive dashes are not allowed for name!'
+    );
+  }
   if (!isValidGitUrl(input.gitUrl)) {
     throw new Error('The provided gitUrl is invalid.');
   }


### PR DESCRIPTION
This PR adds a check for `--` in any new Lagoon project's name, which will cause the process to fail if this string is found.

# Checklist

- [X] Affected Issues have been mentioned in the Closing issues section
- [X] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

Closes #2783 
