### PR TITLE
refactor: capture errors for deploytargets

### DIFF
--- a/node-packages/commons/src/deploy-tasks.ts
+++ b/node-packages/commons/src/deploy-tasks.ts
@@ -75,7 +75,7 @@ const deployBranch = async function(data: any) {
             logger.debug(
                 `projectName: ${projectName}, branchName: ${branchName}, branch deployments disabled`
             );
-            return false
+            throw new NoNeedToDeployBranch('Branch deployments disabled');
         default: {
             logger.debug(
                 `projectName: ${projectName}, branchName: ${branchName}, regex ${branchesRegex}, testing if it matches`
@@ -101,7 +101,9 @@ const deployBranch = async function(data: any) {
             logger.debug(
                 `projectName: ${projectName}, branchName: ${branchName}, regex ${branchesRegex} did not match branchname, not deploying`
             );
-            return false
+            throw new NoNeedToDeployBranch(
+              `configured regex '${branchesRegex}' does not match branchname '${branchName}'`
+            );
         }
     }
 }
@@ -154,10 +156,7 @@ const deployPullrequest = async function(data: any) {
                     );
             }
         case 'false':
-            logger.debug(
-                `projectName: ${projectName}, pullrequest: ${branchName}, pullrequest deployments disabled`
-            );
-            return false
+            throw new NoNeedToDeployBranch('PullRequest deployments disabled');
         default: {
             logger.debug(
                 `projectName: ${projectName}, pullrequest: ${branchName}, regex ${pullrequestRegex}, testing if it matches PR title '${pullrequestTitle}'`
@@ -183,7 +182,9 @@ const deployPullrequest = async function(data: any) {
             logger.debug(
                 `projectName: ${projectName}, branchName: ${branchName}, regex ${pullrequestRegex} did not match PR title, not deploying`
             );
-            return false
+            throw new NoNeedToDeployBranch(
+              `configured regex '${pullrequestRegex}' does not match PR Title '${pullrequestTitle}'`
+            );
         }
     }
 }
@@ -263,11 +264,6 @@ export const deployTargetBranches = async function(data: any) {
                 // if the deploy is successful, then return
                 return deploy
             }
-        }
-        if (deploy == false) {
-            throw new NoNeedToDeployBranch(
-                `configured regex for all deploytargets does not match branchname '${branchName}'`
-            );
         }
     } else {
         // deploy the project using the projects default target
@@ -355,11 +351,6 @@ export const deployTargetPullrequest = async function(data: any) {
                 // if the deploy is successful, then return
                 return deploy
             }
-        }
-        if (deploy == false) {
-            throw new NoNeedToDeployBranch(
-                `configured regex for all deploytargets does not match pullrequest '${branchName}'`
-            );
         }
     } else {
         // deploy the project using the projects default target

--- a/node-packages/commons/src/deploy-tasks.ts
+++ b/node-packages/commons/src/deploy-tasks.ts
@@ -156,6 +156,9 @@ const deployPullrequest = async function(data: any) {
                     );
             }
         case 'false':
+            logger.debug(
+                `projectName: ${projectName}, pullrequest: ${branchName}, pullrequest deployments disabled`
+            );
             throw new NoNeedToDeployBranch('PullRequest deployments disabled');
         default: {
             logger.debug(

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -729,7 +729,12 @@ export const createDeployTask = async function(deployData: any) {
           project,
           deployData
         }
-        return deployTargetBranches(lagoonData)
+        try {
+          let result = deployTargetBranches(lagoonData)
+          return result
+        } catch (error) {
+          throw error
+        }
       } else if (type === 'pullrequest') {
         // use deployTargetPullrequest function to handle
         let lagoonData = {
@@ -740,7 +745,12 @@ export const createDeployTask = async function(deployData: any) {
           pullrequestTitle,
           deployData
         }
-        return deployTargetPullrequest(lagoonData)
+        try {
+          let result = deployTargetPullrequest(lagoonData)
+          return result
+        } catch (error) {
+          throw error
+        }
       }
       break;
     default:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When DeployTargets were introduced, some error handling was moved or removed to other functions but never captured.
Due to how webhooks2tasks was handling these prior, I'm assuming the notification handling https://github.com/uselagoon/lagoon/blob/main/services/webhooks2tasks/src/handlers/githubPush.ts#L59-L81 would fail the try on the `createDeployTask` would return an error before the `sendToLagoonLogs` actually got called.

But since `createDeployTask` wasn't returning any errors where it normally would, it would "succeed" and then send the notification, even though the task probably failed silently.

I tried to capture more errors now to prevent these messages being sent

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2970 