### PR TITLE
Changed tasks retry logic and refresh token permissions

### DIFF
--- a/tests/tests/tasks/create-and-register-task.yaml
+++ b/tests/tests/tasks/create-and-register-task.yaml
@@ -17,21 +17,22 @@
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
-    - name: "{{ testname }} -- this will be posted"
-      debug:
-        msg: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){id}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-    - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
-      uri:
-        url: "{{ graphql_url }}"
-        method: POST
-        headers:
-          Authorization: "Bearer {{ token }}"
-        body_format: json
-        body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-      register: taskCreateApiResponse
-      until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 30
-      delay: 10
+    # - name: "{{ testname }} -- this will be posted"
+    #   debug:
+    #     msg: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){id}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
+    # - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
+    #   uri:
+    #     url: "{{ graphql_url }}"
+    #     method: POST
+    #     headers:
+    #       Authorization: "Bearer {{ token }}"
+    #     body_format: json
+    #     body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
+    #   register: taskCreateApiResponse
+    #   until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
+    #   retries: 30
+    #   delay: 10
+    - include: ./post-api-register-task-command.yaml
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:
         msg: "api response: {{ taskCreateApiResponse }}"

--- a/tests/tests/tasks/create-and-register-task.yaml
+++ b/tests/tests/tasks/create-and-register-task.yaml
@@ -17,21 +17,6 @@
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
-    # - name: "{{ testname }} -- this will be posted"
-    #   debug:
-    #     msg: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){id}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-    # - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
-    #   uri:
-    #     url: "{{ graphql_url }}"
-    #     method: POST
-    #     headers:
-    #       Authorization: "Bearer {{ token }}"
-    #     body_format: json
-    #     body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-    #   register: taskCreateApiResponse
-    #   until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-    #   retries: 30
-    #   delay: 10
     - include: ./post-api-register-task-command.yaml
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:

--- a/tests/tests/tasks/create-and-register-task.yaml
+++ b/tests/tests/tasks/create-and-register-task.yaml
@@ -17,7 +17,6 @@
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
-<<<<<<< HEAD
     # - name: "{{ testname }} -- this will be posted"
     #   debug:
     #     msg: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){id}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
@@ -34,23 +33,6 @@
     #   retries: 30
     #   delay: 10
     - include: ./post-api-register-task-command.yaml
-=======
-    - name: "{{ testname }} -- this will be posted"
-      debug:
-        msg: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){id}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-    - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
-      uri:
-        url: "{{ graphql_url }}"
-        method: POST
-        headers:
-          Authorization: "Bearer {{ token }}"
-        body_format: json
-        body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
-      register: taskCreateApiResponse
-      until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 20
-      delay: 10
->>>>>>> main
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:
         msg: "api response: {{ taskCreateApiResponse }}"

--- a/tests/tests/tasks/create-register-and-test-image-task.yaml
+++ b/tests/tests/tasks/create-register-and-test-image-task.yaml
@@ -17,22 +17,7 @@
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
-<<<<<<< HEAD
     - include: ./post-api-register-task.yaml
