### PR TITLE
Stop using deprecated keycloak "upload scripts" for authorization policies

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,6 +1,13 @@
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest} as commons
+
+RUN apk add --no-cache zip
+
+COPY javascript /tmp/lagoon-scripts
+
+RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
+
 FROM jboss/keycloak:16.1.1
 
 ARG LAGOON_VERSION
@@ -64,6 +71,7 @@ COPY entrypoints/wait-for-mariadb.sh /lagoon/entrypoints/98-wait-for-mariadb.sh
 COPY entrypoints/default-keycloak-entrypoint.sh /lagoon/entrypoints/99-default-keycloak-entrypoint.sh
 COPY startup-scripts /opt/jboss/startup-scripts
 COPY profile.properties /opt/jboss/keycloak/standalone/configuration/profile.properties
+COPY --from=commons /tmp/lagoon-scripts.jar /opt/jboss/keycloak/standalone/deployments/lagoon-scripts.jar
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
 CMD ["-b", "0.0.0.0"]

--- a/services/keycloak/javascript/META-INF/keycloak-scripts.json
+++ b/services/keycloak/javascript/META-INF/keycloak-scripts.json
@@ -1,0 +1,81 @@
+{
+  "mappers": [
+    {
+      "name": "[Lagoon] Groups and Roles",
+      "description": "Gets a users groups and roles",
+      "fileName": "mappers/groups-and-roles.js"
+    }
+  ],
+  "policies": [
+    {
+      "name": "[Lagoon] Users role for realm is Platform Owner",
+      "description": "Checks the users role for the realm is Platform Owner or higher",
+      "fileName": "policies/users-role-for-realm-is-platform-owner.js"
+    },
+    {
+      "name": "[Lagoon] Users role for realm is Admin",
+      "description": "Checks the users role for the realm is Admin",
+      "fileName": "policies/users-role-for-realm-is-admin.js"
+    },
+    {
+      "name": "[Lagoon] Users role for group is Developer",
+      "description": "Checks the users role for a group is Developer or higher",
+      "fileName": "policies/users-role-for-group-is-developer.js"
+    },
+    {
+      "name": "[Lagoon] Users role for project is Developer",
+      "description": "Checks the users role for a project is Developer or higher",
+      "fileName": "policies/users-role-for-project-is-developer.js"
+    },
+    {
+      "name": "[Lagoon] User has access to project",
+      "description": "Checks that the user has access to a project via groups",
+      "fileName": "policies/user-has-access-to-project.js"
+    },
+    {
+      "name": "[Lagoon] Users role for project is Reporter",
+      "description": "Checks the users role for a project is Reporter or higher",
+      "fileName": "policies/users-role-for-project-is-reporter.js"
+    },
+    {
+      "name": "[Lagoon] User has access to own data",
+      "description": "Checks that the current user is same as queried",
+      "fileName": "policies/user-has-access-to-own-data.js"
+    },
+    {
+      "name": "[Lagoon] Users role for group is Guest",
+      "description": "Checks the users role for a group is Guest or higher",
+      "fileName": "policies/users-role-for-group-is-guest.js"
+    },
+    {
+      "name": "[Lagoon] Users role for group is Maintainer",
+      "description": "Checks the users role for a group is Maintainer or higher",
+      "fileName": "policies/users-role-for-group-is-maintainer.js"
+    },
+    {
+      "name": "[Lagoon] Users role for project is Guest",
+      "description": "Checks the users role for a project is Guest or higher",
+      "fileName": "policies/users-role-for-project-is-guest.js"
+    },
+    {
+      "name": "[Lagoon] Users role for project is Maintainer",
+      "description": "Checks the users role for a project is Maintainer or higher",
+      "fileName": "policies/users-role-for-project-is-maintainer.js"
+    },
+    {
+      "name": "[Lagoon] Users role for group is Reporter",
+      "description": "Checks the users role for a group is Reporter or higher",
+      "fileName": "policies/users-role-for-group-is-reporter.js"
+    },
+    {
+      "name": "[Lagoon] Users role for group is Owner",
+      "description": "Checks the users role for a group is Owner or higher",
+      "fileName": "policies/users-role-for-group-is-owner.js"
+    },
+    {
+      "name": "[Lagoon] Users role for project is Owner",
+      "description": "Checks the users role for a project is Owner or higher",
+      "fileName": "policies/users-role-for-project-is-owner.js"
+    }
+  ]
+}

