### PR TITLE
Support checking the dbaas-operator http endpoint for  provider support

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -21,6 +21,8 @@ COPY helmcharts  /kubectl-build-deploy/helmcharts
 
 ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
 
+ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
+
 RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.5.0/lagoon-linter_0.5.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -273,6 +273,52 @@ do
     done
   fi
 
+  # functions used to check dbaas providers
+  ####
+  function checkDBaaSHealth() {
+    response_code=$(curl --write-out "%{http_code}\n" --silent --output /dev/null "${DBAAS_OPERATOR_HTTP}/healthz")
+    if [ "$response_code" == "200" ]; then
+      return 0
+    else
+      return 1
+    fi
+  }
+
+  function checkDBaaSProvider() {
+    response_json=$(curl --silent "${DBAAS_OPERATOR_HTTP}/$1/$2")
+    response_found=$(echo ${response_json} | jq -r '.result.found')
+    response_error=$(echo ${response_json} | jq -r '.error')
+    if [ "${response_error}" == "null" ]; then
+      echo $response_found
+      return 0
+    else
+      echo $response_error
+      return 1
+    fi
+  }
+
+  function getDBaaSEnvironment() {
+    dbaas_environment=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.$1\\.environment "${ENVIRONMENT_TYPE}")
+    # Allow the dbaas shared servicebroker plan to be overriden by environment in .lagoon.yml
+    environment_dbaas_override=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.overrides.$SERVICE_NAME.$1\\.environment false)
+    if [ ! $environment_dbaas_override == "false" ]; then
+      dbaas_environment=$environment_dbaas_override
+    fi
+    # If we have a dbaas environment type override in the api, consume it here
+    if [ ! -z "$LAGOON_DBAAS_ENVIRONMENT_TYPES" ]; then
+      IFS=',' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPES"
+      for LAGOON_DBAAS_ENVIRONMENT_TYPE in "${LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT[@]}"
+      do
+        IFS=':' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPE"
+        if [ "${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[0]}" == "$SERVICE_NAME" ]; then
+          dbaas_environment=${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[1]}
+        fi
+      done
+    fi
+    return dbaas_environment
+  }
+  ####
+
   # Previous versions of Lagoon used "python-ckandatapusher", this should be mapped to "python"
   if [[ "$SERVICE_TYPE" == "python-ckandatapusher" ]]; then
     SERVICE_TYPE="python"
@@ -286,9 +332,17 @@ do
     # mariadb-single deployed (probably from the past where there was no mariadb-shared yet, or mariadb-dbaas) and use that one
     if kubectl --insecure-skip-tls-verify -n ${NAMESPACE} get service "$SERVICE_NAME" &> /dev/null; then
       SERVICE_TYPE="mariadb-single"
-    # check if this cluster supports the default one, if not we assume that this cluster is not capable of shared mariadbs and we use a mariadb-single
-    # real basic check to see if the mariadbconsumer exists as a kind
-    elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]]; then
+    elif [[ checkDBaaSHealth ]]; then
+      # check if the dbaas operator responds to a health check
+      # if it does, then check if the dbaas operator has a provider matching the provider type that is expected
+      if checkDBaaSProvider mariadb $(getDBaaSEnvironment mariadb-dbaas); then
+        SERVICE_TYPE="mariadb-dbaas"
+      else
+        SERVICE_TYPE="mariadb-single"
+      fi
+    elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]] && [[ ! checkDBaaSHealth ]]; then
+      # check if this cluster supports the default one, if not we assume that this cluster is not capable of shared mariadbs and we use a mariadb-single
+      # real basic check to see if the mariadbconsumer exists as a kind
       SERVICE_TYPE="mariadb-dbaas"
     else
       SERVICE_TYPE="mariadb-single"
@@ -303,25 +357,7 @@ do
 
   if [[ "$SERVICE_TYPE" == "mariadb-dbaas" ]]; then
     # Default plan is the enviroment type
-    DBAAS_ENVIRONMENT=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.mariadb-dbaas\\.environment "${ENVIRONMENT_TYPE}")
-
-    # Allow the dbaas shared servicebroker plan to be overriden by environment in .lagoon.yml
-    ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.overrides.$SERVICE_NAME.mariadb-dbaas\\.environment false)
-    if [ ! $DBAAS_ENVIRONMENT_OVERRIDE == "false" ]; then
-      DBAAS_ENVIRONMENT=$ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE
-    fi
-
-    # If we have a dbaas environment type override in the api, consume it here
-    if [ ! -z "$LAGOON_DBAAS_ENVIRONMENT_TYPES" ]; then
-      IFS=',' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPES"
-      for LAGOON_DBAAS_ENVIRONMENT_TYPE in "${LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT[@]}"
-      do
-        IFS=':' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPE"
-        if [ "${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[0]}" == "$SERVICE_NAME" ]; then
-          DBAAS_ENVIRONMENT=${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[1]}
-        fi
-      done
-    fi
+    DBAAS_ENVIRONMENT=$(getDBaaSEnvironment mariadb-dbaas)
 
     MAP_SERVICE_NAME_TO_DBAAS_ENVIRONMENT["${SERVICE_NAME}"]="${DBAAS_ENVIRONMENT}"
   fi
@@ -334,6 +370,14 @@ do
     # postgres-single deployed (probably from the past where there was no postgres-shared yet, or postgres-dbaas) and use that one
     if kubectl --insecure-skip-tls-verify -n ${NAMESPACE} get service "$SERVICE_NAME" &> /dev/null; then
       SERVICE_TYPE="postgres-single"
