### PR TITLE
update build-deploy-tool and add docker-compose validation step

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -24,7 +24,7 @@ ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
 RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.7.0/lagoon-linter_0.7.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
-RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.8.5/build-deploy-tool_0.8.5_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.9.1/build-deploy-tool_0.9.1_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin build-deploy-tool
 
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -1431,3 +1431,29 @@ if [ "$(featureFlag INSIGHTS)" = enabled ]; then
   previousStepEnd=${currentStepEnd}
 fi
 set -x
+
+set +x
+##############################################
+### RUN docker compose config check against the provided docker-compose file
+### use the `build-deploy-tool` built in validater to run over the provided docker-compose file
+##############################################
+dcc=$(bash -c 'build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}' --ignore-non-string-key-errors=false; exit $?' 2>&1)
+dccExit=$?
+if [ "${dcc}" != "0" ]; then
+  echo "
+##############################################
+Warning!
+There are issues with your docker compose file that lagoon uses that should be fixed.
+This does not currently prevent builds from proceeding, but future versions of Lagoon *will* be more strict on issues shown here.
+The following is output from \`build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}' --ignore-non-string-key-errors=false\` which you can run locally to verify and fix.
+##############################################
+"
+  echo ${dockerComposeConfig}
+  echo "
+##############################################"
+  currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
+  patchBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "dockerComposeValidation" "Docker Compose Validation"
+  previousStepEnd=${currentStepEnd}
+fi
+
+set -x

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -143,6 +143,10 @@ set -x
 ##############################################
 
 set +x
+
+# Load path of docker-compose that should be used
+DOCKER_COMPOSE_YAML=($(cat .lagoon.yml | shyaml get-value docker-compose-yaml))
+
 echo "Updating lagoon-yaml configmap with a pre-deploy version of the .lagoon.yml file"
 if kubectl -n ${NAMESPACE} get configmap lagoon-yaml &> /dev/null; then
   # replace it
@@ -160,6 +164,23 @@ if kubectl -n ${NAMESPACE} get configmap lagoon-yaml &> /dev/null; then
   # create it
   kubectl -n ${NAMESPACE} create configmap lagoon-yaml --from-file=pre-deploy=.lagoon.yml
 fi
+echo "Updating docker-compose-yaml configmap with a pre-deploy version of the docker-compose.yml file"
+if kubectl -n ${NAMESPACE} get configmap docker-compose-yaml &> /dev/null; then
+  # replace it
+  # if the environment has already been deployed with an existing configmap that had the file in the key `docker-compose.yml`
+  # just nuke the entire configmap and replace it with our new key and file
+  LAGOON_YML_CM=$(kubectl -n ${NAMESPACE} get configmap docker-compose-yaml -o json)
+  if [ "$(echo ${LAGOON_YML_CM} | jq -r '.data."docker-compose.yml" // false')" == "false" ]; then
+    # if the key doesn't exist, then just update the pre-deploy yaml only
+    kubectl -n ${NAMESPACE} get configmap docker-compose-yaml -o json | jq --arg add "`cat ${DOCKER_COMPOSE_YAML}`" '.data."pre-deploy" = $add' | kubectl apply -f -
+  else
+    # if the key does exist, then nuke it and put the new key
+    kubectl -n ${NAMESPACE} create configmap docker-compose-yaml --from-file=pre-deploy=${DOCKER_COMPOSE_YAML} -o yaml --dry-run=client | kubectl replace -f -
+  fi
+ else
+  # create it
+  kubectl -n ${NAMESPACE} create configmap docker-compose-yaml --from-file=pre-deploy=${DOCKER_COMPOSE_YAML}
+fi
 set -x
 
 # validate .lagoon.yml
@@ -176,9 +197,6 @@ currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
 patchBuildStep "${buildStartTime}" "${buildStartTime}" "${currentStepEnd}" "${NAMESPACE}" "initialSetup" "Initial Environment Setup"
 previousStepEnd=${currentStepEnd}
 set -x
-
-# Load path of docker-compose that should be used
-DOCKER_COMPOSE_YAML=($(cat .lagoon.yml | shyaml get-value docker-compose-yaml))
 
 DEPLOY_TYPE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.deploy-type default)
 
@@ -1404,6 +1422,14 @@ if kubectl -n ${NAMESPACE} get configmap lagoon-yaml &> /dev/null; then
   # create it
   kubectl -n ${NAMESPACE} create configmap lagoon-yaml --from-file=post-deploy=.lagoon.yml
 fi
+echo "Updating docker-compose-yaml configmap with a post-deploy version of the docker-compose.yml file"
+if kubectl -n ${NAMESPACE} get configmap docker-compose-yaml &> /dev/null; then
+  # replace it, no need to check if the key is different, as that will happen in the pre-deploy phase
+  kubectl -n ${NAMESPACE} get configmap docker-compose-yaml -o json | jq --arg add "`cat ${DOCKER_COMPOSE_YAML}`" '.data."post-deploy" = $add' | kubectl apply -f -
+ else
+  # create it
+  kubectl -n ${NAMESPACE} create configmap docker-compose-yaml --from-file=post-deploy=${DOCKER_COMPOSE_YAML}
+fi
 set -x
 
 set +x
@@ -1437,9 +1463,9 @@ set +x
 ### RUN docker compose config check against the provided docker-compose file
 ### use the `build-deploy-tool` built in validater to run over the provided docker-compose file
 ##############################################
-dcc=$(bash -c 'build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}' --ignore-non-string-key-errors=false; exit $?' 2>&1)
+dccOutput=$(bash -c 'build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}' --ignore-non-string-key-errors=false; exit $?' 2>&1)
 dccExit=$?
-if [ "${dcc}" != "0" ]; then
+if [ "${dccExit}" != "0" ]; then
   echo "
 ##############################################
 Warning!
@@ -1448,7 +1474,7 @@ This does not currently prevent builds from proceeding, but future versions of L
 The following is output from \`build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}' --ignore-non-string-key-errors=false\` which you can run locally to verify and fix.
 ##############################################
 "
-  echo ${dockerComposeConfig}
+  echo ${dccOutput}
   echo "
 ##############################################"
   currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"

--- a/tests/files/elasticsearch-cluster/docker-compose.yml
+++ b/tests/files/elasticsearch-cluster/docker-compose.yml
@@ -21,3 +21,6 @@ services:
       dockerfile: nginx.dockerfile
     labels:
       lagoon.type: nginx
+networks:
+  amazeeio-network:
+    external: true

--- a/tests/files/elasticsearch/docker-compose.yml
+++ b/tests/files/elasticsearch/docker-compose.yml
@@ -21,3 +21,6 @@ services:
       dockerfile: nginx.dockerfile
     labels:
       lagoon.type: nginx
+networks:
+  amazeeio-network:
+    external: true


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

A recent release of the build-deploy-tool added the ability to consume the docker-compose file. But due to some issues with some customers having broken or invalid docker-compose files this caused the `LAGOON_ROUTE` to not be displayed and the build-deploy-tool silently failed. Previous versions of Lagoon builds were less strict with this file so these errors went unnoticed for a lot of people.

This PR uses the updated build-deploy-tool v0.9.1 which uses the `compose-spec/compose-go` library to read the docker-compose file, but has some additional functionality to be able ignore some errors with validating the docker-compose file.

An additional step at the end of builds will now run to validate the docker-compose file. If the build-deploy-tool discovers an issue with the file, it will report a warning at the end of a build, this is the same as running `docker compose config` against your docker-compose file.

Additionally, we now also capture the `docker-compose.yml` into pre and post deploy fields in a new configmap.
This way we can analyse docker-compose files if required.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

https://github.com/uselagoon/build-deploy-tool/issues/42