--- a/services/keycloak/javascript/mappers/groups-and-roles.js
+++ b/services/keycloak/javascript/mappers/groups-and-roles.js
@@ -1,0 +1,33 @@
+var ArrayList = Java.type("java.util.ArrayList");
+var groupsAndRoles = new ArrayList();
+var forEach = Array.prototype.forEach;
+
+// add all groups the user is part of
+forEach.call(user.getGroups().toArray(), function(group) {
+  // remove the group role suffixes
+  //lets check if the group has a parent if this is a child
+  if(group.getFirstAttribute("type") == "role-subgroup") {
+    var parent = group.getParent();
+    if(parent.getFirstAttribute("type") == "project-default-group") {
+        var projectIds = parent.getFirstAttribute("lagoon-projects");
+        if(projectIds !== null) {
+            forEach.call(projectIds.split(","), function(g) {
+              groupsAndRoles.add("p" + g);
+            });
+            return;
+        }
+    }
+  }
+
+  var groupName = group.getName().replace(/-owner|-maintainer|-developer|-reporter|-guest/gi,"");
+  groupsAndRoles.add(groupName);
+  return;
+});
+
+// add all roles the user is part of
+forEach.call(user.getRoleMappings().toArray(), function(role) {
+   var roleName = role.getName();
+   groupsAndRoles.add(roleName);
+});
+
+exports = groupsAndRoles;

--- a/services/keycloak/javascript/policies/user-has-access-to-own-data.js
+++ b/services/keycloak/javascript/policies/user-has-access-to-own-data.js
@@ -1,0 +1,24 @@
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+
+if (!ctxAttr.exists('usersQuery') || !ctxAttr.exists('currentUser')) {
+    $evaluation.deny();
+} else {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+    var users = ctxAttr.getValue('usersQuery').asString(0);
+    var usersArr = users.split('|');
+    var grant = false;
+    
+    for (var i=0; i<usersArr.length; i++) {
+        if (currentUser == usersArr[i]) {
+            grant = true;
+            break;
+        }
+    }
+
+    if (grant) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}

--- a/services/keycloak/javascript/policies/user-has-access-to-project.js
+++ b/services/keycloak/javascript/policies/user-has-access-to-project.js
@@ -1,0 +1,35 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+
+// Check projects calculated by lagoon
+if (!ctxAttr.exists('projectQuery') || !ctxAttr.exists('userProjects')) {
+    $evaluation.deny();
+} else {
+    var project = ctxAttr.getValue('projectQuery').asString(0);
+    var projects = ctxAttr.getValue('userProjects').asString(0);
+    var projectsArr = projects.split('-');
+    var grant = false;
+
+    for (var i=0; i<projectsArr.length; i++) {
+        if (project == projectsArr[i]) {
+            grant = true;
+            break;
+        }
+    }
+
+    if (grant) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-group-is-developer.js
+++ b/services/keycloak/javascript/policies/users-role-for-group-is-developer.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userGroupRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userGroupRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-group-is-guest.js
+++ b/services/keycloak/javascript/policies/users-role-for-group-is-guest.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 1,
+    guest: 1,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userGroupRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userGroupRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-group-is-maintainer.js
+++ b/services/keycloak/javascript/policies/users-role-for-group-is-maintainer.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 0,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userGroupRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userGroupRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-group-is-owner.js
+++ b/services/keycloak/javascript/policies/users-role-for-group-is-owner.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 0,
+    developer: 0,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userGroupRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userGroupRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-group-is-reporter.js
+++ b/services/keycloak/javascript/policies/users-role-for-group-is-reporter.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 1,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userGroupRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userGroupRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-project-is-developer.js
+++ b/services/keycloak/javascript/policies/users-role-for-project-is-developer.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userProjectRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userProjectRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-project-is-guest.js
+++ b/services/keycloak/javascript/policies/users-role-for-project-is-guest.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 1,
+    guest: 1,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userProjectRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userProjectRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-project-is-maintainer.js
+++ b/services/keycloak/javascript/policies/users-role-for-project-is-maintainer.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 0,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userProjectRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userProjectRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-project-is-owner.js
+++ b/services/keycloak/javascript/policies/users-role-for-project-is-owner.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 0,
+    developer: 0,
+    reporter: 0,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userProjectRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userProjectRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-project-is-reporter.js
+++ b/services/keycloak/javascript/policies/users-role-for-project-is-reporter.js
@@ -1,0 +1,32 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+var validRoles = {
+    owner: 1,
+    maintainer: 1,
+    developer: 1,
+    reporter: 1,
+    guest: 0,
+};
+
+// Check roles calculated by lagoon
+if (!ctxAttr.exists('userProjectRole')) {
+    $evaluation.deny();
+} else {
+    var groupRole = ctxAttr.getValue('userProjectRole').asString(0);
+
+    if (validRoles[groupRole.toLowerCase()]) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+// Check admin access
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-realm-is-admin.js
+++ b/services/keycloak/javascript/policies/users-role-for-realm-is-admin.js
@@ -1,0 +1,15 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+
+if (!ctxAttr.exists('currentUser')) {
+    $evaluation.deny();
+} else {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'admin')) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}

