### PR TITLE
Adding project naming requirements to documentation

### DIFF
--- a/docs/using-lagoon-the-basics/setup-project.md
+++ b/docs/using-lagoon-the-basics/setup-project.md
@@ -7,6 +7,9 @@ Until then, the setup of a new project involves talking to your Lagoon administr
 
 Please have the following information ready for your Lagoon administrator:
 
+* A name you would like the project to be know by
+  * This nmame can only contain lowercase characters, numbers and dashes
+  * Double dashes (`--`) are not allowed within a project name
 * SSH public keys, email addresses and the names of everybody that will work on this project. Here are instructions for generating and copying SSH keys for [GitHub](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh), [GitLab](https://docs.gitlab.com/ee/ssh/), and [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html).
 * The URL of the Git repository where your code is hosted \(`git@example.com:test/test.git`\).
 * The name of the Git branch you would like to use for your production environment \(see [Environment Types](../using-lagoon-advanced/environment-types.md) for details about the environments\).


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [X] Documentation has been written/updated
- [X] PR title is ready for changelog and subsystem label(s) applied

This PR adds some clarification in the docs on supported/allowed projects names within Lagoon