### PR TITLE
Fix error running addKubernetes with empty id

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/03-procedures.sql
@@ -284,59 +284,7 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
-CREATE OR REPLACE PROCEDURE
-  CreateOpenshift
-  (
-    IN id                int,
-    IN name              varchar(50),
-    IN console_url       varchar(300),
-    IN token             varchar(2000),
-    IN router_pattern    varchar(300),
-    IN project_user      varchar(100),
-    IN ssh_host          varchar(300),
-    IN ssh_port          varchar(50),
-    IN monitoring_config varchar(2048)
-  )
-  BEGIN
-    DECLARE new_oid int;
-
-    IF (id IS NULL) THEN
-      SET id = 0;
-    END IF;
-
-    INSERT INTO openshift (
-      id,
-      name,
-      console_url,
-      token,
-      router_pattern,
-      project_user,
-      ssh_host,
-      ssh_port,
-      monitoring_config
-    ) VALUES (
-      id,
-      name,
-      console_url,
-      token,
-      router_pattern,
-      project_user,
-      ssh_host,
-      ssh_port,
-      monitoring_config
-    );
-
-    IF (id = 0) THEN
-      SET new_oid = LAST_INSERT_ID();
-    ELSE
-      SET new_oid = id;
-    END IF;
-
-    SELECT
-      o.*
-    FROM openshift o
-    WHERE o.id = new_oid;
-  END;
+DROP PROCEDURE IF EXISTS CreateOpenshift;
 $$
 
 CREATE OR REPLACE PROCEDURE

--- a/services/api/src/resources/openshift/resolvers.ts
+++ b/services/api/src/resources/openshift/resolvers.ts
@@ -19,24 +19,10 @@ export const addOpenshift: ResolverFn = async (
 ) => {
   await hasPermission('openshift', 'add');
 
-  const rows = await query(
-    sqlClientPool,
-    `CALL CreateOpenshift(
-      :id,
-      :name,
-      :console_url,
-      ${input.token ? ':token' : 'NULL'},
-      ${input.routerPattern ? ':router_pattern' : 'NULL'},
-      ${input.projectUser ? ':project_user' : 'NULL'},
-      ${input.sshHost ? ':ssh_host' : 'NULL'},
-      ${input.sshPort ? ':ssh_port' : 'NULL'},
-      ${input.monitoringConfig ? ':monitoring_config' : 'NULL'}
-    );`,
-    input
-  );
-  const openshift = R.path([0, 0], rows);
+  const { insertId } = await query(sqlClientPool, Sql.insertOpenshift(input));
 
-  return openshift;
+  const rows = await query(sqlClientPool, Sql.selectOpenshift(insertId));
+  return R.prop(0, rows);
 };
 
 export const deleteOpenshift: ResolverFn = async (
@@ -68,7 +54,7 @@ export const getOpenshiftByProjectId: ResolverFn = async (
   { sqlClientPool, hasPermission }
 ) => {
   await hasPermission('openshift', 'view', {
-    project: pid,
+    project: pid
   });
 
   const rows = await query(
@@ -105,7 +91,7 @@ export const getOpenshiftByDeployTargetId: ResolverFn = async (
 
   // check permissions on the project
   await hasPermission('openshift', 'view', {
-    project: projectrows[0].project,
+    project: projectrows[0].project
   });
 
   const rows = await query(

--- a/services/api/src/resources/openshift/sql.ts
+++ b/services/api/src/resources/openshift/sql.ts
@@ -1,7 +1,47 @@
 import { knex } from '../../util/db';
 
 export const Sql = {
-  updateOpenshift: ({ id, patch }: { id: number; patch: { [key: string]: any } }) =>
+  insertOpenshift: ({
+    id,
+    name,
+    consoleUrl,
+    token,
+    routerPattern,
+    projectUser,
+    sshHost,
+    sshPort,
+    monitoringConfig
+  }: {
+    id?: number;
+    name: string;
+    consoleUrl: string;
+    token?: string;
+    routerPattern?: string;
+    projectUser?: string;
+    sshHost?: string;
+    sshPort?: string;
+    monitoringConfig?: JSON;
+  }) =>
+    knex('openshift')
+      .insert({
+        id,
+        name,
+        consoleUrl,
+        token,
+        routerPattern,
+        projectUser,
+        sshHost,
+        sshPort,
+        monitoringConfig
+      })
+      .toString(),
+  updateOpenshift: ({
+    id,
+    patch
+  }: {
+    id: number;
+    patch: { [key: string]: any };
+  }) =>
     knex('openshift')
       .where('id', '=', id)
       .update(patch)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

There was a SQL error related to the API resolver not defaulting the `id` to `null`. This PR removes the stored procedure to pass the inputs directly.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2755 
