### PR TITLE
implement kubectl check for lagoon-build and add more tests

### DIFF
--- a/local-dev/git/Dockerfile
+++ b/local-dev/git/Dockerfile
@@ -46,7 +46,8 @@ RUN mkdir -m 700 /git/.ssh && \
 	git --bare init /git/python.git && \
 	git --bare init /git/node-mongodb.git && \
 	git --bare init /git/tasks.git && \
-	git --bare init /git/image-cache.git
+	git --bare init /git/image-cache.git && \
+	git --bare init /git/generic.git
 
 USER root
 

--- a/local-dev/git/entrypoint.sh
+++ b/local-dev/git/entrypoint.sh
@@ -4,4 +4,6 @@ if [ "$GIT_AUTHORIZED_KEYS" ]; then
   echo -e "$GIT_AUTHORIZED_KEYS" > /git/.ssh/authorized_keys
 fi
 
+ls -d -- git/*
+
 exec /sbin/runsvdir /etc/service

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -23,9 +23,10 @@ RUN apk add --no-cache --virtual .build-deps \
       PyJWT==2.3.* \
       requests==2.26.* \
       jmespath==0.10.* \
+      kubernetes==21.7.* \
     && apk del .build-deps
 
-RUN ansible-galaxy collection install ansible.posix community.general
+RUN ansible-galaxy collection install ansible.posix community.general kubernetes.core
 
 # download, extract and install kubectl binary
 # https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#downloads-for-v1204

--- a/tests/files/generic/GENERIC_FILES.md
+++ b/tests/files/generic/GENERIC_FILES.md
@@ -1,0 +1,1 @@
+# Copy the project to deploy into this folder

--- a/tests/files/node-mongodb/dbaas/docker-compose.yml
+++ b/tests/files/node-mongodb/dbaas/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: .
       dockerfile: Dockerfile.mongo
     labels:
-      lagoon.type: mongodb-dbaas
+      lagoon.type: mongodb
     # ports:
     #   - "27027:27017"
     # networks:

--- a/tests/files/node-mongodb/dbaas/docker-compose.yml
+++ b/tests/files/node-mongodb/dbaas/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: .
       dockerfile: Dockerfile.mongo
     labels:
-      lagoon.type: mongodb
+      lagoon.type: mongodb-dbaas
     # ports:
     #   - "27027:27017"
     # networks:

--- a/tests/tasks/api/deploy-no-sha.yaml
+++ b/tests/tasks/api/deploy-no-sha.yaml
@@ -22,6 +22,41 @@
     - fail:
         msg: "unsuccessful deploy"
       when: apiresponse.json.data.deployEnvironmentBranch != "success"
+    - name: Get the build pod name
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Running
+        wait_sleep: 1
+        wait_timeout: 60
+      register: build_pod
+    - name: Print build_pod
+      ansible.builtin.debug:
+        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+    - name: Wait until the build pod is completed
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        name: "{{ build_pod.resources[0].metadata.name }}"
+        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Succeeded
+        wait_condition:
+          type: Ready
+          reason: PodCompleted
+          status: "False"
+        wait_sleep: 10
+        wait_timeout: 600
+      register: build_complete
+    - name: Print build_complete
+      ansible.builtin.debug:
+        msg: "build_complete: {{ build_complete.resources[0].metadata.name }} {{ build_complete.resources[0].status.phase }}"
     - name: "Set the retry count back to 0 when successful"
       set_fact:
         retry_count: 0

--- a/tests/tasks/api/deploy-no-sha.yaml
+++ b/tests/tasks/api/deploy-no-sha.yaml
@@ -26,7 +26,7 @@
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:
@@ -42,7 +42,7 @@
         kind: Pod
         wait: yes
         name: "{{ build_pod.resources[0].metadata.name }}"
-        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:

--- a/tests/tasks/api/deploy-pullrequest.yaml
+++ b/tests/tasks/api/deploy-pullrequest.yaml
@@ -26,7 +26,7 @@
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        namespace: "{{ project | regex_replace('_', '-') }}-pr-{{ git_pr_number }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:
@@ -42,7 +42,7 @@
         kind: Pod
         wait: yes
         name: "{{ build_pod.resources[0].metadata.name }}"
-        namespace: "{{ project | regex_replace('_', '-') }}-pr-{{ git_pr_number }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:

--- a/tests/tasks/api/deploy-pullrequest.yaml
+++ b/tests/tasks/api/deploy-pullrequest.yaml
@@ -22,6 +22,41 @@
     - fail:
         msg: "unsuccessful deploy"
       when: apiresponse.json.data.deployEnvironmentPullrequest != "success"
+    - name: Get the build pod name
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        namespace: "{{ project | regex_replace('_', '-') }}-pr-{{ git_pr_number }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Running
+        wait_sleep: 1
+        wait_timeout: 60
+      register: build_pod
+    - name: Print build_pod
+      ansible.builtin.debug:
+        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+    - name: Wait until the build pod is completed
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        name: "{{ build_pod.resources[0].metadata.name }}"
+        namespace: "{{ project | regex_replace('_', '-') }}-pr-{{ git_pr_number }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Succeeded
+        wait_condition:
+          type: Ready
+          reason: PodCompleted
+          status: "False"
+        wait_sleep: 10
+        wait_timeout: 600
+      register: build_complete
+    - name: Print build_complete
+      ansible.builtin.debug:
+        msg: "build_complete: {{ build_complete.resources[0].metadata.name }} {{ build_complete.resources[0].status.phase }}"
     - name: "Set the retry count back to 0 when successful"
       set_fact:
         retry_count: 0

--- a/tests/tasks/api/deploy-sha.yaml
+++ b/tests/tasks/api/deploy-sha.yaml
@@ -22,6 +22,41 @@
     - fail:
         msg: "unsuccessful deploy"
       when: apiresponse.json.data.deployEnvironmentBranch != "success"
+    - name: Get the build pod name
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Running
+        wait_sleep: 1
+        wait_timeout: 60
+      register: build_pod
+    - name: Print build_pod
+      ansible.builtin.debug:
+        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+    - name: Wait until the build pod is completed
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: yes
+        name: "{{ build_pod.resources[0].metadata.name }}"
+        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        label_selectors:
+          - lagoon.sh/jobType = build
+        field_selectors:
+          - status.phase=Succeeded
+        wait_condition:
+          type: Ready
+          reason: PodCompleted
+          status: "False"
+        wait_sleep: 10
+        wait_timeout: 600
+      register: build_complete
+    - name: Print build_complete
+      ansible.builtin.debug:
+        msg: "build_complete: {{ build_complete.resources[0].metadata.name }} {{ build_complete.resources[0].status.phase }}"
     - name: "Set the retry count back to 0 when successful"
       set_fact:
         retry_count: 0

--- a/tests/tasks/api/deploy-sha.yaml
+++ b/tests/tasks/api/deploy-sha.yaml
@@ -26,7 +26,7 @@
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:
@@ -42,7 +42,7 @@
         kind: Pod
         wait: yes
         name: "{{ build_pod.resources[0].metadata.name }}"
-        namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+        namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build
         field_selectors:

--- a/tests/tests/active-standby/active-standby.yaml
+++ b/tests/tests/active-standby/active-standby.yaml
@@ -15,6 +15,7 @@
   vars:
     branch: "{{ prod_branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ prod_branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -33,6 +34,7 @@
   vars:
     branch: "{{ standby_branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ standby_branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/api/deploy-branch.yaml
+++ b/tests/tests/api/deploy-branch.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -45,6 +46,7 @@
     branch: "{{ branch }}"
     project: "{{ project }}"
     sha: "{{ second_commit_hash }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-sha.yaml
 
@@ -62,6 +64,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -79,6 +82,7 @@
     branch: "{{ branch }}"
     project: "{{ project }}"
     sha: "{{ second_commit_hash }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-sha.yaml
 

--- a/tests/tests/api/deploy-pullrequest.yaml
+++ b/tests/tests/api/deploy-pullrequest.yaml
@@ -41,6 +41,7 @@
     git_pr_commit_hash: "{{ pr_commit_hash }}"
     git_pr_number: 1
     git_pr_title: "PR Title"
+    namespace: "{{ project | regex_replace('_', '-') }}-pr-1"
   tasks:
   - include: ../../tasks/api/deploy-pullrequest.yaml
 
@@ -80,6 +81,7 @@
     git_pr_commit_hash: "{{ pr_2nd_commit_hash }}"
     git_pr_number: 1
     git_pr_title: "PR Title - UPDATE"
+    namespace: "{{ project | regex_replace('_', '-') }}-pr-1"
   tasks:
   - include: ../../tasks/api/deploy-pullrequest.yaml
 

--- a/tests/tests/api/promote.yaml
+++ b/tests/tests/api/promote.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ source_environment }}"
     project: "{{ project }}"
+    namespace:  "{{ project }}-{{ source_environment }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/api/push.yaml
+++ b/tests/tests/api/push.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/dbaas.yaml
+++ b/tests/tests/dbaas.yaml
@@ -1,0 +1,65 @@
+---
+- include: features/random-wait.yaml
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-drupal-80-{{ cluster_type }}
+    git_repo_name: drupal-80.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: drupal/drupal.yaml
+  vars:
+    testname: "Drupal 9 composer PHP 8.0 - MARIADB DBAAS {{ cluster_type|upper }}"
+    drupal_version: 9
+    db: mariadb
+    php_version: 8.0
+    git_repo_name: drupal-80.git
+    project: ci-drupal-80-{{ cluster_type }}
+    branch: drupal9-php80-mariadb-dbaas
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-drupal-80-{{ cluster_type }}
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-drupal-pg-{{ cluster_type }}
+    git_repo_name: drupal-postgres.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: drupal/drupal.yaml
+  vars:
+    testname: "Drupal 9 composer PHP 8.0 - POSTGRES DBAAS {{ cluster_type|upper }}"
+    drupal_version: 9
+    db: postgres
+    php_version: 8.0
+    git_repo_name: drupal-postgres.git
+    project: ci-drupal-pg-{{ cluster_type }}
+    branch: drupal9-php80-postgres-dbaas
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-drupal-pg-{{ cluster_type }}
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-node-mongodb-{{ cluster_type }}
+    git_repo_name: node-mongodb.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: node-mongodb/node-mongodb.yaml
+  vars:
+    testname: "Node 16 - MONGODB DBAAS {{ cluster_type|upper }}"
+    node_version: 16
+    db: mongodb
+    git_repo_name: node-mongodb.git
+    project: ci-node-mongodb-{{ cluster_type }}
+    branch: node-mongodb-dbaas
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-node-mongodb-{{ cluster_type }}

--- a/tests/tests/deploytarget/deploytarget.yaml
+++ b/tests/tests/deploytarget/deploytarget.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -37,6 +38,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/drupal/drupal.yaml
+++ b/tests/tests/drupal/drupal.yaml
@@ -15,6 +15,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -38,6 +39,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/drupal/drush-la.yaml
+++ b/tests/tests/drupal/drush-la.yaml
@@ -17,6 +17,7 @@
   vars:
     branch: "drush-first"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-drush-first"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -39,6 +40,7 @@
   vars:
     branch: "drush-second"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-drush-second"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -219,6 +221,7 @@
   vars:
     branch: "foo/bar"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-foo-bar"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/drupal/drush-sa.yaml
+++ b/tests/tests/drupal/drush-sa.yaml
@@ -17,6 +17,7 @@
   vars:
     branch: "drush-first"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-drush-first"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -39,6 +40,7 @@
   vars:
     branch: "drush-second"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-drush-second"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -211,6 +213,7 @@
   vars:
     branch: "foo/bar"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-foo-bar"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/drush.yaml
+++ b/tests/tests/drush.yaml
@@ -17,6 +17,7 @@
     drupal_version: 9
     db: mariadb
     php_version: 8.0
+    overwrite_docker_compose: docker-compose.single.yml
     git_repo_name: drush.git
     project: ci-drush-la-{{ cluster_type }}
 

--- a/tests/tests/elasticsearch/elasticsearch.yaml
+++ b/tests/tests/elasticsearch/elasticsearch.yaml
@@ -16,6 +16,7 @@
     project: "{{ project }}"
     expected_key: "number_of_nodes"
     expected_value: "{{ node_count }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -35,17 +35,16 @@
     branch: ingress-annotations
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
 
-# TODO - undisable once we have a way to acquire the namespace via the API to feed to kubectl for lagoon-build checks
-# - include: features/short-router-url.yaml
-#   vars:
-#     testname: "SHORT ROUTER URL {{ cluster_type|upper }}"
-#     git_repo_name: features.git
-#     project: ci-features-{{ cluster_type }}
-#     branch: short-router-url-from-a-very-long-environment-name-like-this
-#     # lagoon_environment is truncated for very long branches.
-#     # See commons/src/tasks.ts
-#     lagoon_environment: short-router-url-from-a-very-l-ebe8
-#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
+- include: features/short-router-url.yaml
+  vars:
+    testname: "SHORT ROUTER URL {{ cluster_type|upper }}"
+    git_repo_name: features.git
+    project: ci-features-{{ cluster_type }}
+    branch: short-router-url-from-a-very-long-environment-name-like-this
+    # lagoon_environment is truncated for very long branches.
+    # See commons/src/tasks.ts
+    lagoon_environment: short-router-url-from-a-very-l-ebe8
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
 
 - include: features/namespace-labels.yaml
   vars:

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -35,16 +35,17 @@
     branch: ingress-annotations
     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
 
-- include: features/short-router-url.yaml
-  vars:
-    testname: "SHORT ROUTER URL {{ cluster_type|upper }}"
-    git_repo_name: features.git
-    project: ci-features-{{ cluster_type }}
-    branch: short-router-url-from-a-very-long-environment-name-like-this
-    # lagoon_environment is truncated for very long branches.
-    # See commons/src/tasks.ts
-    lagoon_environment: short-router-url-from-a-very-l-ebe8
-    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
+# TODO - undisable once we have a way to acquire the namespace via the API to feed to kubectl for lagoon-build checks
+# - include: features/short-router-url.yaml
+#   vars:
+#     testname: "SHORT ROUTER URL {{ cluster_type|upper }}"
+#     git_repo_name: features.git
+#     project: ci-features-{{ cluster_type }}
+#     branch: short-router-url-from-a-very-long-environment-name-like-this
+#     # lagoon_environment is truncated for very long branches.
+#     # See commons/src/tasks.ts
+#     lagoon_environment: short-router-url-from-a-very-l-ebe8
+#     check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
 
 - include: features/namespace-labels.yaml
   vars:

--- a/tests/tests/features/autogenerated-routes-disabled.yaml
+++ b/tests/tests/features/autogenerated-routes-disabled.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/cronjobs.yaml
+++ b/tests/tests/features/cronjobs.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -87,6 +88,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/disable-inject-git-sha.yaml
+++ b/tests/tests/features/disable-inject-git-sha.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/dot-env.yaml
+++ b/tests/tests/features/dot-env.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/environment-templates.yaml
+++ b/tests/tests/features/environment-templates.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/environment-type.yaml
+++ b/tests/tests/features/environment-type.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/fastly-annotations.yaml
+++ b/tests/tests/features/fastly-annotations.yaml
@@ -56,6 +56,7 @@
 #   vars:
 #     branch: "{{ branch }}"
 #     project: "{{ project }}"
+#     namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
 #   tasks:
 #   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -90,6 +91,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -136,6 +138,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/ingress-annotations.yaml
+++ b/tests/tests/features/ingress-annotations.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/lagoon-api-variables.yaml
+++ b/tests/tests/features/lagoon-api-variables.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/lagoon-type-override.yaml
+++ b/tests/tests/features/lagoon-type-override.yaml
@@ -24,6 +24,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -56,6 +57,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/multiproject.yaml
+++ b/tests/tests/features/multiproject.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project1 }}"
+    namespace: "{{ project1 }}-{{ branch }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -23,6 +24,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project2 }}"
+    namespace: "{{ project2 }}-{{ branch }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/namespace-labels.yaml
+++ b/tests/tests/features/namespace-labels.yaml
@@ -13,6 +13,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/openshift-limit.yaml
+++ b/tests/tests/features/openshift-limit.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/promote.yaml
+++ b/tests/tests/features/promote.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ source_environment }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ source_environment | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/random-wait.yaml
+++ b/tests/tests/features/random-wait.yaml
@@ -1,7 +1,7 @@
-- name: "{{ testname }} - wait for >30 seconds to give an eventual running deployment time to run, after that check again if the first commit is still there"
+- name: "{{ testname }} - wait for >5 seconds to give an eventual running deployment time to run, after that check again if the first commit is still there"
   hosts: localhost
   serial: 1
   vars:
-    seconds: "{{ 120 | random(start=30, step=10) }}"
+    seconds: "{{ 30 | random(start=5, step=5) }}"
   tasks:
   - include: ../../tasks/pause.yaml

--- a/tests/tests/features/remote-shell.yaml
+++ b/tests/tests/features/remote-shell.yaml
@@ -13,6 +13,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/route-env-variables.yaml
+++ b/tests/tests/features/route-env-variables.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/short-router-url.yaml
+++ b/tests/tests/features/short-router-url.yaml
@@ -14,6 +14,8 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    lagoon_environment: "{{ lagoon_environment }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ lagoon_environment }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/features/subfolder.yaml
+++ b/tests/tests/features/subfolder.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/generic.yaml
+++ b/tests/tests/generic.yaml
@@ -1,0 +1,23 @@
+---
+# - include: features/random-wait.yaml
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-generic-{{ cluster_type }}
+    git_repo_name: generic.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: generic/generic.yaml
+  vars:
+    testname: "Generic {{ cluster_type|upper }}"
+    git_repo_name: generic.git
+    project: ci-generic-{{ cluster_type }}
+    branch: generic-main
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-generic-{{ cluster_type }}

--- a/tests/tests/generic/generic.yaml
+++ b/tests/tests/generic/generic.yaml
@@ -1,0 +1,18 @@
+
+- name: "{{ testname }} - init git, add files, commit, git push"
+  hosts: localhost
+  serial: 1
+  vars:
+    git_files: "generic/"
+  tasks:
+  - include: ../../tasks/git-init.yaml
+  - include: ../../tasks/git-add-commit-push.yaml
+
+- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
+  hosts: localhost
+  serial: 1
+  vars:
+    branch: "{{ branch }}"
+    project: "{{ project }}"
+  tasks:
+  - include: ../../tasks/api/deploy-no-sha.yaml

--- a/tests/tests/generic/generic.yaml
+++ b/tests/tests/generic/generic.yaml
@@ -14,5 +14,6 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml

--- a/tests/tests/image-cache/image-cache.yaml
+++ b/tests/tests/image-cache/image-cache.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -32,6 +33,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/nginx/nginx.yaml
+++ b/tests/tests/nginx/nginx.yaml
@@ -42,6 +42,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -65,6 +66,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -92,6 +94,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -127,6 +130,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/node-mongodb/node-mongodb-single.yaml
+++ b/tests/tests/node-mongodb/node-mongodb-single.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/node-mongodb/node-mongodb.yaml
+++ b/tests/tests/node-mongodb/node-mongodb.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/node-various.yaml
+++ b/tests/tests/node-various.yaml
@@ -1,0 +1,63 @@
+---
+- include: features/random-wait.yaml
+
+- include: features/api-token.yaml
+  vars:
+    testname: "API TOKEN"
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-node-mongodb-{{ cluster_type }}
+    git_repo_name: node-mongodb.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: node-mongodb/node-mongodb-single.yaml
+  vars:
+    testname: "Node 16 - MONGODB SINGLE {{ cluster_type|upper }}"
+    node_version: 16
+    db: mongodb
+    git_repo_name: node-mongodb.git
+    project: ci-node-mongodb-{{ cluster_type }}
+    branch: node-mongodb-single
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-node-mongodb-{{ cluster_type }}
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-elasticsearch-{{ cluster_type }}
+    git_repo_name: elasticsearch.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: elasticsearch/elasticsearch.yaml
+  vars:
+    testname: "ELASTICSEARCH SINGLE NODE {{ cluster_type|upper }}"
+    git_repo_name: elasticsearch.git
+    project: ci-elasticsearch-{{ cluster_type }}
+    branch: elasticsearch
+    url: "http://nginx.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/_cluster/health"
+    node_count: 1
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-elasticsearch-{{ cluster_type }}
+
+- include: api/add-project.yaml
+  vars:
+    project: ci-image-cache-{{ cluster_type }}
+    git_repo_name: image-cache.git
+    git_url: "{{ localgit_url }}/{{ git_repo_name }}"
+
+- include: image-cache/image-cache.yaml
+  vars:
+    testname: "image-cache {{ cluster_type|upper }}"
+    git_repo_name: image-cache.git
+    project: ci-image-cache-{{ cluster_type }}
+    branch: image-cache
+    check_url: "http://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}"
+    openshift_project_name: ci-image-cache-{{ cluster_type }}-image-cache
+
+- include: api/delete-project.yaml
+  vars:
+    project: ci-image-cache-{{ cluster_type }}

--- a/tests/tests/python/deploy-branch.yaml
+++ b/tests/tests/python/deploy-branch.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -45,6 +46,7 @@
     branch: "{{ branch }}"
     project: "{{ project }}"
     sha: "{{ second_commit_hash }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-sha.yaml
 
@@ -62,6 +64,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 
@@ -79,6 +82,7 @@
     branch: "{{ branch }}"
     project: "{{ project }}"
     sha: "{{ second_commit_hash }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-sha.yaml
 

--- a/tests/tests/python/deploy-pullrequest.yaml
+++ b/tests/tests/python/deploy-pullrequest.yaml
@@ -41,6 +41,7 @@
     git_pr_commit_hash: "{{ pr_commit_hash }}"
     git_pr_number: "1"
     git_pr_title: "PR Title"
+    namespace: "{{ project | regex_replace('_', '-') }}-pr-1"
   tasks:
   - include: ../../tasks/api/deploy-pullrequest.yaml
 
@@ -87,6 +88,7 @@
     git_pr_commit_hash: "{{ pr_2nd_commit_hash }}"
     git_pr_number: "1"
     git_pr_title: "PR Title - UPDATE"
+    namespace: "{{ project | regex_replace('_', '-') }}-pr-1"
   tasks:
   - include: ../../tasks/api/deploy-pullrequest.yaml
 

--- a/tests/tests/python/push.yaml
+++ b/tests/tests/python/push.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 

--- a/tests/tests/tasks/tasks.yaml
+++ b/tests/tests/tasks/tasks.yaml
@@ -14,6 +14,7 @@
   vars:
     branch: "{{ branch }}"
     project: "{{ project }}"
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
   tasks:
   - include: ../../tasks/api/deploy-no-sha.yaml
 


### PR DESCRIPTION
This PR implements a kubectl check for a lagoon-build pod whenever a branch is deployed. It performs a first check to get the name of the started pod, and then follows that pod until it reaches a "completed" status, before handing back to the ansible task that called it. This completely removes the need for the 30/90 retries we used to check if a service has been deployed. 

There are still some tidyups to do - removing a lot of the cruft around retries and loops etc.

In additon, a couple of additional tests have been added (dbaas and generic), and some other tidyups happened.