### PR TITLE
Set OpenDistro cluster permissions correcly and configure OpenSearch backend_roles

### DIFF
--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -43,9 +43,7 @@ export const OpendistroSecurityOperations = (
     const groupProjectPermissions = {
       body: {
         cluster_permissions: [
-          {
-            allowed_actions: ['cluster:admin/opendistro/reports/menu/download']
-          }
+          'cluster:admin/opendistro/reports/menu/download'
         ],
         index_permissions: [
           {

--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -94,6 +94,14 @@ export const OpendistroSecurityOperations = (
         logger.debug(`${groupName}: Created Tenant "${tenantName}"`);
       } catch (err) {
         logger.error(`Opendistro-Security create tenant error: ${err}`);
+      };
+
+      try {
+        // Create a new RoleMapping for this Group
+        await opendistroSecurityClient.put(`rolesmapping/${tenantName}`, { body: { backend_roles: [`${tenantName}`] } });
+        logger.debug(`${groupName}: Created RoleMapping "${tenantName}"`);
+      } catch (err) {
+        logger.error(`Opendistro-Security create rolemapping error: ${err}`);
       }
     }
 


### PR DESCRIPTION
This PR fixes the code we use to configure cluster permissions in OpenSearch/OpenDistro which was incorrectly structured, and causing roles not to be created correctly

In addition, this PR maps the Tenants and Roles created together to allow for the Logic in OpenSearch to correctly create the permissions.