### PR TITLE
chore: remove random wait from test suite

### DIFF
--- a/tests/tests/active-standby-kubernetes.yaml
+++ b/tests/tests/active-standby-kubernetes.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/active-standby-openshift.yaml
+++ b/tests/tests/active-standby-openshift.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/api.yaml
+++ b/tests/tests/api.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/bitbucket.yaml
+++ b/tests/tests/bitbucket.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: api/add-project.yaml
   vars:
     project: ci-bitbucket-{{ cluster_type }}

--- a/tests/tests/bulk-deployment.yaml
+++ b/tests/tests/bulk-deployment.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/dbaas.yaml
+++ b/tests/tests/dbaas.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/deploytarget.yaml
+++ b/tests/tests/deploytarget.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-php74.yaml
+++ b/tests/tests/drupal-php74.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-php80.yaml
+++ b/tests/tests/drupal-php80.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-postgres.yaml
+++ b/tests/tests/drupal-postgres.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drush.yaml
+++ b/tests/tests/drush.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/elasticsearch.yaml
+++ b/tests/tests/elasticsearch.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-api-variables.yaml
+++ b/tests/tests/features-api-variables.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-kubernetes-2.yaml
+++ b/tests/tests/features-kubernetes-2.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-openshift.yaml
+++ b/tests/tests/features-openshift.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features/random-wait.yaml
+++ b/tests/tests/features/random-wait.yaml
@@ -1,7 +1,0 @@
-- name: "{{ testname }} - wait for >5 seconds to give an eventual running deployment time to run, after that check again if the first commit is still there"
-  hosts: localhost
-  serial: 1
-  vars:
-    seconds: "{{ 30 | random(start=5, step=5) }}"
-  tasks:
-  - include: ../../tasks/pause.yaml

--- a/tests/tests/generic.yaml
+++ b/tests/tests/generic.yaml
@@ -1,6 +1,4 @@
 ---
-# - include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/github.yaml
+++ b/tests/tests/github.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: api/add-project.yaml
   vars:
     project: ci-github-{{ cluster_type }}

--- a/tests/tests/gitlab.yaml
+++ b/tests/tests/gitlab.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: api/add-project.yaml
   vars:
     project: ci-gitlab-{{ cluster_type }}

--- a/tests/tests/image-cache.yaml
+++ b/tests/tests/image-cache.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/nginx.yaml
+++ b/tests/tests/nginx.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node-mongodb.yaml
+++ b/tests/tests/node-mongodb.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node-various.yaml
+++ b/tests/tests/node-various.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node.yaml
+++ b/tests/tests/node.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/python.yaml
+++ b/tests/tests/python.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/ssh-portal.yaml
+++ b/tests/tests/ssh-portal.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/tasks.yaml
+++ b/tests/tests/tasks.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/workflows.yaml
+++ b/tests/tests/workflows.yaml
@@ -1,6 +1,4 @@
 ---
-- include: features/random-wait.yaml
-
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

We now have proper readiness signalling in keycloak so the random wait should no longer be necessary.

This will make test runs slightly faster.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
