### PR TITLE
Updating backup docs to add info on custom backup schedules

### DIFF
--- a/docs/using-lagoon-advanced/backups.md
+++ b/docs/using-lagoon-advanced/backups.md
@@ -4,7 +4,15 @@ Lagoon makes use of the [k8up operator](https://github.com/vshn/k8up) to provide
 
 ## Production Environments
 
-Backups of databases and containers' persistent storage volumes happens nightly within production environments. Production environment backups will be held according to the following schedule by default:
+### Backup Schedules
+
+Backups of databases and containers' persistent storage volumes happens nightly within production environments by default.
+
+If a different backup schedule for production backups is required, this can be specified at a project level via setting the "Backup Schedule" variables in the project's [.lagoon.yml](../using-lagoon-the-basics/lagoon-yml.md#backup-schedule) file.
+
+### Backup Retention
+
+Production environment backups will be held according to the following schedule by default:
 
 * Daily: 7
 * Weekly: 6
@@ -13,13 +21,13 @@ Backups of databases and containers' persistent storage volumes happens nightly 
 
 If a different retention period for production backups is required, this can be specified at a project level via setting the "Backup Retention" variables in the project's [.lagoon.yml](../using-lagoon-the-basics/lagoon-yml.md#backup-retention) file.
 
-### Retrieving Backups
-
-Backups stored in Restic will be tracked within Lagoon, and can be recovered via the "Backup" tab for each environment in the Lagoon UI.
-
 ## Development Environments
 
 Backups of development environments are attempted nightly and are strictly a best effort service.
+
+## Retrieving Backups
+
+Backups stored in Restic will be tracked within Lagoon, and can be recovered via the "Backup" tab for each environment in the Lagoon UI.
 
 ## Custom Backup and/or Restore Locations
 


### PR DESCRIPTION
This PR adds information on custom backup schedules to Lagoon's backup doc page
