### PR TITLE
fix errors in migrations sql

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1626,7 +1626,7 @@ CREATE OR REPLACE PROCEDURE
       column_type_argument_type = "enum('ssh-rsa','ssh-ed25519')"
     ) THEN
       ALTER TABLE ssh_key
-      MODIFY key_type ENUM('ssh-rsa','ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');
+      MODIFY key_type ENUM('ssh-rsa', 'ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521') NOT NULL DEFAULT 'ssh-rsa';
     END IF;
   END;
 $$

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1603,7 +1603,7 @@ CREATE OR REPLACE PROCEDURE
         table_name = 'advanced_task_definition_argument'
         AND column_name = 'display_name'
     ) THEN
-      ALTER TABLE `advanced_task_definition`
+      ALTER TABLE `advanced_task_definition_argument`
       ADD `display_name` varchar(500) NULL;
     END IF;
   END;
@@ -1626,7 +1626,7 @@ CREATE OR REPLACE PROCEDURE
       column_type_argument_type = "enum('ssh-rsa','ssh-ed25519')"
     ) THEN
       ALTER TABLE ssh_key
-      MODIFY type ENUM('ssh-rsa', 'ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');
+      MODIFY type ENUM('ssh-rsa','ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');
     END IF;
   END;
 $$

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1803,6 +1803,7 @@ CALL change_name_index_for_advanced_task_argument();
 CALL add_confirmation_text_to_advanced_task_def();
 CALL add_display_name_to_advanced_task_argument();
 CALL add_ecdsa_ssh_key_types();
+CALL add_task_name_to_tasks();
 CALL add_new_task_status_types();
 CALL update_active_succeeded_tasks();
 CALL update_missing_tasknames();

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1626,7 +1626,7 @@ CREATE OR REPLACE PROCEDURE
       column_type_argument_type = "enum('ssh-rsa','ssh-ed25519')"
     ) THEN
       ALTER TABLE ssh_key
-      MODIFY type ENUM('ssh-rsa','ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');
+      MODIFY key_type ENUM('ssh-rsa','ssh-ed25519','ecdsa-sha2-nistp256','ecdsa-sha2-nistp384','ecdsa-sha2-nistp521');
     END IF;
   END;
 $$


### PR DESCRIPTION
in https://github.com/uselagoon/lagoon/pull/3117 we fixed the column type lookup, but not the redefined type which still included the errant space (again, as per the original PR, I've modified the unreleased migration)

Additionally, in https://github.com/uselagoon/lagoon/pull/3094 we added a migration to update a table, but inadvertently added the new column to the wrong table. I've modified the migration here (instead of adding a new one), as it'll not trigger currently (as the wrong table was updated). Arguably we could add another migration to remove the errant column, but we'll do that separately as part of a larger cleanup

Also added in a missed call from #3114 to enable the new tasks setup (again unreleased)

+1 to any suggestions for a `migrations` testing framework (see #3058 for more wildness)