### PR TITLE
fix: add group-lagoon-project-ids to project-default groups

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -322,7 +322,8 @@ export const addProject = async (
       name: `project-${project.name}`,
       attributes: {
         type: ['project-default-group'],
-        'lagoon-projects': [project.id]
+        'lagoon-projects': [project.id],
+        'group-lagoon-project-ids': [`{${JSON.stringify(`project-${project.name}`)}:[${project.id}]}`]
       }
     });
   } catch (err) {


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This annotation is required for the ssh-portal service to determine
permissions for users which have permissions on a project through a
project-default group.

# Closing issues

n/a
