### PR TITLE
Add cluster permission to allow downloading of reports from Kibana

### DIFF
--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -42,6 +42,11 @@ export const OpendistroSecurityOperations = (
 
     const groupProjectPermissions = {
       body: {
+        cluster_permissions: [
+          {
+            allowed_actions: ['cluster:admin/opendistro/reports/menu/download']
+          }
+        ],
         index_permissions: [
           {
             index_patterns: [],


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Changelog Entry
Adding the role cluster-level permission `cluster:admin/opendistro/reports/menu/download` to allow users to download their reports via Kibana

# Closing issues

Closes #2965 
