### PR TITLE
fix: make aliases.drushrc.php.stub PHP 8 compatible

### DIFF
--- a/services/drush-alias/web/aliases.drushrc.php.stub
+++ b/services/drush-alias/web/aliases.drushrc.php.stub
@@ -38,7 +38,7 @@ $lagoonyml_path = $lagoonyml = FALSE;
 
 drush_log('Finding Drupal Root');
 
-if ( DRUSH_VERSION >= 9 ) {
+if ( (int)DRUSH_VERSION >= 9 ) {
   $_d = new \Drush\Drush();
   $path = $_d->getContainer()->get('bootstrap.manager')->getRoot();
   // _drush_shift_path_up() was part of D8, we define it for D9, borrowed from DrupalFinder->shiftPathUp()


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

Closes https://github.com/uselagoon/lagoon-service-images/issues/19
