### PR TITLE
prune dangling images on docker-host automatically

### DIFF
--- a/images/docker-host/prune-images.sh
+++ b/images/docker-host/prune-images.sh
@@ -4,5 +4,5 @@ if ! docker -H ${DOCKER_HOST} info &> /dev/null; then
     echo "could not connect to ${DOCKER_HOST}"; exit 1
 fi
 
-# prune all images older than 7 days
-docker image prune -af --filter "until=168h"
+# prune all images older than 7 days or what is specified in the environment variable
+docker image prune -af --filter "until=${PRUNE_IMAGES_UNTIL:-168h}"

--- a/images/docker-host/prune-images.sh
+++ b/images/docker-host/prune-images.sh
@@ -6,3 +6,5 @@ fi
 
 # prune all images older than 7 days
 docker image prune -af --filter "until=168h"
+# after old images are pruned, clean up dangling images
+docker image prune -f


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Changelog Entry

After the time-based image prune runs, a second image prune will run which cleans up any dangling images. This will result in lower usage of docker-host volumes

# Closing issues

Closes #2966 
