### PR TITLE
Use local cached copy of svcat for oc image

### DIFF
--- a/images/kubectl/Dockerfile
+++ b/images/kubectl/Dockerfile
@@ -49,8 +49,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing au
     && chmod +x /usr/bin/yq3 \
     && curl -Lo /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 \
     && chmod +x /usr/bin/yq \
-    && curl -Lo /usr/bin/svcat https://download.svcat.sh/cli/latest-v0.2/linux/amd64/svcat \
-    && chmod +x /usr/bin/svcat \
     && curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
     && echo "${HELM_SHA256}  /tmp/helm.tar.gz" | sha256sum -c -  \
     && mkdir /tmp/helm \

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -22,6 +22,8 @@ COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
 COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 
+COPY svcat /usr/bin/svcat
+
 RUN chmod g+w /etc/passwd \
     && mkdir -p /home
 
@@ -58,8 +60,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing au
     echo "$OC_SHA256  /tmp/openshift-origin-client-tools.tar" | sha256sum -c -  && \
     mkdir /tmp/openshift-origin-client-tools && \
     tar -xzf /tmp/openshift-origin-client-tools.tar -C /tmp/openshift-origin-client-tools --strip-components=1 && \
-    install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar && \
-    curl -Lo /usr/bin/svcat https://download.svcat.sh/cli/latest-v0.2/linux/amd64/svcat && \
-    chmod +x /usr/bin/svcat
+    install /tmp/openshift-origin-client-tools/oc /usr/bin/oc && rm -rf /tmp/openshift-origin-client-tools  && rm -rf /tmp/openshift-origin-client-tools.tar
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]

--- a/images/oc/Dockerfile
+++ b/images/oc/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
 COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 
-COPY svcat /usr/bin/svcat
+COPY svcat-0.2.3 /usr/bin/svcat
 
 RUN chmod g+w /etc/passwd \
     && mkdir -p /home


### PR DESCRIPTION
The upstream svcat download host has proven to be unstable - this PR copies a cached binary into the oc image instead of downloading.