### PR TITLE
fix api-db fix-permissions permissions to actually fix api-db permissions

### DIFF
--- a/services/api-db/Dockerfile
+++ b/services/api-db/Dockerfile
@@ -7,6 +7,11 @@ ENV LAGOON_VERSION=$LAGOON_VERSION
 
 USER root
 RUN apk add --no-cache openssh-keygen
+
+COPY ./docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
+RUN chown -R mysql /docker-entrypoint-initdb.d/ \
+    && /bin/fix-permissions /docker-entrypoint-initdb.d/
+
 USER mysql
 
 ENV MARIADB_DATABASE=infrastructure \
@@ -15,6 +20,4 @@ ENV MARIADB_DATABASE=infrastructure \
     MARIADB_CHARSET=utf8 \
     MARIADB_COLLATION=utf8_general_ci
 
-COPY ./docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
-RUN chown -R mysql /docker-entrypoint-initdb.d/; /bin/fix-permissions /docker-entrypoint-initdb.d/
 COPY ./rerun_initdb.sh /rerun_initdb.sh


### PR DESCRIPTION
Because this step was previously called under the mysql user to operate on files/folders owned by root, it would fail (silently - because of uselagoon/lagoon-images#420).

This PR moves the chown and fix-permissions into the `USER root` block, ensuring that they are correctly set prior to changing user back to mysql.

previously:
```
/var/lib/mysql$ ls -al /docker-entrypoint-initdb.d
total 80
drwxrwxr-x    1 mysql    root          4096 Mar 16 05:41 .
drwxr-xr-x    1 root     root          4096 Mar 16 07:01 ..
-rw-rw-r--    1 root     root         13641 Mar 16 05:40 00-tables.sql
-rw-rw-r--    1 root     root         41063 Mar 16 05:40 01-migrations.sql
-rw-rw-r--    1 root     root            30 Mar  9 06:06 02-views.sql
-rw-rw-r--    1 root     root          1250 Mar  9 06:06 03-procedures.sql
-rwxrwxr-x    1 root     root          1373 Mar  9 06:06 04-generate-ssh-key-fingerprints.sh
```

After this PR
```
/var/lib/mysql$ ls -al /docker-entrypoint-initdb.d
total 80
drwxrwxr-x    1 mysql    root          4096 Mar 25 01:17 .
drwxr-xr-x    1 root     root          4096 Mar 25 02:13 ..
-rw-rw-r--    1 mysql    root         13641 Mar 17 02:14 00-tables.sql
-rw-rw-r--    1 mysql    root         41063 Mar 17 02:14 01-migrations.sql
-rw-rw-r--    1 mysql    root            30 Mar 17 02:14 02-views.sql
-rw-rw-r--    1 mysql    root          1250 Mar 17 02:14 03-procedures.sql
-rwxrwxr-x    1 mysql    root          1373 Dec 14 08:38 04-generate-ssh-key-fingerprints.sh
```