### PR TITLE
Add a message in the UI that shows how many results are displayed

### DIFF
--- a/services/ui/src/pages/backups.js
+++ b/services/ui/src/pages/backups.js
@@ -108,6 +108,9 @@ export const PageBackups = ({ router }) => (
                 <Backups backups={environment.backups} />
               </div>
             </div>
+            <div className="message-wrapper">
+              <div className="content">Number of results displayed is limited to {backupsLimit}</div>
+            </div>
             <style jsx>{`
               .content-wrapper {
                 @media ${bp.tabletUp} {
@@ -125,6 +128,18 @@ export const PageBackups = ({ router }) => (
                 background-color: ${color.lightBlue};
                 color: ${color.white};
                 padding: 10px 20px;
+              }
+
+              .message-wrapper {
+                border-top: 1px solid #f5f6fa;
+                border-radius: 3px;
+                box-shadow: 0px 4px 8px 0px rgb(0 0 0 / 3%);
+
+                .content {
+                  padding: 9px calc((100vw / 16) * 1);
+                  text-align: center;
+                  color: ${color.darkGrey};
+                }
               }
             `}</style>
           </MainLayout>

--- a/services/ui/src/pages/deployments.js
+++ b/services/ui/src/pages/deployments.js
@@ -16,7 +16,7 @@ import Deployments from 'components/Deployments';
 import withQueryLoading from 'lib/withQueryLoading';
 import withQueryError from 'lib/withQueryError';
 import { withEnvironmentRequired } from 'lib/withDataRequired';
-import { bp } from 'lib/variables';
+import { bp, color } from 'lib/variables';
 
 const { publicRuntimeConfig } = getConfig();
 const envLimit = parseInt(publicRuntimeConfig.LAGOON_UI_DEPLOYMENTS_LIMIT, 10);
@@ -99,6 +99,9 @@ export const PageDeployments = ({ router }) => {
                   />
                 </div>
               </div>
+              <div className="message-wrapper">
+                <div className="content">Number of results displayed is limited to {deploymentsLimit}</div>
+              </div>
               <style jsx>{`
                 .content-wrapper {
                   @media ${bp.tabletUp} {
@@ -110,6 +113,18 @@ export const PageDeployments = ({ router }) => {
                 .content {
                   padding: 32px calc((100vw / 16) * 1);
                   width: 100%;
+                }
+
+                .message-wrapper {
+                  border-top: 1px solid #f5f6fa;
+                  border-radius: 3px;
+                  box-shadow: 0px 4px 8px 0px rgb(0 0 0 / 3%);
+
+                  .content {
+                    padding: 9px calc((100vw / 16) * 1);
+                    text-align: center;
+                    color: ${color.darkGrey};
+                  }
                 }
               `}</style>
             </MainLayout>

--- a/services/ui/src/pages/tasks.js
+++ b/services/ui/src/pages/tasks.js
@@ -16,7 +16,7 @@ import Tasks from 'components/Tasks';
 import withQueryLoading from 'lib/withQueryLoading';
 import withQueryError from 'lib/withQueryError';
 import { withEnvironmentRequired } from 'lib/withDataRequired';
-import { bp } from 'lib/variables';
+import { bp, color } from 'lib/variables';
 
 const { publicRuntimeConfig } = getConfig();
 const envLimit = parseInt(publicRuntimeConfig.LAGOON_UI_TASKS_LIMIT, 10);
@@ -97,6 +97,9 @@ export const PageTasks = ({ router }) => (
                 />
               </div>
             </div>
+            <div className="message-wrapper">
+              <div className="content">Number of results displayed is limited to {tasksLimit}</div>
+            </div>
             <style jsx>{`
               .content-wrapper {
                 @media ${bp.tabletUp} {
@@ -108,6 +111,18 @@ export const PageTasks = ({ router }) => (
               .content {
                 padding: 32px calc((100vw / 16) * 1);
                 width: 100%;
+              }
+
+              .message-wrapper {
+                border-top: 1px solid #f5f6fa;
+                border-radius: 3px;
+                box-shadow: 0px 4px 8px 0px rgb(0 0 0 / 3%);
+
+                .content {
+                  padding: 9px calc((100vw / 16) * 1);
+                  text-align: center;
+                  color: ${color.darkGrey};
+                }
               }
             `}</style>
           </MainLayout>


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

On the `tasks`, `backups`, and `deployments` pages, we limit the number of results that are displayed to users. We should let them know the results have been limited.

It would be better if this was a drop down selection box that could allow the user to select how many results are returned, rather than defining a hard value.

# Closes

Fixes #2842.
