### PR TITLE
Document additional requirements for collecting logs of the NGINX ingress controller

### DIFF
--- a/docs/using-lagoon-advanced/installing-lagoon-into-existing-kubernetes-cluster.md
+++ b/docs/using-lagoon-advanced/installing-lagoon-into-existing-kubernetes-cluster.md
@@ -10,7 +10,7 @@ description: >-
 
 * Kubernetes 1.18+
 * Familiarity with [Helm](https://helm.sh) and [Helm Charts](https://helm.sh/docs/topics/charts/#helm), and [kubectl](https://kubernetes.io/docs/tasks/tools/).
-* Ingress controller (ingress-nginx)
+* [Ingress controller (ingress-nginx)](#logging-nginx-ingress-controller)
 * Cert manager (for TLS) - We highly recommend using letsencrypt
 * RWO storage
 
@@ -504,7 +504,7 @@ Logs-concentrator collects the logs being sent by Lagoon clusters and augments t
 
 
 
-### Lagoon Logging
+### Lagoon-Logging
 
 Lagoon Logging collects the application, router and container logs from Lagoon projects, and sends them to the logs concentrator.  It needs to be installed onto each `lagoon-remote` instance.
 
@@ -520,8 +520,13 @@ Read more about Lagoon logging here: [https://github.com/uselagoon/lagoon-charts
     ``
 
     `helm upgrade --install --create-namespace --namespace lagoon-logging -f lagoon-logging-values.yaml lagoon-logging lagoon/lagoon-logging`
-3. If you'd like logs from `ingress-nginx` inside `lagoon-logging`:
-   1. Add the content of this gist to `ingress-nginx: `[https://gist.github.com/Schnitzel/bba1a8a437f52fbf123ead1cc0406bf1](https://gist.github.com/Schnitzel/bba1a8a437f52fbf123ead1cc0406bf1)
+
+#### Logging NGINX Ingress Controller
+
+If you'd like logs from `ingress-nginx` inside `lagoon-logging`:
+
+1. The ingress controller must be installed in the namespace `ingress-nginx`
+2. Add the content of this gist to `ingress-nginx: `[https://gist.github.com/Schnitzel/bba1a8a437f52fbf123ead1cc0406bf1](https://gist.github.com/Schnitzel/bba1a8a437f52fbf123ead1cc0406bf1)
 
 ## Lagoon Backups
 


### PR DESCRIPTION


 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The lagoon-logging chart expects a specific namespace that isn't documented anywhere. Even though the nginx ingress controller [example install command](https://kubernetes.github.io/ingress-nginx/deploy/#quick-start) is correct, it's possible for a user to install to a namespace that would not allow collecting the logs

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
