### PR TITLE
fix: use the project name instead of the environment name

### DIFF
--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -384,7 +384,7 @@ export const addOrUpdateEnvironment: ResolverFn = async (
   );
 
   userActivityLogger(`User updated environment`, {
-    project: input.name || '',
+    project: projectOpenshift.name || '',
     event: 'api:addOrUpdateEnvironment',
     payload: {
       ...input


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The userActivityLogger in the `addOrUpdateEnvironment` mutation in the API uses the environment name as the project name, this solves that by using the project name.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->


