### PR TITLE
check s3 object exists before generating signed url

### DIFF
--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -96,28 +96,29 @@ export const getRestoreLocation: ResolverFn = async (
       region: awsS3Parts ? R.prop(1, awsS3Parts) : ''
     });
 
-    try {
-      // before generating the signed url, check the object exists
-      s3Client.headObject({
-        Bucket: R.prop(2, s3Parts),
-        Key: R.prop(3, s3Parts)
-      });
-    } catch (error) {
-      // delete the restore from the database if the head check fails
-      await query(
-        sqlClientPool,
-        Sql.deleteRestore({
-          backupId
-        })
-      );
-      // return an error?
-      throw new Error('The requested restore is no longer available, try retrieve the backup again');
-    }
 
-    return s3Client.getSignedUrl('getObject', {
+    // before generating the signed url, check the object exists
+    await s3Client.headObject({
       Bucket: R.prop(2, s3Parts),
-      Key: R.prop(3, s3Parts),
-      Expires: 300 // 5 minutes
+      Key: R.prop(3, s3Parts)
+    }, async function(err, data) {
+      if (err) {
+        // if there is an error, then delete the restore from the database
+        await query(
+          sqlClientPool,
+          Sql.deleteRestore({
+            backupId
+          })
+        );
+        return ""
+      } else {
+        // otherwise return the signed url
+        return s3Client.getSignedUrl('getObject', {
+          Bucket: R.prop(2, s3Parts),
+          Key: R.prop(3, s3Parts),
+          Expires: 300 // 5 minutes
+        });
+      }
     });
   }
 

--- a/services/api/src/resources/backup/sql.ts
+++ b/services/api/src/resources/backup/sql.ts
@@ -92,6 +92,17 @@ export const Sql = {
         created
       })
       .toString(),
+  deleteRestore: ({
+    backupId
+  }: {
+    backupId: string;
+  }) =>
+    knex('backup_restore')
+      .where({
+        backupId: backupId
+      })
+      .delete()
+      .toString(),
   updateRestore: ({
     backupId,
     patch


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

As described in #3096, if a bucket has a retention period on it, there is a possibility that a file could be removed from the restore bucket before the backup is purged, resulting in an unavailable file when attempting to download it.

What will happen now is when a download is attempted, it will first check that the file exists in s3 before returning the signed url, it will generate an error if the file no longer exists and remove the restore reference from the database allowing the user to trigger a fresh retrieval

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #3096 
