### PR TITLE
Fix `add_ecdsa_ssh_key_types` migration

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1623,7 +1623,7 @@ CREATE OR REPLACE PROCEDURE
       AND column_name = 'key_type';
 
     IF (
-      column_type_argument_type = "enum('ssh-rsa', 'ssh-ed25519')"
+      column_type_argument_type = "enum('ssh-rsa','ssh-ed25519')"
     ) THEN
       ALTER TABLE ssh_key
       MODIFY type ENUM('ssh-rsa', 'ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The migration stored procedure has a superfluous `space` which causes it to think it doesn't need to be run. I ran the migration test query to double check the exact value that's required:

```
MariaDB [infrastructure]> select COLUMN_TYPE from information_schema.columns where table_name = 'ssh_key' and table_schema = 'infrastructure' and column_name = 'key_type';
+-------------------------------+
| COLUMN_TYPE                   |
+-------------------------------+
| enum('ssh-rsa','ssh-ed25519') |
+-------------------------------+
```

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #3116 