--- a/services/keycloak/javascript/policies/users-role-for-realm-is-platform-owner.js
+++ b/services/keycloak/javascript/policies/users-role-for-realm-is-platform-owner.js
@@ -1,0 +1,15 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+
+if (!ctxAttr.exists('currentUser')) {
+    $evaluation.deny();
+} else {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -2,8 +2,9 @@
 
 set -eo pipefail
 
-# 1. The first part of this entrypoint script deals with adding realms and users. Code is a modified version of this entrypoint script:
-# https://github.com/stefanjacobs/keycloak_min/blob/f26927426e60c1ec29fc0c0980e5a694a45dcc05/run.sh
+#####################
+# Utility Functions #
+#####################
 
 function is_keycloak_running {
     local http_code=$(curl -s -o /dev/null -w "%{http_code}" http://$(hostname -i):8080/auth/admin/realms)
@@ -27,6 +28,19 @@ function sync_client_secrets {
   SERVICE_API_CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r ${KEYCLOAK_REALM:-master} clients?clientId=service-api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   /opt/jboss/keycloak/bin/kcadm.sh update clients/$SERVICE_API_CLIENT_ID -s secret=$KEYCLOAK_SERVICE_API_CLIENT_SECRET --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master}
 }
+
+##############
+# Migrations #
+##############
+
+# This script runs on every keycloak startup and needs to be idempotent. It also
+# has to handle both use cases of installing a fresh keycloak (new cluster, CI,
+# etc) and updating existing ones (e.g, prod). For those reasons, every
+# migration must be designed to run __only once__ per keycloak install. Once a
+# function is released, it should be considered "final."
+#
+# The "standard" update mechanism is to first check if some data exists that
+# would've been created by the function, and halting execution if found.
 
 function configure_lagoon_realm {
     if /opt/jboss/keycloak/bin/kcadm.sh get realms/$KEYCLOAK_REALM --config $CONFIG_PATH > /dev/null; then
@@ -744,7 +758,7 @@ EOF
   "decisionStrategy": "UNANIMOUS",
   "resources": ["env_var"],
   "scopes": ["project:add"],
-  "policies": ["Users role for project is Maintainer","User has access to project"]
+  "policies": ["Users role for project is Owner","User has access to project"]
 }
 EOF
 
@@ -780,7 +794,7 @@ EOF
   "decisionStrategy": "UNANIMOUS",
   "resources": ["openshift"],
   "scopes": ["view"],
-  "policies": ["User has access to project","Users role for project is Guest"]
+  "policies": ["User has access to project","Users role for project is Maintainer"]
 }
 EOF
 
@@ -1371,12 +1385,8 @@ EOF
 }
 
 function configure_task_uli {
-
-  echo "configure_task_uli running"
-
   CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   uli_task=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=Run+Drush+uli+on+Production+Environment --config $CONFIG_PATH)
