### PR TITLE
correctly fix permissions for my_query-cache.cnf

### DIFF
--- a/services/keycloak-db/Dockerfile
+++ b/services/keycloak-db/Dockerfile
@@ -13,5 +13,5 @@ ENV MARIADB_DATABASE=keycloak \
 
 COPY my_query-cache.cnf /etc/mysql/conf.d/my_query-cache.cnf
 USER root
-RUN chown -R mysql /etc/mysql/conf.d/
+RUN fix-permissions /etc/mysql/conf.d/
 USER mysql


### PR DESCRIPTION
this fixes an error when the keycloak-db is started as rootless (how it is normal during a lagoon-core install), causing the whole testing pipeline to fail.

```2021/08/30 15:47:45 [ ERROR ] Error while parsing '/etc/mysql/conf.d/my_query-cache.cnf': open /etc/mysql/conf.d/my_query-cache.cnf: permission denied```