### PR TITLE
Adds fact summary functionality to environment fact resolver

### DIFF
--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -791,7 +791,7 @@ const typeDefs = gql`
     advancedTasks: [AdvancedTaskDefinition]
     services: [EnvironmentService]
     problems(severity: [ProblemSeverityRating], source: [String]): [Problem]
-    facts(keyFacts: Boolean, limit: Int): [Fact]
+    facts(keyFacts: Boolean, limit: Int, summary: Boolean): [Fact]
     openshift: Openshift
     openshiftProjectPattern: String
     kubernetes: Kubernetes


### PR DESCRIPTION
This PR adds a a summary option to environment fact details. 

Essentially, calling a query like the following

```
query allp {
  allProjects {
    name
    environments {
      name
      facts(summary:true) {
        id
        name
        source
        category
        description
      }
    }
  }
}

```
Will reduce duplicate facts -- where duplicates are considered those facts with identical names, values, and descriptions as being identical -- to single entries. `source` fields are, further, summarized into a single comma separated value. Unique fields such as `id` and `created` are made null, since in the context of summaries they make little sense.
