### PR TITLE
add drupal-keepup as optional test routine for local development

### DIFF
--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -172,6 +172,9 @@ The individual routines relevant to Kubernetes are:
 * `nginx`, `node` and `python` run basic tests against those project types.
 * `node-mongodb` runs a single-pod MongoDB test and a MongoDB DBaaS test against a Node.js app.
 
+There is also a routine that provisions a persistent Drupal project and finishes testing.  This is useful for debugging a live project
+* `drupal-keepup` runs a single-pod MariaDB-based Drupal project, with Solr and Varnish.
+
 There are a few other legacy Openshift-specific tests in there that may or may not work with Openshift-based clients.
 
 ## Local Development

--- a/local-dev/api-data-watcher-pusher/api-watch-push.sh
+++ b/local-dev/api-data-watcher-pusher/api-watch-push.sh
@@ -3,9 +3,9 @@
 # inject variables from environment into the GQL template
 envsubst '$GIT_HOST $GIT_PORT $INGRESS_IP $CONSOLE_URL $TOKEN' < /api-data/03-populate-api-data-kubernetes.gql | sponge /api-data/03-populate-api-data-kubernetes.gql
 
-clear_gql_file_path="/api-data/00-clear-api-data.gql"
+# clear_gql_file_path="/api-data/00-clear-api-data.gql"
 populate_general_gql_file_path="/api-data/01-populate-api-data-general.gql"
-populate_openshift_gql_file_path="/api-data/02-populate-api-data-openshift.gql"
+# populate_openshift_gql_file_path="/api-data/02-populate-api-data-openshift.gql"
 populate_kubernetes_gql_file_path="/api-data/03-populate-api-data-kubernetes.gql"
 
 send_graphql_query() {
@@ -25,33 +25,33 @@ send_graphql_query() {
 }
 
 watch_apidatafolder() {
-    chsum_clear_prev=""
+    # chsum_clear_prev=""
     chsum_populate_general_prev=""
-    chsum_populate_openshift_prev=""
+    # chsum_populate_openshift_prev=""
     chsum_populate_kubernetes_prev=""
 
     while [[ true ]]
     do
-        chsum_clear_curr=`md5sum $clear_gql_file_path`
+        # chsum_clear_curr=`md5sum $clear_gql_file_path`
         chsum_populate_general_curr=`md5sum $populate_general_gql_file_path`
-        chsum_populate_openshift_curr=`md5sum $populate_openshift_gql_file_path`
+        # chsum_populate_openshift_curr=`md5sum $populate_openshift_gql_file_path`
         chsum_populate_kubernetes_curr=`md5sum $populate_kubernetes_gql_file_path`
 
         if
-            [[ $chsum_clear_prev != $chsum_clear_curr ]] ||
+            # [[ $chsum_clear_prev != $chsum_clear_curr ]] ||
             [[ $chsum_populate_general_prev != $chsum_populate_general_curr ]] ||
-            [[ $chsum_populate_openshift_prev != $chsum_populate_openshift_curr ]] ||
+            # [[ $chsum_populate_openshift_prev != $chsum_populate_openshift_curr ]] ||
             [[ $chsum_populate_kubernetes_prev != $chsum_populate_kubernetes_curr ]];
         then
             echo "******* Found changes in gql files in /api-data/, clearing and re-populating"
 
-            if
-                send_graphql_query $clear_gql_file_path;
-            then
-                chsum_clear_prev=$chsum_clear_curr
-            else
-                echo '**** ERROR while clearing, will try again.'
-            fi
+            # if
+            #     send_graphql_query $clear_gql_file_path;
+            # then
+            #     chsum_clear_prev=$chsum_clear_curr
+            # else
+            #     echo '**** ERROR while clearing, will try again.'
+            # fi
 
             if
                 send_graphql_query $populate_general_gql_file_path;
@@ -61,13 +61,13 @@ watch_apidatafolder() {
                 echo "**** ERROR while re-populating $populate_general_gql_file_path, will try again."
             fi
 
-            if
-                send_graphql_query $populate_openshift_gql_file_path;
-            then
-                chsum_populate_openshift_prev=$chsum_populate_openshift_curr
-            else
-                echo "**** ERROR while re-populating $populate_openshift_gql_file_path, will try again."
-            fi
+            # if
+            #     send_graphql_query $populate_openshift_gql_file_path;
+            # then
+            #     chsum_populate_openshift_prev=$chsum_populate_openshift_curr
+            # else
+            #     echo "**** ERROR while re-populating $populate_openshift_gql_file_path, will try again."
+            # fi
 
             if
                 send_graphql_query $populate_kubernetes_gql_file_path;

--- a/tests/tests/drupal-keepup.yaml
+++ b/tests/tests/drupal-keepup.yaml
@@ -1,0 +1,22 @@
+---
+- include: features/random-wait.yaml
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/add-project.yaml
+  vars:
+    project: drupal-keepup
+    git_repo_name: drupal-74.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: drupal/drupal-keepup.yaml
+  vars:
+    testname: "Drupal 8 composer PHP 7.4 - MARIADB SINGLE {{ cluster_type|upper }}"
+    drupal_version: 8
+    db: mariadb-single
+    php_version: 7.4
+    git_repo_name: drupal-74.git
+    project: drupal-keepup
+    branch: main

--- a/tests/tests/drupal/drupal-keepup.yaml
+++ b/tests/tests/drupal/drupal-keepup.yaml
@@ -1,0 +1,42 @@
+
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "drupal{{ drupal_version }}-{{ db }}/"
+    docker_files: "drupal{{ drupal_version }}-dockerfiles/php{{ php_version }}/"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml
+
+- include: check-deployed.yaml
+  vars:
+    expected_head: "{{ current_head }}"
+    expected_branch: "{{ branch }}"
+    project: "{{ project }}"
+
+- name: "{{ testname }} - second commit (empty) and git push into same git repo"
+  hosts: localhost
+  serial: 1
+  tasks:
+  - include: ../../tasks/git-empty-commit-push.yaml
+  - set_fact:
+      second_commit_hash: "{{ current_head }}"
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the second commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml


### PR DESCRIPTION
Build a local Lagoon with a running Drupal project like so

`make kind/test TESTS=[drupal-keepup]`

It should also be safe to use with other CI routines as it completes successfully - it just doesn't get torn down after testing completes.