### PR TITLE
fix: use a sql query to get project vars for restores rather than graphql

### DIFF
--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -27,7 +27,7 @@ export const getRestoreLocation: ResolverFn = async (
   const { sqlClientPool, hasPermission } = context;
   const rows = await query(sqlClientPool, Sql.selectBackupByBackupId(backupId));
   const project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(rows[0].environment);
-  const projectEnvVars = await getEnvVarsByProjectId({ id: project.projectId }, args, context);
+  const projectEnvVars = await query(sqlClientPool, Sql.selectEnvVariablesByProjectsById(project.projectId));
 
   // https://{endpoint}/{bucket}/{key}
   const s3LinkMatch = /([^/]+)\/([^/]+)\/([^/]+)/;

--- a/services/api/src/resources/backup/sql.ts
+++ b/services/api/src/resources/backup/sql.ts
@@ -9,6 +9,10 @@ export const Sql = {
     knex('environment_backup')
       .where('backup_id', '=', backupId)
       .toString(),
+  selectEnvVariablesByProjectsById: (projectId: number) =>
+    knex('env_vars')
+      .where('project', projectId)
+      .toString(),
   selectBackupsByEnvironmentId: ({
     environmentId,
     includeDeleted


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

https://github.com/uselagoon/lagoon/pull/2820 added envvar support for restores, but uses a graphql query to return the project environment variables. This means that if a user with developer role tries to view the backups page with downloadable backups, they get a permission error.

Since these variables aren't exposed to the user, this PR changes it to use a sql query to get projects variables instead, and still allows developers to download production environment backups like they were able to previously.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

