### PR TITLE
Schedule cronjobs on spot instances by default

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
@@ -74,11 +74,11 @@ spec:
           nodeSelector:
             {{- toYaml $ | nindent 12 }}
           {{- end }}
-        {{- with $.Values.affinity }}
+        {{- with (coalesce $.Values.affinity $.Values.cronjobAffinity) }}
           affinity:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
-        {{- with $.Values.tolerations }}
+        {{- with (coalesce $.Values.tolerations $.Values.cronjobTolerations) }}
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/values.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/values.yaml
@@ -49,3 +49,18 @@ inPodCronjobs: ""
 nativeinPodCronjobs: ""
 
 configMapSha: ""
+
+# cronjobs prefer spot instances by default
+
+cronjobTolerations:
+- key: "lagoon.sh/spot"
+  operator: "Exists"
+
+cronjobAffinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      preference:
+        matchExpressions:
+        - key: "lagoon.sh/spot"
+          operator: "Exists"


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Use the standard `lagoon.sh/spot` label and taint to try to get cronjobs to execute on spot instances by default.

To be very conservative I thought to only target cronjobs initially. Potentially in future entire services in e.g. development environments could prefer spots. Setting the standard chart `.Values.affinity` and `.Values.tolerations` would allow this and would override the "fallback" spot scheduling for cronjobs in this PR.

This is a draft to gather feedback on the approach. I've only done one template so far, but the idea would be to apply the same change to all standard Lagoon cronjob templates. I also haven't tested that this actually works in a cluster yet :smile: 

# Closing issues

n/a
