### PR TITLE
fix up counter check for dbaas provisioning

### DIFF
--- a/images/kubectl-build-deploy-dind/scripts/exec-kubectl-mariadb-dbaas.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-kubectl-mariadb-dbaas.sh
@@ -8,7 +8,7 @@ OPERATOR_TIMEOUT=180
 until kubectl -n ${NAMESPACE} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database
 do
 if [ $OPERATOR_COUNTER -lt $OPERATOR_TIMEOUT ]; then
-    let SERVICE_BROKER_COUNTER=SERVICE_BROKER_COUNTER+1
+    let OPERATOR_COUNTER=OPERATOR_COUNTER+1
     echo "Service for ${SERVICE_NAME} not available yet, waiting for 5 secs"
     sleep 5
 else

--- a/images/kubectl-build-deploy-dind/scripts/exec-kubectl-postgres-dbaas.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-kubectl-postgres-dbaas.sh
@@ -8,7 +8,7 @@ OPERATOR_TIMEOUT=180
 until kubectl -n ${NAMESPACE} get postgresqlconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database
 do
 if [ $OPERATOR_COUNTER -lt $OPERATOR_TIMEOUT ]; then
-    let SERVICE_BROKER_COUNTER=SERVICE_BROKER_COUNTER+1
+    let OPERATOR_COUNTER=OPERATOR_COUNTER+1
     echo "Service for ${SERVICE_NAME} not available yet, waiting for 5 secs"
     sleep 5
 else


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

There is an error in our checks for dbaas being provisioned that doesn't increment the counter so builds could run indefinitely waiting for the dbaas to provision

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

