### PR TITLE
fix: check for task "complete" status, as succeeded is being deprecated

### DIFF
--- a/services/controllerhandler/src/index.ts
+++ b/services/controllerhandler/src/index.ts
@@ -241,6 +241,7 @@ const messageConsumer = async function(msg) {
         // that we get back from the controllers
         case "kubernetes:route:migrate":
           switch (meta.jobStatus) {
+            case "complete":
             case "succeeded":
               try {
                 // since the advanceddata contains a base64 encoded value, we have to decode it first

--- a/tests/tests/active-standby/deploy-active-standby.yaml
+++ b/tests/tests/active-standby/deploy-active-standby.yaml
@@ -23,7 +23,7 @@
         body_format: json
         body: '{ "query": "query($id: Int!) {taskById(id: $id){status}}", "variables": {"id":{{ apiresponse.json.data.switchActiveStandby.id }}}}'
       register: taskresult
-      until: taskresult.json.data is defined and (taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed")
+      until: taskresult.json.data is defined and (taskresult.json.data.taskById.status == "complete" or taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed")
       retries: 20
       delay: 10
     - name: "{{ testname }} - fail if task fails"

--- a/tests/tests/tasks/create-register-and-test-image-task.yaml
+++ b/tests/tests/tasks/create-register-and-test-image-task.yaml
@@ -46,6 +46,6 @@
         body_format: json
         body: '{ "query": "query($taskId: Int!) {taskById(id:$taskId){status}}", "variables": {"taskId": {{ invokeRegisteredTaskApiResponse.json.data.invokeRegisteredTask.id }}}}'
       register: result
-      until: result.json.data.taskById.status == "succeeded"
+      until: (result.json.data.taskById.status == "complete" or result.json.data.taskById.status == "succeeded")
       retries: 90
       delay: 20


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

#3114 added additional enums for tasks to be more like deployments, the tests should leverage the newer enums as well as the older ones for now until `remote-controller` has been released long enough with the update

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

