### PR TITLE
use request-timeout for storage calculator

### DIFF
--- a/services/storage-calculator/calculate-storage.sh
+++ b/services/storage-calculator/calculate-storage.sh
@@ -107,7 +107,7 @@ echo "$ALL_ENVIRONMENTS" | jq -c '.data.environments[] | select((.environments |
 
     ${OC} rollout resume deployment/storage-calc
     echo "$OPENSHIFT_URL - $PROJECT_NAME - $ENVIRONMENT_NAME: redeploying storage-calc to mount volumes"
-    ${OC} rollout status deployment/storage-calc --watch --timeout=30s
+    ${OC} rollout status deployment/storage-calc --watch --request-timeout=30s
 
     POD=$(${OC} get pods -l app=storage-calc -o json | jq -r '[.items[] | select(.metadata.deletionTimestamp == null) | select(.status.phase == "Running")] | first | .metadata.name // empty')
 


### PR DESCRIPTION
the version of oc used in the storage-calculator (OC 3.11) doesn't support the --timeout command (but does have --request-timeout)

I did try building the storage-calculator image from kubectl instead of oc, but it got complicated, quickly...

fixes #2984 