### PR TITLE
fix: don't touch the sentinel file if it already exists

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -49,8 +49,8 @@ spec:
                 find /storage -mindepth 1 -exec chgrp $(stat -c "%g" /storage) {} +
                 find /storage -mindepth 1 -exec chmod g+rw {} +
                 find /storage -mindepth 1 -type d -exec chmod g+x {} +
+                touch "$SENTINEL"
               fi
-              touch "$SENTINEL"
           image: busybox:musl
           imagePullPolicy: IfNotPresent
           name: fix-storage-permissions


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This is a minor fix and follow-up to #2481 .

The sentinel file only needs to be touched once, not every time the initContainer runs.

# Closing issues

n/a
