### PR TITLE
Add image scanning and SBOM creation back to lagoon tag publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,6 +187,18 @@ pipeline {
         sh script: "make -O -j$NPROC publish-uselagoon-baseimages publish-uselagoon-serviceimages publish-uselagoon-taskimages", label: "Publishing built images to uselagoon"
       }
     }
+    stage ('scan built images') {
+      when {
+        anyOf {
+          branch 'testing-scans'
+          buildingTag()
+        }
+      }
+      sh script: 'make scan-images', label: "perform scan routines"
+      sh script:  'find ./scans/*trivy* -type f | xargs tail -n +1', label: "Show Trivy vulnerability scan results"
+      sh script:  'find ./scans/*grype* -type f | xargs tail -n +1', label: "Show Grype vulnerability scan results"
+      sh script:  'find ./scans/*syft* -type f | xargs tail -n +1', label: "Show Syft SBOM results"
+    }
   }
 
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ pipeline {
     stage ('scan built images') {
       when {
         anyOf {
-          branch 'testing-scans'
+          branch 'testing/scans'
           buildingTag()
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,10 +194,12 @@ pipeline {
           buildingTag()
         }
       }
-      sh script: 'make scan-images', label: "perform scan routines"
-      sh script:  'find ./scans/*trivy* -type f | xargs tail -n +1', label: "Show Trivy vulnerability scan results"
-      sh script:  'find ./scans/*grype* -type f | xargs tail -n +1', label: "Show Grype vulnerability scan results"
-      sh script:  'find ./scans/*syft* -type f | xargs tail -n +1', label: "Show Syft SBOM results"
+      steps {
+        sh script: 'make scan-images', label: "perform scan routines"
+        sh script:  'find ./scans/*trivy* -type f | xargs tail -n +1', label: "Show Trivy vulnerability scan results"
+        sh script:  'find ./scans/*grype* -type f | xargs tail -n +1', label: "Show Grype vulnerability scan results"
+        sh script:  'find ./scans/*syft* -type f | xargs tail -n +1', label: "Show Syft SBOM results"
+      }
     }
   }
 


### PR DESCRIPTION
This PR re-adds the generation of a SBOM, and the accompanying Trivy/Grype scans.

This is an intermediate step until we get a full lagoon-images SBOM solution running.