### PR TITLE
Upgrade fluentd and enforce Opensearch compatibility in logs-concentrator

### DIFF
--- a/services/logs-concentrator/Dockerfile
+++ b/services/logs-concentrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.11-1
+FROM fluent/fluentd:v1.13-1
 LABEL maintainer="support@amazee.io"
 
 ARG LAGOON_VERSION

--- a/services/logs-concentrator/Dockerfile
+++ b/services/logs-concentrator/Dockerfile
@@ -8,6 +8,7 @@ USER root
 
 RUN apk add --no-cache --update --virtual .build-deps \
       build-base ruby-dev \
+      && gem install elasticsearch -v '< 7.14' \
       && gem install fluent-plugin-elasticsearch \
       && gem install fluent-plugin-prometheus \
       && gem sources --clear-all \


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The upstream `elasticsearch` gem is not compatible with Opensearch starting from version `7.14`, so limit the gem version used in the `logs-concentrator` to `< 7.14`.

This PR also upgrades the base fluentd image to fix https://github.com/uken/fluent-plugin-elasticsearch/issues/909.

# Closing issues

n/a
