### PR TITLE
fix: improve rootless migration logic

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -46,9 +46,9 @@ spec:
               set -e
               SENTINEL="/storage/.lagoon-rootless-migration-complete"
               if ! [ -f "$SENTINEL" ]; then
-                find /storage -mindepth 1 -exec chgrp $(stat -c "%g" /storage) {} +
-                find /storage -mindepth 1 -exec chmod g+rw {} +
-                find /storage -mindepth 1 -type d -exec chmod g+x {} +
+                find /storage -exec chown {{ .Values.podSecurityContext.runAsUser }}:0 {} +
+                find /storage -exec chmod a+r,u+w {} +
+                find /storage -type d -exec chmod a+x {} +
                 touch "$SENTINEL"
               fi
           image: busybox:musl


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This PR improves handling of the case where a Lagoon environment running
as root has changed the ownership and permissions of files in their
shared storage volume by rsyncing from another location, and then
switched to rootless.

It should now be the case that no matter how the ownership/permissions
have been changed, enabling rootless for the environment will normalise
the filesystem correctly for the rootless workload to have full access.

This change has been tested across three managed Kubernetes vendors
(EKS, GKE, AKS).

See: https://github.com/amazeeio/rootless-migration-tests

# Closing issues

Closes: #3044 
