### PR TITLE
add docker_pull routine to makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
     }
     stage ('build images') {
       steps {
+        sh script: "make -O -j$NPROC docker_pull", label: "Ensuring fresh upstream images"
         sh script: "make -O -j$NPROC build SCAN_IMAGES=true", label: "Building images"
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,9 @@ docker_publish_testlagoon = docker tag $(CI_BUILD_TAG)/$(1) testlagoon/$(2) && d
 # Tags an image with the `uselagoon` repository and pushes it
 docker_publish_uselagoon = docker tag $(CI_BUILD_TAG)/$(1) uselagoon/$(2) && docker push uselagoon/$(2) | cat
 
+.PHONY: docker_pull
+docker_pull:
+	docker images --format "{{.Repository}}:{{.Tag}}" | grep -E '$(UPSTREAM_REPO)' | grep -E '$(UPSTREAM_TAG)' | xargs -L1 docker pull;
 
 #######
 ####### Base Images


### PR DESCRIPTION
This uses the upstream repo and tag to force the system to do a docker pull on those images before a build is run - this will ensure that fresh images are present if they are already in the image cache.

Note that the images used in test runs (testlagoon/* are loaded straight into the harbor registry in Kubernetes so will always be fresh)

This won't fully resolve the issue in #2823, but should mitigate some of it.