-  echo Checking task:drushUserLogin
 
   if [ "$uli_task" != "[ ]" ]; then
     echo "scopes:drushUserLogin already configured"
@@ -1422,12 +1432,8 @@ EOF
 }
 
 function configure_problems_system {
-
-  echo "configure_problems_system running"
-
   CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   problems_system=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=View+Problems --config $CONFIG_PATH)
-  echo Checking task:manageProblems
 
   if [ "$problems_system" != "[ ]" ]; then
     echo "Problems Permissions already configured"
@@ -1435,8 +1441,6 @@ function configure_problems_system {
   fi
 
   echo Configuring Problems Permissions
-
-  echo Creating resource problem
 
   echo '{"name":"problem","displayName":"problem","scopes":[{"name":"view"},{"name":"add"},{"name":"delete"}],"attributes":{},"uris":[],"ownerManagedAccess":""}' | /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/resource --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -f -
 
@@ -1481,12 +1485,8 @@ EOF
 
 
 function configure_harbor_scan_system {
-
-  echo "configure_harbor_scan_system running"
-
   CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   hs_system=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=View+Harbor+Scan+Match --config $CONFIG_PATH)
-  echo Checking task:View Harbor Scan Match
 
   if [ "$hs_system" != "[ ]" ]; then
     echo "Harbor Scan Match Permissions already configured"
@@ -1494,8 +1494,6 @@ function configure_harbor_scan_system {
   fi
 
   echo Configuring Harbor Scan Match Permissions
-
-  echo Creating resource harbor_scan_match
 
   echo '{"name":"harbor_scan_match","displayName":"Harbor scan match","scopes":[{"name":"view"},{"name":"add"},{"name":"delete"}],"attributes":{},"uris":[],"ownerManagedAccess":""}' | /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/resource --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -f -
 
@@ -1540,12 +1538,8 @@ EOF
 
 
 function configure_facts_system {
-
-  echo "configure_facts_system running"
-
   CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   facts_system=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=View+Facts --config $CONFIG_PATH)
-  echo Checking task:manageFacts
 
   if [ "$facts_system" != "[ ]" ]; then
     echo "Facts Permissions already configured"
@@ -1553,8 +1547,6 @@ function configure_facts_system {
   fi
 
   echo Configuring Facts Permissions
-
-  echo Creating resource fact
 
   echo '{"name":"fact","displayName":"fact","scopes":[{"name":"view"},{"name":"add"},{"name":"delete"}],"attributes":{},"uris":[],"ownerManagedAccess":""}' | /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/resource --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -f -
 
@@ -1599,12 +1591,8 @@ EOF
 
 
 function configure_advanced_task_system {
-
-  echo "configure_advanced_task_system running"
-
   CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
   facts_system=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=Invoke+Task+Guest --config $CONFIG_PATH)
-  echo Checking advanced_task invoke:guest
 
   if [ "$facts_system" != "[ ]" ]; then
     echo "Advanced Task Permissions already configured"
@@ -1612,8 +1600,6 @@ function configure_advanced_task_system {
   fi
 
   echo Configuring Advanced Task Permissions
-
-  echo Creating resource fact
 
   echo '{"name":"advanced_task","displayName":"advanced_task","scopes":[{"name":"invoke:guest"}, {"name":"invoke:developer"},{"name":"invoke:maintainer"}, {"name":"create:advanced"}, {"name":"delete:advanced"}],"attributes":{},"uris":[],"ownerManagedAccess":""}' | /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/resource --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -f -
 
@@ -1685,6 +1671,7 @@ function remove_billing_modifier {
   billing_modifier=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=Delete+All+Billing+Group+Modifiers --config $CONFIG_PATH)
 
   if [ "$billing_modifier" == "[ ]" ]; then
+      echo Billing modifiers already removed
       return 0
   fi
 
@@ -1701,11 +1688,19 @@ function remove_billing_modifier {
 }
 
 function update_openshift_view_permission {
-  CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
-  echo Reconfiguring View Openshift
-  VIEW_OPENSHIFT_PERMISSION_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=View+Openshift --config $CONFIG_PATH | jq -r '.[0]["id"]')
-  /opt/jboss/keycloak/bin/kcadm.sh delete -r lagoon clients/$CLIENT_ID/authz/resource-server/permission/$VIEW_OPENSHIFT_PERMISSION_ID --config $CONFIG_PATH
-  /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/permission/scope --config $CONFIG_PATH -r lagoon -f - <<EOF
+  local api_client_id=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
+  local openshift_view_permission_id=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$api_client_id/authz/resource-server/permission?name=View+Openshift --config $CONFIG_PATH | jq -r '.[0]["id"]')
+  local associated_policies=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$api_client_id/authz/resource-server/policy/$openshift_view_permission_id/associatedPolicies --config $CONFIG_PATH | jq -c 'map({name})')
+
+  if [ "$associated_policies" != '[{"name":"Users role for project is Maintainer"},{"name":"User has access to project"}]' ]; then
+    echo \"View Openshift\" permissions already updated
+    return 0;
+  fi
+
+  echo Updating \"View Openshift\" permissions
+
+  /opt/jboss/keycloak/bin/kcadm.sh delete -r lagoon clients/$api_client_id/authz/resource-server/permission/$openshift_view_permission_id --config $CONFIG_PATH
+  /opt/jboss/keycloak/bin/kcadm.sh create clients/$api_client_id/authz/resource-server/permission/scope --config $CONFIG_PATH -r lagoon -f - <<EOF
 {
   "name": "View Openshift",
   "type": "scope",
@@ -1764,11 +1759,19 @@ function configure_token_exchange {
 }
 
 function update_add_env_var_to_project {
-  CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
-  echo Reconfiguring Add Environment Variable to Project
-  ADD_PROJECT_ENV_VAR_PERMISSION_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=Add+Environment+Variable+to+Project --config $CONFIG_PATH | jq -r '.[0]["id"]')
-  /opt/jboss/keycloak/bin/kcadm.sh delete -r lagoon clients/$CLIENT_ID/authz/resource-server/permission/$ADD_PROJECT_ENV_VAR_PERMISSION_ID --config $CONFIG_PATH
-  /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/permission/scope --config $CONFIG_PATH -r lagoon -f - <<EOF
+  local api_client_id=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
+  local env_var_project_add_permission_id=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$api_client_id/authz/resource-server/permission?name=Add+Environment+Variable+to+Project --config $CONFIG_PATH | jq -r '.[0]["id"]')
+  local associated_policies=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$api_client_id/authz/resource-server/policy/$env_var_project_add_permission_id/associatedPolicies --config $CONFIG_PATH | jq -c 'map({name})')
+
+  if [ "$associated_policies" != '[{"name":"Users role for project is Owner"},{"name":"User has access to project"}]' ]; then
+    echo \"Add Environment Variable to Project\" permissions already updated
+    return 0;
+  fi
+
+  echo Updating \"Add Environment Variable to Project\" permissions
+
+  /opt/jboss/keycloak/bin/kcadm.sh delete -r lagoon clients/$api_client_id/authz/resource-server/permission/$env_var_project_add_permission_id --config $CONFIG_PATH
+  /opt/jboss/keycloak/bin/kcadm.sh create clients/$api_client_id/authz/resource-server/permission/scope --config $CONFIG_PATH -r lagoon -f - <<EOF
 {
   "name": "Add Environment Variable to Project",
   "type": "scope",
@@ -1868,6 +1871,10 @@ function migrate_to_js_provider {
     IFS=$OLDIFS
 }
 
+##################
+# Initialization #
+##################
+
 function configure_keycloak {
     until is_keycloak_running; do
         echo Keycloak still not running, waiting 5 seconds
@@ -1881,6 +1888,7 @@ function configure_keycloak {
 
     /opt/jboss/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://$(hostname -i):8080/auth --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD --realm master
 
+    # Sets the order of migrations, add new ones at the end.
     configure_lagoon_realm
     configure_opendistro_security_client
     configure_api_client


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

In Keycloak 18, the deprecated "upload scripts" features is finally being removed. In order to to import our authorization scripts we need to convert them to a custom provider. This is a proof of concept to show that we can make the change when the need arises.

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
