### PR TITLE
Dep. trivy integration from core

### DIFF
--- a/services/webhooks2tasks/Dockerfile
+++ b/services/webhooks2tasks/Dockerfile
@@ -2,6 +2,7 @@ ARG LAGOON_GIT_BRANCH
 ARG IMAGE_REPO
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
+ARG ENABLE_DEPRECATED_TRIVY_INTEGRATION=false
 # STAGE 1: Loading Image lagoon-node-packages-builder which contains node packages shared by all Node Services
 FROM ${IMAGE_REPO:-lagoon}/yarn-workspace-builder as yarn-workspace-builder
 
@@ -10,6 +11,7 @@ FROM ${UPSTREAM_REPO:-uselagoon}/node-16:${UPSTREAM_TAG:-latest}
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+ENV ENABLE_DEPRECATED_TRIVY_INTEGRATION=$ENABLE_DEPRECATED_TRIVY_INTEGRATION
 
 # Copying generated node_modules from the first stage
 COPY --from=yarn-workspace-builder /app /app

--- a/services/webhooks2tasks/src/index.ts
+++ b/services/webhooks2tasks/src/index.ts
@@ -10,6 +10,7 @@ initSendToLagoonTasks();
 const rabbitmqHost = process.env.RABBITMQ_HOST || "broker"
 const rabbitmqUsername = process.env.RABBITMQ_USERNAME || "guest"
 const rabbitmqPassword = process.env.RABBITMQ_PASSWORD || "guest"
+
 // @ts-ignore
 const connection = amqp.connect([`amqp://${rabbitmqUsername}:${rabbitmqPassword}@${rabbitmqHost}`], { json: true });
 

--- a/services/webhooks2tasks/src/webhooks/problems.ts
+++ b/services/webhooks2tasks/src/webhooks/problems.ts
@@ -15,10 +15,10 @@ import {
 // NOTE: Here we are going through the process of deprecating the Trivy integration
 const enableHarborIntegration = (() => {
 	if(process.env.ENABLE_DEPRECATED_TRIVY_INTEGRATION && process.env.ENABLE_DEPRECATED_TRIVY_INTEGRATION == "true") {
-    console.log("enabling trivy");
+    console.log("ENABLE_DEPRECATED_TRIVY_INTEGRATION is 'true' -- enabling Harbor/Trivy");
 		return true;
 	}
-  console.log("Trivy is not enabled");
+  console.log("ENABLE_DEPRECATED_TRIVY_INTEGRATION is not 'true' -- Harbor/Trivy integration is not enabled");
 	return false;
 })();
 
@@ -38,7 +38,7 @@ export async function processProblems(
           console.log("NOTE: Harbor integration for Problems is deprecated and will be removed from Lagoon in an upcoming release");
           await handle(harborScanningCompleted, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
         } else {
-          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Problems integration is disabled");
+          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Trivy integration is disabled");
         }
 
         break
@@ -47,7 +47,7 @@ export async function processProblems(
           console.log("NOTE: Harbor integration for Problems is deprecated and will be removed from Lagoon in an upcoming release");
           await handle(processHarborVulnerabilityList, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
         } else {
-          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Problems integration is disabled");
+          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Trivy integration is disabled");
         }
       break;
       case 'drutiny:resultset' :

--- a/services/webhooks2tasks/src/webhooks/problems.ts
+++ b/services/webhooks2tasks/src/webhooks/problems.ts
@@ -12,6 +12,16 @@ import {
   Project
 } from '../types';
 
+// NOTE: Here we are going through the process of deprecating the Trivy integration
+const enableHarborIntegration = (() => {
+	if(process.env.ENABLE_DEPRECATED_TRIVY_INTEGRATION && process.env.ENABLE_DEPRECATED_TRIVY_INTEGRATION == "true") {
+    console.log("enabling trivy");
+		return true;
+	}
+  console.log("Trivy is not enabled");
+	return false;
+})();
+
 export async function processProblems(
     rabbitMsg,
     channelWrapperWebhooks
@@ -24,10 +34,21 @@ export async function processProblems(
 
     switch(webhook.event) {
       case 'harbor:scanningcompleted' :
-        await handle(harborScanningCompleted, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
+        if(enableHarborIntegration == true) {
+          console.log("NOTE: Harbor integration for Problems is deprecated and will be removed from Lagoon in an upcoming release");
+          await handle(harborScanningCompleted, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
+        } else {
+          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Problems integration is disabled");
+        }
+
         break
       case 'harbor:scanningresultfetched' :
-        await handle(processHarborVulnerabilityList, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
+        if(enableHarborIntegration == true) {
+          console.log("NOTE: Harbor integration for Problems is deprecated and will be removed from Lagoon in an upcoming release");
+          await handle(processHarborVulnerabilityList, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);
+        } else {
+          console.log("NOTE: Harbor scan recieved but not processed because Harbor/Problems integration is disabled");
+        }
       break;
       case 'drutiny:resultset' :
         await handle(processDrutinyResultset, webhook, `${webhooktype}:${event}`, channelWrapperWebhooks);


### PR DESCRIPTION
This addresses point 1 of #3082 by marking as deprecated the Harbor/Trivy integration in core but making it optional.