+    elif [[ checkDBaaSHealth ]]; then
+      # check if the dbaas operator responds to a health check
+      # if it does, then check if the dbaas operator has a provider matching the provider type that is expected
+      if checkDBaaSProvider postgres $(getDBaaSEnvironment postgres-dbaas); then
+        SERVICE_TYPE="postgres-dbaas"
+      else
+        SERVICE_TYPE="postgres-single"
+      fi
     # heck if this cluster supports the default one, if not we assume that this cluster is not capable of shared PostgreSQL and we use a postgres-single
     # real basic check to see if the postgreSQLConsumer exists as a kind
     elif [[ "${CAPABILITIES[@]}" =~ "postgres.amazee.io/v1/PostgreSQLConsumer" ]]; then
@@ -351,13 +395,7 @@ do
 
   if [[ "$SERVICE_TYPE" == "postgres-dbaas" ]]; then
     # Default plan is the enviroment type
-    DBAAS_ENVIRONMENT=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.postgres-dbaas\\.environment "${ENVIRONMENT_TYPE}")
-
-    # Allow the dbaas shared servicebroker plan to be overriden by environment in .lagoon.yml
-    ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.overrides.$SERVICE_NAME.postgres-dbaas\\.environment false)
-    if [ ! $DBAAS_ENVIRONMENT_OVERRIDE == "false" ]; then
-      DBAAS_ENVIRONMENT=$ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE
-    fi
+    DBAAS_ENVIRONMENT=$(getDBaaSEnvironment postgres-dbaas)
 
     MAP_SERVICE_NAME_TO_DBAAS_ENVIRONMENT["${SERVICE_NAME}"]="${DBAAS_ENVIRONMENT}"
   fi
@@ -370,6 +408,14 @@ do
     # mongodb-single deployed (probably from the past where there was no mongodb-shared yet, or mongodb-dbaas) and use that one
     if kubectl --insecure-skip-tls-verify -n ${NAMESPACE} get service "$SERVICE_NAME" &> /dev/null; then
       SERVICE_TYPE="mongodb-single"
+    elif [[ checkDBaaSHealth ]]; then
+      # check if the dbaas operator responds to a health check
+      # if it does, then check if the dbaas operator has a provider matching the provider type that is expected
+      if checkDBaaSProvider postgres $(getDBaaSEnvironment mongodb-dbaas); then
+        SERVICE_TYPE="mongodb-dbaas"
+      else
+        SERVICE_TYPE="mongodb-single"
+      fi
     # heck if this cluster supports the default one, if not we assume that this cluster is not capable of shared MongoDB and we use a mongodb-single
     # real basic check to see if the MongoDBConsumer exists as a kind
     elif [[ "${CAPABILITIES[@]}" =~ "mongodb.amazee.io/v1/MongoDBConsumer" ]]; then
@@ -386,26 +432,7 @@ do
   fi
 
   if [[ "$SERVICE_TYPE" == "mongodb-dbaas" ]]; then
-    # Default plan is the enviroment type
-    DBAAS_ENVIRONMENT=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$COMPOSE_SERVICE.labels.lagoon\\.mongodb-dbaas\\.environment "${ENVIRONMENT_TYPE}")
-
-    # Allow the dbaas shared servicebroker plan to be overriden by environment in .lagoon.yml
-    ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.overrides.$SERVICE_NAME.mongodb-dbaas\\.environment false)
-    if [ ! $DBAAS_ENVIRONMENT_OVERRIDE == "false" ]; then
-      DBAAS_ENVIRONMENT=$ENVIRONMENT_DBAAS_ENVIRONMENT_OVERRIDE
-    fi
-
-    # If we have a dbaas environment type override in the api, consume it here
-    if [ ! -z "$LAGOON_DBAAS_ENVIRONMENT_TYPES" ]; then
-      IFS=',' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPES"
-      for LAGOON_DBAAS_ENVIRONMENT_TYPE in "${LAGOON_DBAAS_ENVIRONMENT_TYPES_SPLIT[@]}"
-      do
-        IFS=':' read -ra LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT <<< "$LAGOON_DBAAS_ENVIRONMENT_TYPE"
-        if [ "${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[0]}" == "$SERVICE_NAME" ]; then
-          DBAAS_ENVIRONMENT=${LAGOON_DBAAS_ENVIRONMENT_TYPE_SPLIT[1]}
-        fi
-      done
-    fi
+    DBAAS_ENVIRONMENT=$(getDBaaSEnvironment mongodb-dbaas)
 
     MAP_SERVICE_NAME_TO_DBAAS_ENVIRONMENT["${SERVICE_NAME}"]="${DBAAS_ENVIRONMENT}"
   fi

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -314,7 +314,7 @@ do
         fi
       done
     fi
-    return $dbaas_environment
+    echo $dbaas_environment
   }
   ####
 

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -315,7 +315,7 @@ do
         fi
       done
     fi
-    return dbaas_environment
+    return $dbaas_environment
   }
   ####
 

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -289,10 +289,9 @@ do
     response_found=$(echo ${response_json} | jq -r '.result.found')
     response_error=$(echo ${response_json} | jq -r '.error')
     if [ "${response_error}" == "null" ]; then
-      echo $response_found
       return 0
     else
-      echo $response_error
+      echo $response_error 1>&2
       return 1
     fi
   }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Currently builds check for the existence of CRDs for the dbaas-operator to know which providers it can provision. This has a downside in that CRDs are installed by default for the dbaas-operator, and there is no easy way to remove these without the potential for them to return.

The dbaas-operator has been updated to expose a http endpoint that can be used to check if a provider of the requested type exists to be provisioned against. Lagoon builds will now use this check first, before falling back to the CRD check. This allows for backwards compatibility if the dbaas-operator installed is not updated to support the new http endpoint yet.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

