### PR TITLE
Add drupal/purge to suggested Composer command

### DIFF
--- a/docs/drupal/integrate-drupal-and-fastly.md
+++ b/docs/drupal/integrate-drupal-and-fastly.md
@@ -11,7 +11,7 @@
 Use Composer to get the latest version of the module:
 
 ```text
-composer require drupal/fastly drupal/http_cache_control
+composer require drupal/fastly drupal/http_cache_control drupal/purge
 ```
 
 You will need to enable the following modules:


### PR DESCRIPTION
I went to setup Drupal & Fastly integration and was missing Purge when I followed the docs.
