### PR TITLE
disable dev env retention policy adjustments

### DIFF
--- a/images/kubectl-build-deploy-dind/scripts/exec-backup-generation.sh
+++ b/images/kubectl-build-deploy-dind/scripts/exec-backup-generation.sh
@@ -20,51 +20,52 @@ set +x
 ##############################################
 
 # check if a specific override has been defined in the api
-case "$BUILD_TYPE" in
-    promote)
-        ;;
-    branch)
-        if [ "${ENVIRONMENT_TYPE}" == "development" ]; then
-            # check if the API defined variable LAGOON_BACKUP_DEV_RETENTION contains what is needed
-            # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_DEV_RETENTION
-            BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_DEV_RETENTION "${LAGOON_FEATURE_BACKUP_DEV_RETENTION}")
-            if [ ! -z "$BACKUP_RETENTION" ]; then
-                IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
-                HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
-                DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
-                WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
-                MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
-            fi
-        fi
-        ;;
-    pullrequest)
-        # check if the API defined variable LAGOON_BACKUP_PR_RETENTION contains what is needed
-        # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_PR_RETENTION
-        BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_PR_RETENTION "${LAGOON_FEATURE_BACKUP_PR_RETENTION}")
-        if [ ! -z "$BACKUP_RETENTION" ]; then
-            IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
-            HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
-            DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
-            WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
-            MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
-        fi
-        if [ -z "$BACKUP_RETENTION" ];then
-            ## fall back to dev retention if no pr retention is defined
-            # check if the API defined variable LAGOON_BACKUP_DEV_RETENTION contains what is needed
-            # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_DEV_RETENTION
-            BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_DEV_RETENTION "${LAGOON_FEATURE_BACKUP_DEV_RETENTION}")
-            if [ ! -z "$BACKUP_RETENTION" ]; then
-                IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
-                HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
-                DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
-                WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
-                MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
-            fi
-        fi
-        ;;
-    *)
-        echo "${BUILD_TYPE} not implemented"; exit 1;
-esac
+# DISABLE CUSTOM RETENTION FOR DEVELOPMENT ENVIRONMENTS
+# case "$BUILD_TYPE" in
+#     promote)
+#         ;;
+#     branch)
+#         if [ "${ENVIRONMENT_TYPE}" == "development" ]; then
+#             # check if the API defined variable LAGOON_BACKUP_DEV_RETENTION contains what is needed
+#             # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_DEV_RETENTION
+#             BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_DEV_RETENTION "${LAGOON_FEATURE_BACKUP_DEV_RETENTION}")
+#             if [ ! -z "$BACKUP_RETENTION" ]; then
+#                 IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
+#                 HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
+#                 DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
+#                 WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
+#                 MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
+#             fi
+#         fi
+#         ;;
+#     pullrequest)
+#         # check if the API defined variable LAGOON_BACKUP_PR_RETENTION contains what is needed
+#         # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_PR_RETENTION
+#         BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_PR_RETENTION "${LAGOON_FEATURE_BACKUP_PR_RETENTION}")
+#         if [ ! -z "$BACKUP_RETENTION" ]; then
+#             IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
+#             HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
+#             DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
+#             WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
+#             MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
+#         fi
+#         if [ -z "$BACKUP_RETENTION" ];then
+#             ## fall back to dev retention if no pr retention is defined
+#             # check if the API defined variable LAGOON_BACKUP_DEV_RETENTION contains what is needed
+#             # if one in the API is not defined, fall back to what could be injected by the controller LAGOON_FEATURE_BACKUP_DEV_RETENTION
+#             BACKUP_RETENTION=$(projectEnvironmentVariableCheck LAGOON_BACKUP_DEV_RETENTION "${LAGOON_FEATURE_BACKUP_DEV_RETENTION}")
+#             if [ ! -z "$BACKUP_RETENTION" ]; then
+#                 IFS=':' read -ra BACKUP_RETENTION_SPLIT <<< "$BACKUP_RETENTION"
+#                 HOURLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[0]}
+#                 DAILY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[1]}
+#                 WEEKLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[2]}
+#                 MONTHLY_BACKUP_DEFAULT_RETENTION=${BACKUP_RETENTION_SPLIT[3]}
+#             fi
+#         fi
+#         ;;
+#     *)
+#         echo "${BUILD_TYPE} not implemented"; exit 1;
+# esac
 
 # Implement global default value for backup retentions
 if [ -z "$MONTHLY_BACKUP_DEFAULT_RETENTION" ]


### PR DESCRIPTION
In #3087 we introduced a number of features to control the backup schedules and retentions for development environments separately to production environments. This was intended to reduce the burden on clusters that have fast repeating schedules needed for production environments, as the schedule would also trigger for non-production environments, massively increasing the volumes of backups undertaken.

On investigation into K8up operation, it has become apparent that the prune schedule (defined by the retention settings) was not being applied to production and development environments differently (Related https://github.com/k8up-io/k8up/issues/686). This would have the effect of treating all backups based on the shortest retention period.

We have taken the step in this PR of removing Lagoon's ability to action the variables (specifically `LAGOON_BACKUP_DEV_RETENTION` and `LAGOON_BACKUP_PR_RETENTION`) that define different retention periods for development environments. If these variables are defined, they will not be read in the build deploy, and the retention schedules will not be created. We have left in the ability to set differing backup schedules, as this functionality is still operational (and beneficial).

In order to assess whether you have any projects impacted by this issue, you can check to see whether any projects have these variables set.

i.e.
```
MariaDB [infrastructure]> select * from env_vars where name like "LAGOON_BACKUP_%";
Empty set (0.001 sec)
```

You could also check the retentions to see if any projects have differing schedules:

```
kubectl get schedule -A -o json > /tmp/schedule.json
jq '.items|group_by(.metadata.labels."lagoon.sh/project")[]|{"project": .[0].metadata.labels."lagoon.sh/project", "retentions":map({"namespace": .metadata.namespace, "retention": .spec.prune.retention})} | .retentions[0] as $first | select(.retentions | any(.retention != $first.retention))' /tmp/schedule.json
```

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog
