### PR TITLE
Adjust permissions on openshift:view

### DIFF
--- a/docs/administering-lagoon/rbac.md
+++ b/docs/administering-lagoon/rbac.md
@@ -109,7 +109,7 @@ Here is a table that lists the roles and the access they have:
 | deleteOpenshift | openshift | delete |  | Yes | Yes | No | No | No | No | No |  |
 | deleteAllOpenshifts | openshift | deleteAll |  | Yes | Yes | No | No | No | No | No |  |
 | getAllOpenshifts | openshift | viewAll |  | Yes | No | No | No | No | No | No |  |
-| getOpenshiftByProjectId | openshift | view | projectID | Yes | Yes | Yes | Yes | No | No | No |  |
+| getOpenshiftByProjectId | openshift | view | projectID | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |
 | addNotificationToProject | project | addNotification | projectID | Yes | Yes | Yes | Yes | No | No | No |  |
 | removeNotificationFromProject | project | removeNotification | projectID | Yes | Yes | Yes | Yes | No | No | No |  |
 | addProject | project | add |  | Yes | Yes | Yes | Yes | Yes | Yes | Yes |  |

--- a/services/api/src/resources/openshift/resolvers.ts
+++ b/services/api/src/resources/openshift/resolvers.ts
@@ -10,7 +10,7 @@ const attrFilter = async (hasPermission, entity) => {
     await hasPermission('openshift', 'view:token');
     return entity;
   } catch (err) {
-    return R.omit(['token'], entity);
+    return R.omit(['token','consoleUrl','monitoringConfig'], entity);
   }
 };
 
@@ -126,12 +126,13 @@ export const getOpenshiftByEnvironmentId: ResolverFn = async (
   { sqlClientPool, hasPermission }
 ) => {
   // get the project id for the environment
-  const { id: projectId } = await projectHelpers(
+  const project = await projectHelpers(
     sqlClientPool
   ).getProjectByEnvironmentId(eid);
+
   // check permissions on the project
   await hasPermission('openshift', 'view', {
-    project: projectId
+    project: project.project
   });
 
   const rows = await query(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The UI exposes some openshift fields to users now, but permissions errors occur for certain users

This makes `openshift:view` available to Guest and above now to allow the UI to display this information, but also implements some features to omit fields unless the user has `openshift:viewToken` permission

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

