### PR TITLE
fix: handle symlink to charts directory other than a local subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -770,8 +770,8 @@ kind/retest:
 		&& export IMAGE_REGISTRY="registry.$$(./local-dev/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/library" \
 		&& cd lagoon-charts.kind.lagoon \
 		&& $(MAKE) fill-test-ci-values TESTS=$(TESTS) IMAGE_TAG=$(SAFE_BRANCH_NAME) \
-			HELM=$$(realpath ../local-dev/helm) KUBECTL=$$(realpath ../local-dev/kubectl) \
-			JQ=$$(realpath ../local-dev/jq) \
+			HELM=$$(cd .. && realpath ./local-dev/helm) KUBECTL=$$(cd .. && realpath ./local-dev/kubectl) \
+			JQ=$$(cd .. && realpath ./local-dev/jq) \
 			OVERRIDE_BUILD_DEPLOY_DIND_IMAGE=$$IMAGE_REGISTRY/kubectl-build-deploy-dind:$(SAFE_BRANCH_NAME) \
 			IMAGE_REGISTRY=$$IMAGE_REGISTRY \
 			SKIP_ALL_DEPS=true \
@@ -781,7 +781,7 @@ kind/retest:
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \
-			--volume "$$(realpath ../kubeconfig.kind.$(CI_BUILD_TAG)):/root/.kube/config" \
+			--volume "$$(cd .. && realpath ./kubeconfig.kind.$(CI_BUILD_TAG)):/root/.kube/config" \
 			--workdir /workdir \
 			"quay.io/helmpack/chart-testing:$(CHART_TESTING_VERSION)" \
 			ct install


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Part of my development workflow is to point the charts directory symlink used by `make kind/retest` at a local charts directory that is outside of my `lagoon` working directory. Currently that doesn't work.

This change allows `kind/retest` to follow that symlink even if it is not pointing at a subdirectory of the `lagoon` working directory.

> If the charts symlink is pointing somewhere other than a subdirectory of
> the local lagoon working tree then readlink gets confused. The problem
> is described here, which is also where I got the solution:
> https://superuser.com/a/1217241

# Closing issues

n/a
