### PR TITLE
feature: add a timeout on the rollout status watch

### DIFF
--- a/images/kubectl-build-deploy-dind/scripts/exec-monitor-deploy.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-monitor-deploy.sh
@@ -32,7 +32,10 @@ stream_logs_deployment &
 STREAM_LOGS_PID=$!
 
 ret=0
-kubectl rollout --insecure-skip-tls-verify -n ${NAMESPACE} status deployment ${SERVICE_NAME} --watch || ret=$?
+# default progressDeadlineSeconds is 600, doubling that here for a timeout on the status check for 1200s (20m) as a fallback for exceeding the progressdeadline
+# when there may be another issue with the rollout failing, the progresdeadline doesn't always work
+# (eg, existing pod in previous replicaset fails to terminate properly)
+kubectl rollout --insecure-skip-tls-verify -n ${NAMESPACE} status deployment ${SERVICE_NAME} --watch --timeout=1200s || ret=$?
 
 if [[ $ret -ne 0 ]]; then
   # stop all running stream logs


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Sometimes `kubectl rollout status` can get stuck indefinitely waiting for a rollout to complete due to an issue with the previous pod in the existing replicaset possibly not terminating.

Adding a `--timeout=1200s` to this status check is double what the `progressDeadlineSeconds` value is, and if a pod rollout is taking more than 20 minutes to complete, there is probably something wrong anyway.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

Partially closes #2861 as it won't actually report on a long running notification, but will prevent the condition where a long running deployment would occur. With intermittent build logs now, it can be more obvious where a build has stalled, before calling it "long running"
