### PR TITLE
feat: add verbose linter message on success

### DIFF
--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -107,6 +107,8 @@ if ! lagoon-linter; then
 	echo "https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#restrictions describes some possible reasons for this build failure."
 	echo "If you require assistance to fix this error, please contact support."
 	exit 1
+else
+	echo "lagoon-linter found no issues with the .lagoon.yml file"
 fi
 
 # Load path of docker-compose that should be used


### PR DESCRIPTION
Currently the linter provides no output to the lagoon build log on success.

To avoid doubt as to whether it is in operation, this adds a basic else statement to indicate that the file has been linted successfully