### PR TITLE
feat: add configuration-complete readiness signalling to keycloak

### DIFF
--- a/services/keycloak/start.sh
+++ b/services/keycloak/start.sh
@@ -1700,6 +1700,9 @@ function configure_keycloak {
     remove_billing_modifier
 
     echo "Config of Keycloak done. Log in via admin user '$KEYCLOAK_ADMIN_USER' and password '$KEYCLOAK_ADMIN_PASSWORD'"
+
+    # signal config complete
+    touch /tmp/keycloak-config-complete
 }
 
 /opt/jboss/keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_ADMIN_USER --password $KEYCLOAK_ADMIN_PASSWORD


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

By signalling when keycloak configuration is complete we can avoid some of the racy workarounds in the charts and tests which currently wait for some period after keycloak is "ready" according to the Kubernetes API to allow its configuration startup script to run to completion.

I considered using `/tmp/ready` as used in the [entrypoint readiness script](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/lagoon/entrypoints/999-readiness.sh) but did not because:
* the keycloak image already contains this entrypoint script
* keycloak's `start.sh` forks the configuration into a background process which completes asynchronously after the keycloak container has started running, so the entrypoint scripts have already completed long before configuration completes

The associated Lagoon Charts PR is https://github.com/uselagoon/lagoon-charts/pull/387

# Closing issues

n/a
