### PR TITLE
Bump lagoon-linter version to address tls-acme validation issue

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -21,7 +21,7 @@ COPY helmcharts  /kubectl-build-deploy/helmcharts
 
 ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
 
-RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.3.0/lagoon-linter_0.3.0_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.3.1/lagoon-linter_0.3.1_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
 CMD ["/kubectl-build-deploy/build-deploy.sh"]


### PR DESCRIPTION

# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The linter was overly strict. See https://github.com/uselagoon/lagoon-linter/issues/5

# Closing issues

n/a
