### PR TITLE
add buildName label to sbom configMap

### DIFF
--- a/images/kubectl-build-deploy-dind/scripts/exec-generate-sbom-configmap.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-generate-sbom-configmap.sh
@@ -31,6 +31,7 @@ if [ -f "${SBOM_OUTPUT_FILE}" ]; then
             -n ${NAMESPACE} \
             label configmap ${SBOM_CONFIGMAP} \
             lagoon.sh/insightsType=sbom \
+            lagoon.sh/buildName=${LAGOON_BUILD_NAME} \
             lagoon.sh/project=${PROJECT} \
             lagoon.sh/environment=${ENVIRONMENT} \
             lagoon.sh/service=${IMAGE_NAME}
@@ -45,6 +46,7 @@ if [ -f "${SBOM_OUTPUT_FILE}" ]; then
             -n ${NAMESPACE} \
             label configmap ${SBOM_CONFIGMAP} \
             lagoon.sh/insightsType=sbom \
+            lagoon.sh/buildName=${LAGOON_BUILD_NAME} \
             lagoon.sh/project=${PROJECT} \
             lagoon.sh/environment=${ENVIRONMENT} \
             lagoon.sh/service=${IMAGE_NAME}


### PR DESCRIPTION
This PR adds a lagoon.sh/buildName label to the configMap generated to hold the SBOM, which will make it easier to match on later.