### PR TITLE
fixup ingress and persistant storage for node-based tests

### DIFF
--- a/tests/files/features-autogenerated-routes-disabled/docker-compose.yml
+++ b/tests/files/features-autogenerated-routes-disabled/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
+      lagoon.persistent.size: 500Mi
     volumes:
       - ./index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-autogenerated-routes-disabled/docker-compose.yml
+++ b/tests/files/features-autogenerated-routes-disabled/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
     volumes:
       - ./index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-disable-inject-git-sha/docker-compose.yml
+++ b/tests/files/features-disable-inject-git-sha/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
+      lagoon.persistent.size: 500Mi
     volumes:
       - ./index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-disable-inject-git-sha/docker-compose.yml
+++ b/tests/files/features-disable-inject-git-sha/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
     volumes:
       - ./index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-lagoon-type-override/docker-compose.yml
+++ b/tests/files/features-lagoon-type-override/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: none
       lagoon.persistent: /files
+      lagoon.persistent.size: 100Mi
     volumes:
       - ./index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-subfolder/subfolder1/subfolder2/docker-compose.yml
+++ b/tests/files/features-subfolder/subfolder1/subfolder2/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
     volumes:
       - ./subfolder3/index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features-subfolder/subfolder1/subfolder2/docker-compose.yml
+++ b/tests/files/features-subfolder/subfolder1/subfolder2/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
+      lagoon.persistent.size: 500Mi
     volumes:
       - ./subfolder3/index.js:/app/index.js:delegated
     expose:

--- a/tests/files/features/.lagoon-no-cronjobs.yml
+++ b/tests/files/features/.lagoon-no-cronjobs.yml
@@ -2,13 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  branch/routes:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com
-  branch/env-specific-template:
-    templates:
-      node: .lagoon.node-env-specific.yml

--- a/tests/files/features/docker-compose.yml
+++ b/tests/files/features/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
+      lagoon.persistent.size: 500Mi
       lagoon.template: .lagoon.node.yml
     volumes:
       - ./index.js:/app/index.js:delegated

--- a/tests/files/features/docker-compose.yml
+++ b/tests/files/features/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /files
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
       lagoon.template: .lagoon.node.yml
     volumes:
       - ./index.js:/app/index.js:delegated

--- a/tests/files/image-cache/.lagoon.yml
+++ b/tests/files/image-cache/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  tasks:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/image-cache/docker-compose.yml
+++ b/tests/files/image-cache/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /app/files/
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
     ports:
       - "3000:3000"
     environment:

--- a/tests/files/image-cache/docker-compose.yml
+++ b/tests/files/image-cache/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /app/files/
+      lagoon.persistent.size: 500Mi
     ports:
       - "3000:3000"
     environment:

--- a/tests/files/node-mongodb/dbaas/.lagoon.yml
+++ b/tests/files/node-mongodb/dbaas/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  node16:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/node-mongodb/single/.lagoon.yml
+++ b/tests/files/node-mongodb/single/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  node16:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/node12/.lagoon.yml
+++ b/tests/files/node12/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  node8:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/node14/.lagoon.yml
+++ b/tests/files/node14/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  node14:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/node16/.lagoon.yml
+++ b/tests/files/node16/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  node16:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/tasks/.lagoon.yml
+++ b/tests/files/tasks/.lagoon.yml
@@ -2,10 +2,3 @@ docker-compose-yaml: docker-compose.yml
 
 environment_variables:
   git_sha: 'true'
-
-environments:
-  tasks:
-    routes:
-    - node:
-      - customdomain-will-be-main-domain.com
-      - customdomain-will-be-not-be-main-domain.com

--- a/tests/files/tasks/docker-compose.yml
+++ b/tests/files/tasks/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /app/files/
-      lagoon.persistent.size: 500Mi
+      lagoon.persistent.size: 100Mi
     ports:
       - "3000:3000"
     environment:

--- a/tests/files/tasks/docker-compose.yml
+++ b/tests/files/tasks/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     labels:
       lagoon.type: node-persistent
       lagoon.persistent: /app/files/
+      lagoon.persistent.size: 500Mi
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
A number of node-based examples copy/pasted the .lagoon.yml files, and as a result, there may be some race conditions around ingress creation - the same ingress may be "already taken" by another competing test,

This PR removes the ingresses from all tests except features - where they are actually used