### PR TITLE
strip acl param from multipart task file uploads

### DIFF
--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -4,7 +4,6 @@ import { s3Client } from '../../clients/aws';
 import { query } from '../../util/db';
 import { Sql } from './sql';
 import { Sql as taskSql } from '../task/sql';
-import { getConfigFromEnv } from '../../util/config';
 
 export const getDownloadLink: ResolverFn = async ({ s3Key }) =>
   s3Client.getSignedUrl('getObject', {

--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -37,7 +37,7 @@ export const uploadFilesForTask: ResolverFn = async (
   const resolvedFiles = await Promise.all(files);
   const uploadAndTrackFiles = resolvedFiles.map(async (newFile: any) => {
     const s3_key = `tasks/${task}/${newFile.filename}`;
-    let params = {
+    const params = {
       Key: s3_key,
       Body: newFile.createReadStream(),
       ...(isGCS == 'false' && {ACL: 'private'}),

--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -4,6 +4,7 @@ import { s3Client } from '../../clients/aws';
 import { query } from '../../util/db';
 import { Sql } from './sql';
 import { Sql as taskSql } from '../task/sql';
+import { getConfigFromEnv } from '../../util/config';
 
 export const getDownloadLink: ResolverFn = async ({ s3Key }) =>
   s3Client.getSignedUrl('getObject', {
@@ -36,8 +37,7 @@ export const uploadFilesForTask: ResolverFn = async (
     const s3_key = `tasks/${task}/${newFile.filename}`;
     const params = {
       Key: s3_key,
-      Body: newFile.createReadStream(),
-      ACL: 'private'
+      Body: newFile.createReadStream()
     };
     // @ts-ignore
     await s3Client.upload(params).promise();

--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -5,6 +5,9 @@ import { query } from '../../util/db';
 import { Sql } from './sql';
 import { Sql as taskSql } from '../task/sql';
 
+// if this is google cloud storage or not
+const isGCS = process.env.S3_FILES_GCS || 'false'
+
 export const getDownloadLink: ResolverFn = async ({ s3Key }) =>
   s3Client.getSignedUrl('getObject', {
     Key: s3Key,
@@ -34,9 +37,10 @@ export const uploadFilesForTask: ResolverFn = async (
   const resolvedFiles = await Promise.all(files);
   const uploadAndTrackFiles = resolvedFiles.map(async (newFile: any) => {
     const s3_key = `tasks/${task}/${newFile.filename}`;
-    const params = {
+    let params = {
       Key: s3_key,
-      Body: newFile.createReadStream()
+      Body: newFile.createReadStream(),
+      ...(isGCS == 'false' && {ACL: 'private'}),
     };
     // @ts-ignore
     await s3Client.upload(params).promise();


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

File uploads via the upload functionality result in an error when using google cloud blob storage. The error is as follows
```
HTTP 400
InvalidArgument: Invalid argument
```

After some digging, I found [this issue for another project called rclone](https://forum.rclone.org/t/multipart-uploads-to-gcs-using-s3-protocol-fail-with-400-error/26198/5) which mentions a similar error, and the issue seems to be that google cloud storage doesn't support ACLs on multipart uploads. Stripping this param resolves the issue for file uploads in google cloud storage.

A new variable `S3_FILES_GCS` will allow setting the ACL field. Since GCS (google cloud storage) is the only one so far that doesn't support this, there could be other things it doesn't support too which this variable could cover in the future.

It defaults to `false` if not defined, which will put the ACL field. It needs to be set to `true` (as a string, because it is an envvar) to not set the ACL field.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #3095 
