### PR TITLE
 remove ELASTICSEARCH_HOST, use ELASTICSEARCH_URL

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -30,7 +30,6 @@ RUN yarn check --verify-tree
 ENV NODE_ENV=production \
     LOGSDB_ADMIN_PASSWORD=admin \
     KEYCLOAK_ADMIN_PASSWORD=admin \
-    ELASTICSEARCH_HOST=logs-db-service:9200 \
     ELASTICSEARCH_URL=http://logs-db-service:9200 \
     KEYCLOAK_API_CLIENT_SECRET=39d5282d-3684-4026-b4ed-04bbc034b61a \
     HARBOR_ADMIN_PASSWORD=Harbor12345 \

--- a/services/api/src/clients/esClient.ts
+++ b/services/api/src/clients/esClient.ts
@@ -2,7 +2,7 @@ import { Client } from 'elasticsearch';
 import { getConfigFromEnv } from '../util/config';
 
 export const config = {
-  host: getConfigFromEnv('ELASTICSEARCH_HOST', 'logs-db-service:9200'),
+  host: getConfigFromEnv('ELASTICSEARCH_URL', 'http://logs-db-service:9200'),
   user: 'admin',
   pass: getConfigFromEnv('LOGSDB_ADMIN_PASSWORD', '<password not set>')
 };


### PR DESCRIPTION
see also https://github.com/uselagoon/lagoon-charts/pull/307 
currently we have `ELASTICSEARCH_HOST` and `ELASTICSEARCH_URL` which both support a full URL (with scheme and port), so this just uses one variable for everything