### PR TITLE
Adding startingDeadlineSeconds to all cli native cronjob templates

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/kibana/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/kibana/templates/cronjob.yaml
@@ -12,6 +12,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/python/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/python/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/rabbitmq/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/rabbitmq/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 240
   jobTemplate:
     metadata:
       labels:


### PR DESCRIPTION
# Checklist

- [] Affected Issues have been mentioned in the Closing issues section
- [] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR adds the `startingDeadlineSeconds` value to both native cronjob templates for cli cron tasks. This prevents stale jobs from preventing the cronjob from running altogether.

# Closing issues
