### PR TITLE
enable 20MB query cache for keycloak-db

### DIFF
--- a/services/keycloak-db/Dockerfile
+++ b/services/keycloak-db/Dockerfile
@@ -10,3 +10,8 @@ ENV MARIADB_DATABASE=keycloak \
     MARIADB_PASSWORD=keycloak \
     MARIADB_CHARSET=utf8 \
     MARIADB_COLLATION=utf8_general_ci
+
+COPY my_query-cache.cnf /etc/mysql/conf.d/my_query-cache.cnf
+USER root
+RUN chown -R mysql /etc/mysql/conf.d/
+USER mysql

--- a/services/keycloak-db/my_query-cache.cnf
+++ b/services/keycloak-db/my_query-cache.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+
+# This enables the query cache, by default query cache is disabled in lagoon-images
+# but for keycloak it actually makes sense to have it enabled, as there are so many thousand read queries and just
+# a few inserts
+query_cache_size = 20000000
+query_cache_type = 1


### PR DESCRIPTION
This enables the query cache, by default query cache is disabled in lagoon-images
but for keycloak it actually makes sense to have it enabled, as there are so many thousand read queries and just a few inserts