### PR TITLE
Adding deterministic value comparisons to restore config creation.

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -803,10 +803,10 @@ const restoreConfig = (name, backupId, safeProjectName, baasBucketName, backupS3
     spec: {
       snapshot: backupId,
       restoreMethod: {
-        s3: restoreS3Config ? restoreS3Config : {},
+        s3: restoreS3Config ? restoreS3Config != {} : {},
       },
       backend: {
-        s3: backupS3Config ? backupS3Config : {
+        s3: backupS3Config ? backupS3Config != {} : {
           bucket: baasBucketName ? baasBucketName : `baas-${safeProjectName}`
         },
         repoPasswordSecretRef: {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -803,10 +803,10 @@ const restoreConfig = (name, backupId, safeProjectName, baasBucketName, backupS3
     spec: {
       snapshot: backupId,
       restoreMethod: {
-        s3: restoreS3Config ? restoreS3Config != {} : {},
+        s3: restoreS3Config != {} ? restoreS3Config : {},
       },
       backend: {
-        s3: backupS3Config ? backupS3Config != {} : {
+        s3: backupS3Config != {} ? backupS3Config : {
           bucket: baasBucketName ? baasBucketName : `baas-${safeProjectName}`
         },
         repoPasswordSecretRef: {


### PR DESCRIPTION
This PR should resolve the issues we are seeing with restore objects missing their baasbucketname values

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