-=======
-    - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
-      uri:
-        url: "{{ graphql_url }}"
-        method: POST
-        headers:
-          Authorization: "Bearer {{ admin_token }}"
-        body_format: json
-        body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $image: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:IMAGE, description: $description, service: $service, image: $image}){... on AdvancedTaskDefinitionImage {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-image","description":"Runs a hello world task", "service":"node", "image":"hello-world"}}'
-      register: taskCreateApiResponse
-      until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 20
-      delay: 10
->>>>>>> main
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:
         msg: "api response: {{ taskCreateApiResponse }}"

--- a/tests/tests/tasks/create-register-and-test-image-task.yaml
+++ b/tests/tests/tasks/create-register-and-test-image-task.yaml
@@ -17,18 +17,7 @@
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
-    - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
-      uri:
-        url: "{{ graphql_url }}"
-        method: POST
-        headers:
-          Authorization: "Bearer {{ admin_token }}"
-        body_format: json
-        body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $image: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:IMAGE, description: $description, service: $service, image: $image}){... on AdvancedTaskDefinitionImage {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-image","description":"Runs a hello world task", "service":"node", "image":"hello-world"}}'
-      register: taskCreateApiResponse
-      until: taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id is defined
-      retries: 30
-      delay: 10
+    - include: ./post-api-register-task.yaml
     - name: "{{ testname }} - DEBUG taskCreateApiResponse"
       debug:
         msg: "api response: {{ taskCreateApiResponse }}"

--- a/tests/tests/tasks/post-api-register-task-command.yaml
+++ b/tests/tests/tasks/post-api-register-task-command.yaml
@@ -1,6 +1,6 @@
 - name: 'Wait until success'
   block:
-  - include: ../../tasks/api/refresh-token.yaml
+  - include: ../../tasks/api/admin-token.yaml
   - name: Set the retry count
     set_fact:
       retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
@@ -9,7 +9,7 @@
       url: "{{ graphql_url }}"
       method: POST
       headers:
-        Authorization: "Bearer {{ token }}"
+        Authorization: "Bearer {{ admin_token }}"
       body_format: json
       body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
     register: taskCreateApiResponse

--- a/tests/tests/tasks/post-api-register-task-command.yaml
+++ b/tests/tests/tasks/post-api-register-task-command.yaml
@@ -1,0 +1,28 @@
+- name: 'Wait until success'
+  block:
+  - include: ../../tasks/api/refresh-token.yaml
+  - name: Set the retry count
+    set_fact:
+      retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
+  - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
+    uri:
+      url: "{{ graphql_url }}"
+      method: POST
+      headers:
+        Authorization: "Bearer {{ token }}"
+      body_format: json
+      body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $command: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:COMMAND, description: $description, service: $service, command: $command}){... on AdvancedTaskDefinitionCommand {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-echo","description":"echos to file", "service":"node", "command":"echo ''REPLACED BY TASK'' > /app/files/testoutput.txt"}}'
+    register: taskCreateApiResponse
+  rescue:
+    - debug:
+        msg: "{{ taskCreateApiResponse }}"
+    - fail:
+        msg: Ended after 3 retries
+      when: retry_count|int == 3
+    - name: Pause for retry
+      pause:
+        seconds: 10
+    - debug:
+        msg: "Failed to connect - Retrying..."
+
+    - include_tasks: ./post-api-register-task-command.yaml

--- a/tests/tests/tasks/post-api-register-task.yaml
+++ b/tests/tests/tasks/post-api-register-task.yaml
@@ -1,0 +1,29 @@
+- name: 'Wait until success'
+  block:
+  - include: ../../tasks/api/admin-token.yaml
+  - name: Set the retry count
+    set_fact:
+      retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
+  - name: "{{ testname }} - POST api register task definition to {{ graphql_url }}"
+    uri:
+      url: "{{ graphql_url }}"
+      method: POST
+      headers:
+        Authorization: "Bearer {{ admin_token }}"
+      body_format: json
+      body: '{ "query": "mutation($environmentId: Int!, $taskName: String!, $description: String!, $service: String!, $image: String!) {addAdvancedTaskDefinition(input: {environment:$environmentId, name:$taskName, type:IMAGE, description: $description, service: $service, image: $image}){... on AdvancedTaskDefinitionImage {id}}}", "variables": {"environmentId": {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "taskName":"testing-image","description":"Runs a hello world task", "service":"node", "image":"hello-world"}}'
+    register: taskCreateApiResponse
+
+  rescue:
+    - debug:
+        msg: "{{ taskCreateApiResponse }}"
+    - fail:
+        msg: Ended after 3 retries
+      when: retry_count|int == 3
+    - name: Pause for retry
+      pause:
+        seconds: 10
+    - debug:
+        msg: "Failed to connect - Retrying..."
+
+    - include_tasks: ./post-api-register-task.yaml

--- a/tests/tests/tasks/tasks.yaml
+++ b/tests/tests/tasks/tasks.yaml
@@ -28,6 +28,7 @@
 
 - name: "{{ testname }} - POST api Add task to {{ project }} via {{ graphql_url }}"
   hosts: localhost
+  serial: 1
   tasks:
     - include: ../../tasks/api/refresh-token.yaml
     - include: ./create-and-register-task.yaml
@@ -41,11 +42,12 @@
   tasks:
   - include: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - POST api Add Image task to {{ project }} via {{ graphql_url }}"
-  hosts: localhost
-  tasks:
-    - include: ../../tasks/api/refresh-token.yaml
-    - include: ./create-register-and-test-image-task.yaml
+# - name: "{{ testname }} - POST api Add Image task to {{ project }} via {{ graphql_url }}"
+#   hosts: localhost
+#   serial: 1
+#   tasks:
+#     - include: ../../tasks/api/refresh-token.yaml
+#     - include: ./create-register-and-test-image-task.yaml
 
 - name: "{{ testname }} - api deleteEnvironment on {{ project }}, which should remove all resources"
   hosts: localhost


### PR DESCRIPTION
This PR adds a debug/retry loop to the tricky tasks tests, which should ensure some robustness.

Preliminary testing has not highlighted any issues, so will merge this for now, and continue to monitor before updating the logic for more tests.