### PR TITLE
feat: upgrade lagoon-linter v0.5.0 -> v0.7.0

### DIFF
--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -257,6 +257,8 @@ If your `.lagoon.yml` contains one of these annotations it will cause a build fa
 | `nginx.ingress.kubernetes.io/configuration-snippet` | Restricted to `rewrite`, `add_header`, `set_real_ip`, and `more_set_headers` directives. |
 | `nginx.ingress.kubernetes.io/modsecurity-snippet`   | Disallowed                                                                               |
 | `nginx.ingress.kubernetes.io/server-snippet`        | Restricted to `rewrite`, `add_header`, `set_real_ip`, and `more_set_headers` directives. |
+| `nginx.ingress.kubernetes.io/stream-snippet`        | Disallowed                                                                               |
+| `nginx.ingress.kubernetes.io/use-regex`             | Disallowed                                                                               |
 
 #### **Ingress annotations redirects**
 

--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -21,7 +21,7 @@ ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
 
 ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
 
-RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.5.0/lagoon-linter_0.5.0_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.7.0/lagoon-linter_0.7.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This bans some more ingress annotations and also adds support for linter
profiles (though multiple profiles are currently not in use).

# Closing issues

n/a
