### PR TITLE
Make tasks more like deployments

### DIFF
--- a/node-packages/commons/src/util.ts
+++ b/node-packages/commons/src/util.ts
@@ -5,6 +5,10 @@ export const generateBuildId = function() {
     return `lagoon-build-${Math.random().toString(36).substring(7)}`;
 };
 
+export const generateTaskName = function() {
+    return `lagoon-task-${Math.random().toString(36).substring(7)}`;
+};
+
 export const jsonMerge = function(a, b, prop) {
   var reduced = a.filter(function(aitem) {
     return !b.find(function(bitem) {

--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -183,10 +183,11 @@ CREATE TABLE IF NOT EXISTS environment_service (
 CREATE TABLE IF NOT EXISTS task (
   id                        int NOT NULL auto_increment PRIMARY KEY,
   name                      varchar(100) NOT NULL,
+  task_name                 varchar(100) NULL,
   environment               int NOT NULL REFERENCES environment (id),
   service                   varchar(100) NOT NULL,
   command                   varchar(300) NOT NULL,
-  status                    ENUM('active', 'succeeded', 'failed') NOT NULL,
+  status                    ENUM('new', 'pending', 'running', 'cancelled', 'error', 'failed', 'complete', 'active', 'succeeded') NOT NULL,
   created                   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   started                   datetime NULL,
   completed                 datetime NULL,

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1696,9 +1696,6 @@ CREATE OR REPLACE PROCEDURE
       t.task_name = CONCAT('lagoon-task-', (SELECT LEFT(UUID(), 6)))
     WHERE
       t.task_name IS NULL;
-END WHILE;
-
-
   END;
 $$
 

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -54,6 +54,7 @@ const {
 
 const {
   getTasksByEnvironmentId,
+  getTaskByTaskName,
   getTaskByRemoteId,
   getTaskById,
   addTask,
@@ -306,6 +307,12 @@ const resolvers = {
     PROBLEM: 'problem',
   },
   TaskStatusType: {
+    NEW: 'new',
+    PENDING: 'pending',
+    RUNNING: 'running',
+    CANCELLED: 'cancelled',
+    ERROR: 'error',
+    COMPLETE: 'complete',
     ACTIVE: 'active',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
@@ -432,6 +439,7 @@ const resolvers = {
     userCanSshToEnvironment,
     deploymentByRemoteId: getDeploymentByRemoteId,
     deploymentsByBulkId: getDeploymentsByBulkId,
+    taskByTaskName: getTaskByTaskName,
     taskByRemoteId: getTaskByRemoteId,
     taskById: getTaskById,
     advancedTaskDefinitionById,

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -14,6 +14,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
   addTask: async ({
     id,
     name,
+    taskName,
     status,
     created,
     started,
@@ -26,6 +27,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
   }: {
     id?: number;
     name: string;
+    taskName: string;
     status?: string;
     created?: string;
     started?: string;
@@ -41,6 +43,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       Sql.insertTask({
         id,
         name,
+        taskName,
         status,
         created,
         started,
@@ -99,6 +102,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
     {
       id,
       name,
+      taskName,
       status,
       created,
       started,
@@ -112,6 +116,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
     }: {
       id?: number,
       name: string,
+      taskName: string,
       status?: string,
       created?: string,
       started?: string,
@@ -142,6 +147,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       Sql.insertTask({
         id,
         name,
+        taskName,
         status,
         created,
         started,

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -13,6 +13,7 @@ import { Helpers as projectHelpers } from '../project/helpers';
 import { Validators as envValidators } from '../environment/validators';
 import S3 from 'aws-sdk/clients/s3';
 import sha1 from 'sha1';
+import { generateTaskName } from '@lagoon/commons/dist/util';
 
 const accessKeyId =  process.env.S3_FILES_ACCESS_KEY_ID || 'minio'
 const secretAccessKey =  process.env.S3_FILES_SECRET_ACCESS_KEY || 'minio123'
@@ -97,7 +98,7 @@ export const getTaskLog: ResolverFn = async (
 
 export const getTasksByEnvironmentId: ResolverFn = async (
   { id: eid },
-  { id: filterId, limit },
+  { id: filterId, taskName: taskName, limit },
   { sqlClientPool, hasPermission }
 ) => {
   const environment = await environmentHelpers(
@@ -116,11 +117,39 @@ export const getTasksByEnvironmentId: ResolverFn = async (
     queryBuilder = queryBuilder.andWhere('id', filterId);
   }
 
+  if (taskName) {
+    queryBuilder = queryBuilder.andWhere('task_name', taskName);
+  }
+
   if (limit) {
     queryBuilder = queryBuilder.limit(limit);
   }
 
   return query(sqlClientPool, queryBuilder.toString());
+};
+
+export const getTaskByTaskName: ResolverFn = async (
+  root,
+  { taskName },
+  { sqlClientPool, hasPermission }
+) => {
+  const queryString = knex('task')
+    .where('task_name', '=', taskName)
+    .toString();
+
+  const rows = await query(sqlClientPool, queryString);
+  const task = R.prop(0, rows);
+
+  if (!task) {
+    return null;
+  }
+
+  const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
+  await hasPermission('task', 'view', {
+    project: R.path(['0', 'pid'], rowsPerms)
+  });
+
+  return task;
 };
 
 export const getTaskByRemoteId: ResolverFn = async (
@@ -208,6 +237,8 @@ export const addTask: ResolverFn = async (
     execute = true;
   }
 
+  let taskName = generateTaskName()
+
   userActivityLogger(`User added task '${name}'`, {
     project: '',
     event: 'api:addTask',
@@ -215,6 +246,7 @@ export const addTask: ResolverFn = async (
       input: {
         id,
         name,
+        taskName,
         status,
         created,
         started,
@@ -231,6 +263,7 @@ export const addTask: ResolverFn = async (
   const taskData = await Helpers(sqlClientPool).addTask({
     id,
     name,
+    taskName,
     status,
     created,
     started,
@@ -393,6 +426,7 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush archive-dump',
+    taskName: generateTaskName(),
     environment: environmentId,
     service: 'cli',
     command,
@@ -441,6 +475,7 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush sql-dump',
+    taskName: generateTaskName(),
     environment: environmentId,
     service: 'cli',
     command,
@@ -491,6 +526,7 @@ export const taskDrushCacheClear: ResolverFn = async (
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush cache-clear',
+    taskName: generateTaskName(),
     environment: environmentId,
     service: 'cli',
     command,
@@ -530,6 +566,7 @@ export const taskDrushCron: ResolverFn = async (
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush cron',
+    taskName: generateTaskName(),
     environment: environmentId,
     service: 'cli',
     command: `drush cron`,
@@ -601,6 +638,7 @@ export const taskDrushSqlSync: ResolverFn = async (
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: `Sync DB ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
+    taskName: generateTaskName(),
     environment: destinationEnvironmentId,
     service: 'cli',
     command: command,
@@ -672,6 +710,7 @@ export const taskDrushRsyncFiles: ResolverFn = async (
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: `Sync files ${sourceEnvironment.name} -> ${destinationEnvironment.name}`,
+    taskName: generateTaskName(),
     environment: destinationEnvironmentId,
     service: 'cli',
     command: command,
@@ -711,6 +750,7 @@ export const taskDrushUserLogin: ResolverFn = async (
 
   const taskData = await Helpers(sqlClientPool).addTask({
     name: 'Drush uli',
+    taskName: generateTaskName(),
     environment: environmentId,
     service: 'cli',
     command: `drush uli`,

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -8,6 +8,7 @@ export const Sql = {
   insertTask: ({
     id,
     name,
+    taskName,
     status,
     created,
     started,
@@ -22,6 +23,7 @@ export const Sql = {
   }: {
     id: number;
     name: string;
+    taskName: string,
     status: string;
     created: string;
     started: string;
@@ -38,6 +40,7 @@ export const Sql = {
       .insert({
         id,
         name,
+        taskName,
         status,
         created,
         started,

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -19,6 +19,7 @@ import convertDateToMYSQLDateTimeFormat from '../../util/convertDateToMYSQLDateT
 import * as advancedTaskToolbox from './advancedtasktoolbox';
 import { IKeycloakAuthAttributes, KeycloakUnauthorizedError } from '../../util/auth';
 import { Environment } from '../../resolvers';
+import { generateTaskName } from '@lagoon/commons/dist/util';
 
 enum AdvancedTaskDefinitionTarget {
   Group,
@@ -532,6 +533,7 @@ export const invokeRegisteredTask = async (
 
         const taskData = await Helpers(sqlClientPool).addTask({
           name: task.name,
+          taskName: generateTaskName(),
           environment: environment,
           service: task.service,
           command: taskCommand,
@@ -554,6 +556,7 @@ export const invokeRegisteredTask = async (
 
         const advancedTaskData = await Helpers(sqlClientPool).addAdvancedTask({
           name: task.name,
+          taskName: generateTaskName(),
           created: undefined,
           started: undefined,
           completed: undefined,

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -70,6 +70,12 @@ const typeDefs = gql`
     ACTIVE
     SUCCEEDED
     FAILED
+    NEW
+    PENDING
+    RUNNING
+    CANCELLED
+    ERROR
+    COMPLETE
   }
 
   enum RestoreStatusType {
@@ -829,7 +835,7 @@ const typeDefs = gql`
     monitoringUrls: String
     deployments(name: String, limit: Int): [Deployment]
     backups(includeDeleted: Boolean, limit: Int): [Backup]
-    tasks(id: Int, limit: Int): [Task]
+    tasks(id: Int, taskName: String, limit: Int): [Task]
     advancedTasks: [AdvancedTaskDefinition]
     services: [EnvironmentService]
     problems(severity: [ProblemSeverityRating], source: [String]): [Problem]
@@ -915,6 +921,7 @@ const typeDefs = gql`
   type Task {
     id: Int
     name: String
+    taskName: String
     status: String
     created: String
     started: String
@@ -930,6 +937,7 @@ const typeDefs = gql`
   type AdvancedTask {
     id: Int
     name: String
+    taskName: String
     status: String
     created: String
     started: String
@@ -1067,6 +1075,7 @@ const typeDefs = gql`
     ): Environment
     deploymentByRemoteId(id: String): Deployment
     deploymentsByBulkId(bulkId: String): [Deployment]
+    taskByTaskName(taskName: String): Task
     taskByRemoteId(id: String): Task
     taskById(id: Int): Task
     """
@@ -1401,6 +1410,7 @@ const typeDefs = gql`
 
   input UpdateTaskPatchInput {
     name: String
+    taskName: String
     status: TaskStatusType
     created: String
     started: String

--- a/services/controllerhandler/src/index.ts
+++ b/services/controllerhandler/src/index.ts
@@ -38,30 +38,14 @@ const updateLagoonTask = async (meta) => {
     const dateOrNull = R.unless(R.isNil, convertDateFormat) as any;
     let completedDate = dateOrNull(meta.endTime) as any;
 
-    if (meta.jobStatus === 'failed') {
+    if (meta.jobStatus.toUpperCase() === 'FAILED' || meta.jobStatus.toUpperCase() === 'CANCELLED') {
       completedDate = dateOrNull(meta.endTime);
     }
 
-    // transform the jobstatus into one the API knows about
-    let jobStatus = 'active';
-    switch (meta.jobStatus) {
-      case 'pending':
-        jobStatus = 'active'
-        break;
-      case 'running':
-        jobStatus = 'active'
-        break;
-      case 'complete':
-        jobStatus = 'succeeded'
-        break;
-      default:
-        jobStatus = meta.jobStatus
-        break;
-    }
     // update the actual task now
     await updateTask(Number(meta.task.id), {
       remoteId: meta.remoteId,
-      status: jobStatus.toUpperCase(),
+      status: meta.jobStatus.toUpperCase(),
       started: dateOrNull(meta.startTime),
       completed: completedDate
     });

--- a/services/ui/server.js
+++ b/services/ui/server.js
@@ -87,7 +87,7 @@ app
       (req, res) => {
         app.render(req, res, '/task', {
           openshiftProjectName: req.params.environmentSlug,
-          taskId: req.params.taskSlug
+          taskName: req.params.taskSlug
         });
       }
     );

--- a/services/ui/src/components/Breadcrumbs/Task.js
+++ b/services/ui/src/components/Breadcrumbs/Task.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { getLinkData } from 'components/link/Task';
+import Breadcrumb from 'components/Breadcrumbs/Breadcrumb';
+
+const TaskBreadcrumb = ({ taskName, taskSlug, environmentSlug, projectSlug }) => {
+  const linkData = getLinkData(taskSlug, environmentSlug, projectSlug);
+
+  return (
+    <Breadcrumb
+      header="Task"
+      title={taskName}
+      {... linkData}
+    />
+  );
+};
+
+export default TaskBreadcrumb;

--- a/services/ui/src/components/Task/index.js
+++ b/services/ui/src/components/Task/index.js
@@ -9,7 +9,6 @@ import { bp } from 'lib/variables';
 const Task = ({ task }) => (
   <div className="task">
     <div className="details">
-      <h3>{task.name}</h3>
       <div className="field-wrapper created">
         <div>
           <label>Created</label>
@@ -138,13 +137,43 @@ const Task = ({ task }) => (
               }
             }
 
+            &.new {
+              &::before {
+                background-image: url('/static/images/in-progress.svg');
+              }
+            }
+
+            &.pending {
+              &::before {
+                background-image: url('/static/images/in-progress.svg');
+              }
+            }
+
+            &.running {
+              &::before {
+                background-image: url('/static/images/in-progress.svg');
+              }
+            }
+
             &.failed {
               &::before {
                 background-image: url('/static/images/failed.svg');
               }
             }
 
+            &.cancelled {
+              &::before {
+                background-image: url('/static/images/failed.svg');
+              }
+            }
+
             &.succeeded {
+              &::before {
+                background-image: url('/static/images/successful.svg');
+              }
+            }
+
+            &.complete {
               &::before {
                 background-image: url('/static/images/successful.svg');
               }

--- a/services/ui/src/components/Tasks/index.js
+++ b/services/ui/src/components/Tasks/index.js
@@ -18,12 +18,12 @@ const Tasks = ({ tasks, environmentSlug, projectSlug }) => (
       {!tasks.length && <div className="data-none">No Tasks</div>}
       {tasks.map(task => (
         <TaskLink
-          taskSlug={task.id}
+          taskSlug={task.taskName}
           environmentSlug={environmentSlug}
           projectSlug={projectSlug}
-          key={task.id}
+          key={task.taskName}
         >
-          <div className="data-row" task={task.id}>
+          <div className="data-row" task={task.taskName}>
             <div className="name">{task.name}</div>
             <div className="started">
               {moment
@@ -148,11 +148,31 @@ const Tasks = ({ tasks, environmentSlug, projectSlug }) => (
               background-image: url('/static/images/in-progress.svg');
             }
 
+            &.new {
+              background-image: url('/static/images/in-progress.svg');
+            }
+
+            &.pending {
+              background-image: url('/static/images/in-progress.svg');
+            }
+
+            &.running {
+              background-image: url('/static/images/in-progress.svg');
+            }
+
             &.failed {
               background-image: url('/static/images/failed.svg');
             }
 
+            &.cancelled {
+              background-image: url('/static/images/failed.svg');
+            }
+
             &.succeeded {
+              background-image: url('/static/images/successful.svg');
+            }
+
+            &.complete {
               background-image: url('/static/images/successful.svg');
             }
 

--- a/services/ui/src/components/errors/TaskNotFound.js
+++ b/services/ui/src/components/errors/TaskNotFound.js
@@ -4,6 +4,6 @@ import ErrorPage from 'pages/_error';
 export default ({ variables }) => (
   <ErrorPage
     statusCode={404}
-    errorMessage={`Task "${variables.taskId}" not found`}
+    errorMessage={`Task "${variables.taskName}" not found`}
   />
 );

--- a/services/ui/src/components/errors/TaskNotFound.stories.js
+++ b/services/ui/src/components/errors/TaskNotFound.stories.js
@@ -9,7 +9,7 @@ export default {
 export const Default = () => (
   <TaskNotFound
     variables={{
-      taskId: 42,
+      taskName: 'lagoon-task-abcdef',
     }}
   />
 );

--- a/services/ui/src/components/link/Task.js
+++ b/services/ui/src/components/link/Task.js
@@ -5,7 +5,7 @@ export const getLinkData = (taskSlug, environmentSlug, projectSlug) => ({
     pathname: '/task',
     query: {
       openshiftProjectName: environmentSlug,
-      taskId: taskSlug
+      taskName: taskSlug
     }
   },
   asPath: `/projects/${projectSlug}/${environmentSlug}/tasks/${taskSlug}`

--- a/services/ui/src/lib/query/EnvironmentWithTask.js
+++ b/services/ui/src/lib/query/EnvironmentWithTask.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export default gql`
-  query getEnvironment($openshiftProjectName: String!, $taskId: Int!) {
+  query getEnvironment($openshiftProjectName: String!, $taskName: String!) {
     environment: environmentByOpenshiftProjectName(
       openshiftProjectName: $openshiftProjectName
     ) {
@@ -13,8 +13,9 @@ export default gql`
         problemsUi
         factsUi
       }
-      tasks(id: $taskId) {
+      tasks(taskName: $taskName) {
         name
+        taskName
         status
         created
         service

--- a/services/ui/src/lib/query/EnvironmentWithTasks.js
+++ b/services/ui/src/lib/query/EnvironmentWithTasks.js
@@ -59,6 +59,7 @@ export default gql`
       tasks(limit: $limit) {
         id
         name
+        taskName
         status
         created
         service

--- a/services/ui/src/pages/stories/task.stories.js
+++ b/services/ui/src/pages/stories/task.stories.js
@@ -11,7 +11,7 @@ export const Default = () => (
     router={{
       query: {
         openshiftProjectName: 'Example',
-        taskId: 42,
+        taskName: 'lagoon-task-abcdef',
       },
     }}
   />

--- a/services/ui/src/pages/task.js
+++ b/services/ui/src/pages/task.js
@@ -8,6 +8,7 @@ import EnvironmentWithTaskQuery from 'lib/query/EnvironmentWithTask';
 import Breadcrumbs from 'components/Breadcrumbs';
 import ProjectBreadcrumb from 'components/Breadcrumbs/Project';
 import EnvironmentBreadcrumb from 'components/Breadcrumbs/Environment';
+import TaskBreadcrumb from 'components/Breadcrumbs/Task';
 import NavTabs from 'components/NavTabs';
 import Task from 'components/Task';
 import withQueryLoading from 'lib/withQueryLoading';
@@ -24,13 +25,13 @@ import { bp } from 'lib/variables';
 export const PageTask = ({ router }) => (
   <>
     <Head>
-      <title>{`${router.query.taskId} | Task`}</title>
+      <title>{`${router.query.taskName} | Task`}</title>
     </Head>
     <Query
       query={EnvironmentWithTaskQuery}
       variables={{
         openshiftProjectName: router.query.openshiftProjectName,
-        taskId: parseInt(router.query.taskId, 10)
+        taskName: router.query.taskName
       }}
     >
       {R.compose(
@@ -45,6 +46,12 @@ export const PageTask = ({ router }) => (
             <EnvironmentBreadcrumb
               environmentSlug={environment.openshiftProjectName}
               projectSlug={environment.project.name}
+            />
+            <TaskBreadcrumb
+              environmentSlug={environment.openshiftProjectName}
+              projectSlug={environment.project.name}
+              taskSlug={environment.tasks[0].taskName}
+              taskName={environment.tasks[0].name}
             />
           </Breadcrumbs>
           <div className="content-wrapper">


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When looking at #3106 I noticed that there are some differences in how tasks are created, updated, and displayed in the API, versus the same for deployments. Really though, they should be the same or more similar, they both use similar delivery mechanisms from core->remote.

One of the main things is that in tasks we use `active`, `succeeded`, and `failed` as the status types. But in deployments we use `new`, `pending`, `running`, `completed`, `failed`, `cancelled`, and `error`(but this isn't used afaict).
Tasks should also have these same states, where when creating a task it sits in a `new` status until the controller processes it and it goes through to `pending`, then `running`, and eventually completing or failing. Adding these new enums into the API is a first step to supporting cancelling tasks.

Currently the remote-controller (v0.3.0) will send only the statuses that the API is expecting (active and succeeded/failed), introducing the additional enums won't break anything as the existing enums remain in the API for now. Eventually the controller will be updated to send the newer enums that the API knows about. This allows this PR to be backwards compatible with older controllers, and once controller support is added, core will know how to support them out of the box.

Another of the features is adding a new `taskName` field to tasks. This is an autogenerated name that is generated similar to how builds are generated, being `lagoon-task-xxxxxx`. New queries and mutations (WIP) will be available to interact with tasks using this taskName. To account for this new field, a migration function is added to api-db that will go through and generate a taskName for any tasks that are missing this field when `rerun-initdb` is called. This allows the UI to start using this new taskName field as a router query/slug instead of using the tasks ID number.

As this is intended to be backwards compatible support for the new features, there will be follow up issues raised that will need to be tackled under debtsmash labels to remove identified functionality or deprecate things later on.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
