### PR TITLE
Admin and non-UI tasks

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -292,6 +292,8 @@ CREATE TABLE IF NOT EXISTS advanced_task_definition (
   permission               ENUM('GUEST', 'DEVELOPER', 'MAINTAINER') DEFAULT 'GUEST',
   command                  text DEFAULT '',
   confirmation_text        varchar(2000) NULL,
+  show_ui                  int(1) NOT NULL default 1,
+  admin_task               int(1) NOT NULL default 0,
   created                  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   deleted                  timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   UNIQUE(name, environment, project, group_name)

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1699,6 +1699,25 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
+CREATE OR REPLACE PROCEDURE
+  add_no_ui_and_admin_task_to_advanced_task_def()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'advanced_task_definition'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'show_ui'
+    ) THEN
+      ALTER TABLE `advanced_task_definition`
+      ADD  `show_ui`    int(1) NOT NULL default 1,
+      ADD  `admin_task` int(1) NOT NULL default 0;
+    END IF;
+  END;
+$$
+
 -- TODO: Eventually the `active/succeeded` values should go away once `remote-controller` is updated to send the correct values
 -- CREATE OR REPLACE PROCEDURE
 --   remove_active_succeeded_task_types()
@@ -1807,6 +1826,7 @@ CALL add_task_name_to_tasks();
 CALL add_new_task_status_types();
 CALL update_active_succeeded_tasks();
 CALL update_missing_tasknames();
+CALL add_no_ui_and_admin_task_to_advanced_task_def();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -113,6 +113,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload = {},
       remoteId,
       execute,
+      adminTask,
     }: {
       id?: number,
       name: string,
@@ -127,6 +128,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload: object,
       remoteId?: string,
       execute: boolean,
+      adminTask: boolean,
     },
   ) => {
     let rows = await query(
@@ -175,7 +177,9 @@ export const Helpers = (sqlClientPool: Pool) => ({
       environment: environmentData,
       advancedTask: {
         RunnerImage: image,
-        JSONPayload: new Buffer(JSON.stringify(payload).replace(/\\n/g, "\n")).toString('base64')
+        JSONPayload: new Buffer(JSON.stringify(payload).replace(/\\n/g, "\n")).toString('base64'),
+        deployerToken: adminTask, //an admintask will have a deployer token and ssh key injected into it
+        sshKey: adminTask,
       }
     }
 

--- a/services/api/src/resources/task/models/taskRegistration.ts
+++ b/services/api/src/resources/task/models/taskRegistration.ts
@@ -38,6 +38,8 @@ export interface AdvancedTaskDefinitionInterface {
   command?: string;
   service?: string;
   image?: string;
+  showUi?: number;
+  adminTask?: number;
   advancedTaskDefinitionArguments?: Partial<AdvancedTaskDefinitionArguments>;
 }
 

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -84,6 +84,8 @@ export const Sql = {
     environment,
     permission,
     confirmation_text,
+    show_ui,
+    admin_task
     }: {
       id: number,
       name: string,
@@ -97,7 +99,10 @@ export const Sql = {
       group_name: string,
       environment: number,
       permission: string,
-      confirmation_text: string
+      confirmation_text: string,
+      show_ui: number,
+      admin_task: number,
+
     }) =>
     knex('advanced_task_definition')
       .insert({
@@ -114,6 +119,8 @@ export const Sql = {
         environment,
         permission,
         confirmation_text,
+        show_ui,
+        admin_task,
       })
     .toString(),
     insertAdvancedTaskDefinitionArgument: ({

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -480,6 +480,7 @@ export const invokeRegisteredTask = async (
     environment,
     models
   );
+  console.log(task);
 
   const atb = advancedTaskToolbox.advancedTaskFunctions(
     sqlClientPool, models, hasPermission
@@ -570,6 +571,7 @@ export const invokeRegisteredTask = async (
           service: task.service || 'cli',
           image: task.image, //the return data here is basically what gets dropped into the DB.
           payload: payload,
+          adminTask: task.adminTask == 1,
           remoteId: undefined,
           execute: true
         });

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -235,6 +235,8 @@ export const addAdvancedTaskDefinition = async (
     advancedTaskDefinitionArguments,
     created,
     confirmationText,
+    showUi,
+    adminTask,
   } = input;
 
   const atb = advancedTaskToolbox.advancedTaskFunctions(
@@ -313,6 +315,8 @@ export const addAdvancedTaskDefinition = async (
       group_name: groupName,
       permission,
       confirmation_text: confirmationText,
+      show_ui: showUi,
+      admin_task: adminTask,
     })
   );
 
@@ -360,7 +364,8 @@ export const updateAdvancedTaskDefinition = async (
         command,
         permission,
         advancedTaskDefinitionArguments,
-        confirmationText
+        confirmationText,
+        showUi,
       }
     }
   },
@@ -399,7 +404,8 @@ export const updateAdvancedTaskDefinition = async (
         command,
         service,
         permission,
-        confirmation_text: confirmationText
+        confirmation_text: confirmationText,
+        show_ui: showUi
       }
     })
   );
@@ -730,7 +736,7 @@ async function checkAdvancedTaskPermissions(input:AdvancedTaskDefinitionInterfac
     //In the first release, we're not actually supporting this
     //TODO: add checks once images are officially supported - for now, throw an error
     throw Error('Adding Images and System Wide Tasks are not yet supported');
-  } else if (getAdvancedTaskDefinitionType(input) == AdvancedTaskDefinitionType.image) {
+  } else if (getAdvancedTaskDefinitionType(input) == AdvancedTaskDefinitionType.image || input.adminTask != 0) {
     //We're only going to allow administrators to add these for now ...
     await hasPermission('advanced_task', 'create:advanced');
   } else if (input.groupName) {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -153,6 +153,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
+    showUi: Int
+    adminTask: Int
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -170,6 +172,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
+    showUi: Int
+    adminTask: Int
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1382,6 +1382,8 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
+    showUi: Int
+    adminTask: Int
   }
 
   input UpdateAdvancedTaskDefinitionInput {
@@ -1402,6 +1404,7 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
+    showUi: Int
   }
 
   input DeleteTaskInput {

--- a/services/ui/src/components/AddTask/logic.js
+++ b/services/ui/src/components/AddTask/logic.js
@@ -44,7 +44,7 @@ const withOptions = withProps(({ pageEnvironment }) => {
   ];
 
   // Add Advanced Task Definitions
-  let advancedTasks = pageEnvironment.advancedTasks.map(task => {
+  let advancedTasks = pageEnvironment.advancedTasks.filter(e => { return e.showUi == 1;}).map(task => {
     let commandstring = task.command ? `[${task.command}]` : '';
     let label = task.description ? `${task.description} ${commandstring}` :'';
     return {

--- a/services/ui/src/lib/query/EnvironmentWithTasks.js
+++ b/services/ui/src/lib/query/EnvironmentWithTasks.js
@@ -27,6 +27,8 @@ export default gql`
           service
           created
           deleted
+          adminTask
+          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id
@@ -46,6 +48,8 @@ export default gql`
           service
           created
           deleted
+          adminTask
+          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id


### PR DESCRIPTION
This PR introduces two new flags to the advanced task definition system
* `adminTask`: This marks a task as requiring slightly elevated privileges within the task system (i.e. having the deployer token mounted into the task container). By default, tasks will not be set as adminTask. Details in #3182 
* `showUi`: if set to 0, the custom task will not be shown in the UI. Details in #3183 


<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog


# Closing issues

closes #3183  and closes #3182 
