### PR TITLE
fix autogenerated urls to correctly truncate if they are too long

### DIFF
--- a/images/kubectl-build-deploy-dind/scripts/exec-autogenerated-pattern.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-autogenerated-pattern.sh
@@ -5,7 +5,7 @@
 ### Given a router pattern, it will create the required domains
 ##############################################
 function routerPattern2DomainGenerator {
-    ROUTER_URL=${1}
+    DOMAIN_PARTS=${1}
     SERVICE=${2}
     PROJECT=${3}
     ENVIRONMENT=${4}
@@ -13,49 +13,48 @@ function routerPattern2DomainGenerator {
     HAS_SERVICE_PATTERN=false
 
     re='(.*)\$\{service\}(.*)'
-    if [[ $ROUTER_URL =~ $re ]]; then
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
         HAS_SERVICE_PATTERN=true
-        ROUTER_URL2=${BASH_REMATCH[1]}${SERVICE}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${SERVICE}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     re='(.*)\$\{project\}(.*)'
-    if [[ $ROUTER_URL =~ $re ]]; then
-        ROUTER_URL2=${BASH_REMATCH[1]}${PROJECT}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${PROJECT}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     re='(.*)\$\{environment\}(.*)'
-    SUFFIX=""
-    if [[ $ROUTER_URL =~ $re ]]; then
-        ROUTER_URL2=${BASH_REMATCH[1]}${ENVIRONMENT}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
-        SUFFIX=${BASH_REMATCH[2]}
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${ENVIRONMENT}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     # fallback to the default behaviour which adds the service with a dot
     # if the pattern doesn't have a service pattern defined in it
     if [ $HAS_SERVICE_PATTERN == "false" ]; then
-        ROUTER_URL2=${SERVICE}.${ROUTER_URL2}
+        DOMAIN_PARTS2=${SERVICE}.${DOMAIN_PARTS2}
     fi
 
-    SUFFIX_HASH=$(echo $ROUTER_URL2 | sha256sum | awk '{print $1}' | cut -c -8)
-    re='(.*)([.])(.*)'
-    if [[ $ROUTER_URL2 =~ $re ]]; then
-        if [ ${#BASH_REMATCH[3]} -gt 63 ]; then
 
-            ROUTER_URL2=$(echo ${BASH_REMATCH[3]} | cut -c -55 | sed -e 's/-$//')-${SUFFIX_HASH}
-            ROUTER_URL2=${BASH_REMATCH[1]}.${ROUTER_URL2}
-            echo $ROUTER_URL2$SUFFIX
-            return
+    # once all the parts of the router pattern have been
+    DOMAIN_HASH=$(echo $DOMAIN_PARTS | sha256sum | awk '{print $1}' | cut -c -8)
+    FINAL_DOMAIN=""
+    # split the domain up by the dot and iterate over each part to check its length
+    IFS='.' read -ra DOMAIN_PARTS_SPLIT <<< "$DOMAIN_PARTS"
+    for DOMAIN_PART in ${DOMAIN_PARTS_SPLIT[@]}
+    do
+        if [ ${#DOMAIN_PART} -gt 63 ]; then
+            # if the part of the domain is greater than 63, then keep 54 characters and add the domain hash (8) and a dash (1)
+            # to the remaining domain part (54+1+8=63)
+            DOMAIN_PART=$(echo ${DOMAIN_PART} | cut -c -54 | sed -e 's/-$//')-${DOMAIN_HASH}
         fi
-        echo $ROUTER_URL2$SUFFIX
-    else
-        if [ ${#ROUTER_URL2} -gt 63 ]; then
-            ROUTER_URL2=$(echo $ROUTER_URL2 | cut -c -55 | sed -e 's/-$//')-${SUFFIX_HASH}
-        fi
-        echo $ROUTER_URL2$SUFFIX
-    fi
+        # combine the parts
+        FINAL_DOMAIN=${FINAL_DOMAIN}${DOMAIN_PART}.
+    done
+    # strip the trailing dot from the domain
+    echo "$(echo ${FINAL_DOMAIN} | rev | cut -c 2- | rev)"
 }
 
 ##############################################
@@ -63,7 +62,7 @@ function routerPattern2DomainGenerator {
 ### Performs the same function that the build-deploy controller currently does
 ##############################################
 function generateShortUrl {
-    ROUTER_URL=${1}
+    DOMAIN_PARTS=${1}
     SERVICE=${2}
     PROJECT=${3}
     ENVIRONMENT=${4}
@@ -71,31 +70,30 @@ function generateShortUrl {
     HAS_SERVICE_PATTERN=false
 
     re='(.*)\$\{service\}(.*)'
-    if [[ $ROUTER_URL =~ $re ]]; then
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
         HAS_SERVICE_PATTERN=true
-        ROUTER_URL2=${BASH_REMATCH[1]}${SERVICE}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${SERVICE}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     re='(.*)\$\{project\}(.*)'
-    if [[ $ROUTER_URL =~ $re ]]; then
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
         SHA256_B32_PROJECT=$(echo -e "import sys\nimport base64\nimport hashlib\nprint(base64.b32encode(bytearray(hashlib.sha256(sys.argv[1].encode()).digest())).decode('utf-8'))" | python3 -  "${PROJECT}" | tr '[:upper:]' '[:lower:]' | cut -c -8)
-        ROUTER_URL2=${BASH_REMATCH[1]}${SHA256_B32_PROJECT}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${SHA256_B32_PROJECT}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     re='(.*)\$\{environment\}(.*)'
-    if [[ $ROUTER_URL =~ $re ]]; then
+    if [[ $DOMAIN_PARTS =~ $re ]]; then
         SHA256_B32_ENVIRONMENT=$(echo -e "import sys\nimport base64\nimport hashlib\nprint(base64.b32encode(bytearray(hashlib.sha256(sys.argv[1].encode()).digest())).decode('utf-8'))" | python3 -  "${ENVIRONMENT}" | tr '[:upper:]' '[:lower:]' | cut -c -8)
-        ROUTER_URL2=${BASH_REMATCH[1]}${SHA256_B32_ENVIRONMENT}
-        ROUTER_URL=${ROUTER_URL2}${BASH_REMATCH[2]}
+        DOMAIN_PARTS2=${BASH_REMATCH[1]}${SHA256_B32_ENVIRONMENT}
+        DOMAIN_PARTS=${DOMAIN_PARTS2}${BASH_REMATCH[2]}
     fi
 
     # fallback to the default behaviour which adds the service with a dot
     # if the pattern doesn't have a service pattern defined in it
     if [ $HAS_SERVICE_PATTERN == "false" ]; then
-        ROUTER_URL=${SERVICE}.${ROUTER_URL}
+        DOMAIN_PARTS=${SERVICE}.${DOMAIN_PARTS}
     fi
-
-    echo $ROUTER_URL
+    echo $DOMAIN_PARTS
 }

--- a/images/kubectl-build-deploy-dind/scripts/exec-autogenerated-pattern.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-autogenerated-pattern.sh
@@ -34,7 +34,7 @@ function routerPattern2DomainGenerator {
     # fallback to the default behaviour which adds the service with a dot
     # if the pattern doesn't have a service pattern defined in it
     if [ $HAS_SERVICE_PATTERN == "false" ]; then
-        DOMAIN_PARTS2=${SERVICE}.${DOMAIN_PARTS2}
+        DOMAIN_PARTS=${SERVICE}.${DOMAIN_PARTS}
     fi
 
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The previous logic for truncating autogenerated urls was flawed, this logic iterates over each section of the autogenerated url and shortens parts that are too long

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

