### PR TITLE
Add example for pinning Node.js version in `php-cli` images

### DIFF
--- a/docs/docker-images/php-cli/README.md
+++ b/docs/docker-images/php-cli/README.md
@@ -35,7 +35,7 @@ This image is prepared to be used on Lagoon. There are therefore some things alr
 The included cli tools are:
 
 * [`composer` version 1.9.0](https://getcomposer.org/) \(changeable via `COMPOSER_VERSION` and `COMPOSER_HASH_SHA256`\)
-* [`node.js` verison 12](https://nodejs.org/en/) \(as of Jan 2020\)
+* [`node.js` verison 17](https://nodejs.org/en/) \(as of Mar 2022\)
 * [`npm`](https://www.npmjs.com/)
 * [`yarn`](https://yarnpkg.com/lang/en/)
 * `mariadb-client`
@@ -43,7 +43,12 @@ The included cli tools are:
 
 ### Change Node.js Version
 
-By default this image ships with the current Node.js Version \(v12 as of Jan 2020\). If you need another version you can remove the current version and install the one of your choice.
+By default this image ships with the `nodejs-current` package \(v17 as of Mar 2022\). If you need another version you can remove the current version and install the one of your choice. For example, to install Node.js 16, modify your dockerfile to include:
+
+```
+RUN apk del nodejs-current \
+    && apk add --no-cache nodejs=~16
+```
 
 ## Environment variables
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Updating the docs to list current installed version of Node.js and add dockerfile example for pinning a specific version.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
