### PR TITLE
Reduce test parallelisation, and increase log debuggability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,27 +64,27 @@ pipeline {
       parallel {
         stage('API tests') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-1", label: "Running tests on kind cluster"
           }
         }
         stage('k8s features 1') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-2", label: "Running tests on kind cluster"
           }
         }
         stage('git scm') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-3", label: "Running tests on kind cluster"
           }
         }
         stage('Drupal') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-4", label: "Running tests on kind cluster"
           }
         }
         stage('others') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-5", label: "Running tests on kind cluster"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,8 +56,32 @@ pipeline {
       }
     }
     stage ('run test suite') {
-      steps {
-        sh script: "make -j$NPROC kind/test BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+      parallel {
+        stage('API tests') {
+          steps {
+            sh script: "make -j$NPROC kind/test TESTS[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+          }
+        }
+        stage('k8s features 1') {
+          steps {
+            sh script: "make -j$NPROC kind/test TESTS[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+          }
+        }
+        stage('git scm') {
+          steps {
+            sh script: "make -j$NPROC kind/test TESTS[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+          }
+        }
+        stage('Drupal') {
+          steps {
+            sh script: "make -j$NPROC kind/test TESTS[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+          }
+        }
+        stage('others') {
+          steps {
+            sh script: "make -j$NPROC kind/test TESTS[python,nginx,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+          }
+        }
       }
     }
     stage ('push images to testlagoon/* with :latest tag') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,7 @@ pipeline {
         }
         stage ('collect logs') {
           steps {
+            sleep 30
             sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.lagoon --all-namespaces '^[a-z]' -t > test-suite-0.txt || true", label: "Collecting Logs"
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,28 +55,28 @@ pipeline {
         sh script: "make -O -j$NPROC publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
       }
     }
-    stage ('Setup test cluster') {
+    stage ('setup test cluster') {
       parallel {
-        stage ('Setup test cluster') {
+        stage ('0: setup test cluster') {
           steps {
             sh script: "make -j$NPROC kind/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Setup cluster and run nginx smoketest"
             sh script: "pkill -f './local-dev/stern'", label: "Closing off test-suite-0 log after test completion"
           }
         }
-        stage ('collect test-suite-0 logs') {
+        stage ('collect logs') {
           steps {
             sh script: "while [ ! -f ./kubeconfig.kind.${CI_BUILD_TAG} ]; do sleep 1; done", label: "Check for kubeconfig created"
             timeout(time: 30, unit: 'MINUTES') {
               sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' -t > test-suite-0.txt || true", label: "Collecting test-suite-0 logs"
             }
-            sh script: "cat test-suite-0.txt", label: "View collected logs, or download from ${NODE_NAME} at ${WORKSPACE}/test-suite-0.txt"
+            sh script: "cat test-suite-0.txt", label: "View ${NODE_NAME}:${WORKSPACE}/test-suite-0.txt"
           }
         }
       }
     }
     stage ('run first test suite') {
       parallel {
-        stage ('run first test suite') {
+        stage ('1: run first test suite') {
           steps {
             sh script: "make -j$NPROC kind/retest TESTS=[api,active-standby-kubernetes,features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running first test suite on kind cluster"
             sh script: "pkill -f './local-dev/stern'", label: "Closing off test-suite-1 log after test completion"
@@ -85,27 +85,29 @@ pipeline {
         stage ('collect logs') {
           steps {
             timeout(time: 30, unit: 'MINUTES') {
-              sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' --since 1s -t > test-suite-1.txt || true", label: "Collecting Logs"
+              sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' --since 1s -t > test-suite-1.txt || true", label: "Collecting test-suite-1 logs"
             }
-            sh script: "cat test-suite-1.txt", label: "View collected logs, or download from ${NODE_NAME} at ${WORKSPACE}/test-suite-1.txt"
+            sh script: "cat test-suite-1.txt", label: "View ${NODE_NAME}:${WORKSPACE}/test-suite-1.txt"
           }
         }
       }
     }
     stage ('run second test suite') {
       parallel {
-        stage ('run second test suite') {
+        stage ('2: run second test suite') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[drupal-php74,drupal-postgres,gitlab,github,bitbucket,python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running second test suite on kind cluster"
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                sh script: "make -j$NPROC kind/retest TESTS=[tasks,drupal-php74,drupal-postgres,gitlab,github,bitbucket,python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running second test suite on kind cluster"
+            }
             sh script: "pkill -f './local-dev/stern'", label: "Closing off test-suite-2 log after test completion"
           }
         }
         stage ('collect logs') {
           steps {
             timeout(time: 45, unit: 'MINUTES') {
-              sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' --since 1s -t > test-suite-2.txt || true", label: "Collecting Logs"
+              sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' --since 1s -t > test-suite-2.txt || true", label: "Collecting test-suite-2 logs"
             }
-            sh script: "cat test-suite-2.txt", label: "View collected logs, or download from ${NODE_NAME} at ${WORKSPACE}/test-suite-2.txt"
+            sh script: "cat test-suite-2.txt", label: "View ${NODE_NAME}:${WORKSPACE}/test-suite-2.txt"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,10 +55,12 @@ pipeline {
         sh script: "make -O -j$NPROC publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
       }
     }
-    stage ('run test suite') {
+    stage ('Setup test cluster') {
       steps {
         sh script: "make -j$NPROC kind/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
       }
+    }
+    stage ('run test suite') {
       parallel {
         stage('API tests') {
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         }
         stage ('collect logs') {
           steps {
-            sleep 30
+            sh script: "while [ ! -f ./kubeconfig.kind.${CI_BUILD_TAG} ]; do sleep 1; done", label: "Check for kubeconfig"
             sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' -t > test-suite-0.txt || true", label: "Collecting Logs"
             sh script: "cat test-suite-0.txt", label: "Viewing collected logs"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,23 +67,27 @@ pipeline {
             sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-1", label: "Running tests on kind cluster"
           }
         }
-        stage('k8s features 1') {
+        stage('k8s features') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-2", label: "Running tests on kind cluster"
-          }
-        }
-        stage('git scm') {
-          steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-3", label: "Running tests on kind cluster"
+            sleep 60
+            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-2", label: "Running tests on kind cluster"
           }
         }
         stage('Drupal') {
           steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-4", label: "Running tests on kind cluster"
+            sleep 120
+            sh script: "make -j$NPROC kind/retest TESTS=[drupal-php74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-4", label: "Running tests on kind cluster"
+          }
+        }
+        stage('git scm') {
+          steps {
+            sleep 180
+            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-3", label: "Running tests on kind cluster"
           }
         }
         stage('others') {
           steps {
+            sleep 240
             sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-5", label: "Running tests on kind cluster"
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,8 @@ pipeline {
         stage ('collect logs') {
           steps {
             sleep 30
-            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.lagoon --all-namespaces '^[a-z]' -t > test-suite-0.txt || true", label: "Collecting Logs"
+            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' -t > test-suite-0.txt || true", label: "Collecting Logs"
+            sh script: "cat test-suite-0.txt", label: "Viewing collected logs"
           }
         }
       }
@@ -86,7 +87,7 @@ pipeline {
         }
         stage ('collect logs') {
           steps {
-            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.lagoon --all-namespaces '^[a-z]' -t > test-suite-1.txt || true", label: "Collecting Logs"
+            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' -t > test-suite-1.txt || true", label: "Collecting Logs"
           }
         }
       }
@@ -106,7 +107,7 @@ pipeline {
         }
         stage ('collect logs') {
           steps {
-            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.lagoon --all-namespaces '^[a-z]' -t > test-suite-2.txt || true", label: "Collecting Logs"
+            sh script: "./local-dev/stern --kubeconfig ./kubeconfig.kind.${CI_BUILD_TAG} --all-namespaces '^[a-z]' -t > test-suite-2.txt || true", label: "Collecting Logs"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,27 +59,27 @@ pipeline {
       parallel {
         stage('API tests') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/test TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('k8s features 1') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/test TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('git scm') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/test TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('Drupal') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/test TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('others') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS[python,nginx,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/test TESTS=[python,nginx,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
     }
     stage ('run test suite') {
       steps {
-        sh script: "make -j$NPROC kind/test TESTS=[nginx,api,tasks,active-standby-kubernetes,features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+        sh script: "make -j$NPROC kind/test TESTS=[nginx,api,active-standby-kubernetes,features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,30 +56,33 @@ pipeline {
       }
     }
     stage ('run test suite') {
+      steps {
+        sh script: "make -j$NPROC kind/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+      }
       parallel {
         stage('API tests') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('k8s features 1') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables,] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('git scm') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('Drupal') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[drupal-74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
         stage('others') {
           steps {
-            sh script: "make -j$NPROC kind/test TESTS=[python,nginx,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+            sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,44 +55,57 @@ pipeline {
         sh script: "make -O -j$NPROC publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
       }
     }
-    stage ('Setup test cluster') {
-      steps {
-        sh script: "make -j$NPROC kind/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
-      }
-    }
     stage ('run test suite') {
-      parallel {
-        stage('API tests') {
-          steps {
-            sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-1", label: "Running tests on kind cluster"
-          }
-        }
-        stage('k8s features') {
-          steps {
-            sleep 60
-            sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-2", label: "Running tests on kind cluster"
-          }
-        }
-        stage('Drupal') {
-          steps {
-            sleep 120
-            sh script: "make -j$NPROC kind/retest TESTS=[drupal-php74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-4", label: "Running tests on kind cluster"
-          }
-        }
-        stage('git scm') {
-          steps {
-            sleep 180
-            sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-3", label: "Running tests on kind cluster"
-          }
-        }
-        stage('others') {
-          steps {
-            sleep 240
-            sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-5", label: "Running tests on kind cluster"
-          }
-        }
+      steps {
+        sh script: "make -j$NPROC kind/test TESTS=[nginx,api,tasks,active-standby-kubernetes,features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
       }
     }
+
+    stage ('run additional tests suite') {
+      steps {
+        sleep 120
+        sh script: "make -j$NPROC kind/retest TESTS=[drupal-php74,drupal-postgres,gitlab,github,bitbucket,python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+      }
+    }
+
+    // stage ('Setup test cluster') {
+    //   steps {
+    //     sh script: "make -j$NPROC kind/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Running tests on kind cluster"
+    //   }
+    // }
+    // stage ('run test suite') {
+    //   parallel {
+    //     stage('API tests') {
+    //       steps {
+    //         sh script: "make -j$NPROC kind/retest TESTS=[api,tasks,active-standby-kubernetes] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-1", label: "Running tests on kind cluster"
+    //       }
+    //     }
+    //     stage('k8s features') {
+    //       steps {
+    //         sleep 60
+    //         sh script: "make -j$NPROC kind/retest TESTS=[features-kubernetes,features-kubernetes-2,features-api-variables] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-2", label: "Running tests on kind cluster"
+    //       }
+    //     }
+    //     stage('Drupal') {
+    //       steps {
+    //         sleep 120
+    //         sh script: "make -j$NPROC kind/retest TESTS=[drupal-php74,drupal-postgres] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-4", label: "Running tests on kind cluster"
+    //       }
+    //     }
+    //     stage('git scm') {
+    //       steps {
+    //         sleep 180
+    //         sh script: "make -j$NPROC kind/retest TESTS=[gitlab,github,bitbucket] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-3", label: "Running tests on kind cluster"
+    //       }
+    //     }
+    //     stage('others') {
+    //       steps {
+    //         sleep 240
+    //         sh script: "make -j$NPROC kind/retest TESTS=[python,node-mongodb,elasticsearch] BRANCH_NAME=${SAFEBRANCH_NAME} CT_BUILD_TAG=${CI_BUILD_TAG}-5", label: "Running tests on kind cluster"
+    //       }
+    //     }
+    //   }
+    // }
     stage ('push images to testlagoon/* with :latest tag') {
       when {
         branch 'main'

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ DOCKER_BUILD_PARAMS := --quiet
 # CI systems to define an Environment variable CI_BUILD_TAG which uniquely identifies each build.
 # If it's not set we assume that we are running local and just call it lagoon.
 CI_BUILD_TAG ?= lagoon
+CT_BUILD_TAG ?= $(CI_BUILD_TAG)
+
 # SOURCE_REPO is the repos where the upstream images are found (usually uselagoon, but can substiture for testlagoon)
 UPSTREAM_REPO ?= uselagoon
 UPSTREAM_TAG ?= latest
@@ -1177,7 +1179,7 @@ kind/retest:
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_ALL_DEPS=true \
-		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
+		&& docker run --rm --network host --name ct-$(CT_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
 			--volume "$$(realpath ../kubeconfig.kind.$(CI_BUILD_TAG)):/root/.kube/config" \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ DOCKER_BUILD_PARAMS := --quiet
 # CI systems to define an Environment variable CI_BUILD_TAG which uniquely identifies each build.
 # If it's not set we assume that we are running local and just call it lagoon.
 CI_BUILD_TAG ?= lagoon
-CT_BUILD_TAG ?= $(CI_BUILD_TAG)
 
 # SOURCE_REPO is the repos where the upstream images are found (usually uselagoon, but can substiture for testlagoon)
 UPSTREAM_REPO ?= uselagoon
@@ -1190,7 +1189,7 @@ kind/retest:
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_ALL_DEPS=true \
-		&& docker run --rm --network host --name ct-$(CT_BUILD_TAG) \
+		&& docker run --rm --network host --name $(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
 			--volume "$$(realpath ../kubeconfig.kind.$(CI_BUILD_TAG)):/root/.kube/config" \

--- a/Makefile
+++ b/Makefile
@@ -950,6 +950,7 @@ api-development: build/api build/api-db build/local-api-data-watcher-pusher buil
 
 KIND_VERSION = v0.11.1
 GOJQ_VERSION = v0.12.3
+STERN_VERSION = 2.1.17
 CHART_TESTING_VERSION = v3.4.0
 KIND_IMAGE = kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 TESTS = [api,features-kubernetes,features-kubernetes-2,features-api-variables,active-standby-kubernetes,nginx,drupal-php73,drupal-php74,drupal-postgres,python,gitlab,github,bitbucket,node-mongodb,elasticsearch,tasks]
@@ -980,6 +981,16 @@ else
 	mv ./local-dev/{go,}jq
 endif
 	chmod a+x local-dev/jq
+endif
+
+local-dev/stern:
+ifeq ($(STERN_VERSION), $(shell stern --version 2>/dev/null | sed -nE 's/stern version //p'))
+	$(info linking local stern version $(KIND_VERSION))
+	ln -s $(shell command -v stern) ./local-dev/stern
+else
+	$(info downloading stern version $(STERN_VERSION) for $(ARCH))
+	curl -sSLo local-dev/stern https://github.com/derdanne/stern/releases/download/$(STERN_VERSION)/stern_$(ARCH)_amd64
+	chmod a+x local-dev/stern
 endif
 
 .PHONY: helm/repos
@@ -1038,7 +1049,7 @@ endif
 
 KIND_SERVICES = api api-db api-redis auth-server broker controllerhandler docker-host drush-alias keycloak keycloak-db webhook-handler webhooks2tasks kubectl-build-deploy-dind local-api-data-watcher-pusher local-git ssh tests ui
 KIND_TESTS = local-api-data-watcher-pusher local-git tests
-KIND_TOOLS = kind helm kubectl jq
+KIND_TOOLS = kind helm kubectl jq stern
 
 # install lagoon charts and run lagoon test suites in a kind cluster
 .PHONY: kind/test

--- a/Makefile
+++ b/Makefile
@@ -1189,7 +1189,7 @@ kind/retest:
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_ALL_DEPS=true \
-		&& docker run --rm --network host --name $(CI_BUILD_TAG) \
+		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
 			--volume "$$(realpath ../kubeconfig.kind.$(CI_BUILD_TAG)):/root/.kube/config" \

--- a/tests/tests/active-standby/deploy-active-standby.yaml
+++ b/tests/tests/active-standby/deploy-active-standby.yaml
@@ -24,7 +24,7 @@
         body: '{ "query": "query($id: Int!) {taskById(id: $id){status}}", "variables": {"id":{{ apiresponse.json.data.switchActiveStandby.id }}}}'
       register: taskresult
       until: taskresult.json.data is defined and (taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed")
-      retries: 30
+      retries: 20
       delay: 10
     - name: "{{ testname }} - fail if task fails"
       fail:
@@ -40,5 +40,5 @@
         body: '{ "query": "query($projectName: String!) {projectByName(name:$projectName){productionEnvironment,standbyProductionEnvironment}}", "variables": {"projectName":"{{ project }}"}}'
       register: switchresult
       until: switchresult.json.data.projectByName.productionEnvironment == standby_branch or switchresult.json.data.projectByName.standbyProductionEnvironment == prod_branch
-      retries: 30
+      retries: 20
       delay: 10

--- a/tests/tests/tasks/create-and-register-task.yaml
+++ b/tests/tests/tasks/create-and-register-task.yaml
@@ -30,7 +30,7 @@
         body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
       register: taskCreateApiResponse
       until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 30
+      retries: 20
       delay: 10
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:

--- a/tests/tests/tasks/create-register-and-test-image-task.yaml
+++ b/tests/tests/tasks/create-register-and-test-image-task.yaml
@@ -27,7 +27,7 @@
         body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $image: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:IMAGE, description: $description, service: $service, image: $image}){... on AdvancedTaskDefinitionImage {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-image","description":"Runs a hello world task", "service":"node", "image":"hello-world"}}'
       register: taskCreateApiResponse
       until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 30
+      retries: 20
       delay: 10
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:


### PR DESCRIPTION
This PR does a few things to try to make the testing more reliable and easier to debug.

1. It splits the Lagoon tests into three phases:
a. Setup Kind cluster and run nginx smoketest
b. Run main Lagoon tests - API, features etc
c. Run application/integration tests - Drupal, Python, SCM, DBaaS 
2. The first two phases must pass, the third phase is allowed to fail (it's where most of the erroneous errors are at).
3. Each phase also contains a standalone logger that captures *ALL* pod logs into a file
4. These files are displayed in Jenkins, but can also be downloaded on failed attempts.
5. Reduces retries on API calls to 20, as 30 was taking longer than the token validity, and may be reporting incorrect errors.