### PR TITLE
always create backend_role RoleMapping for roles in OpenSearch

### DIFF
--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -86,22 +86,32 @@ export const OpendistroSecurityOperations = (
     } catch (err) {
       logger.error(`OpendistroSecurity create role error: ${err}`);
     }
+    
+    try {
+      // Create a new RoleMapping for this Role
+      await opendistroSecurityClient.put(
+        `rolesmapping/${groupName}`,
+        { body: { backend_roles: [`${groupName}`] } }
+      );
+      logger.debug(
+        `${groupName}: Created RoleMapping "${groupName}"`
+      );
+    } catch (err) {
+      logger.error(`Opendistro-Security create rolemapping error: ${err}`);
+    }
 
     if (tenantName != 'global_tenant') {
       try {
         // Create a new Tenant for this Group
-        await opendistroSecurityClient.put(`tenants/${tenantName}`, { body: { description: `${tenantName}` } });
-        logger.debug(`${groupName}: Created Tenant "${tenantName}"`);
+        await opendistroSecurityClient.put(
+          `tenants/${tenantName}`,
+          { body: { description: `${tenantName}` } }
+        );
+        logger.debug(
+          `${groupName}: Created Tenant "${tenantName}"`
+        );
       } catch (err) {
         logger.error(`Opendistro-Security create tenant error: ${err}`);
-      };
-
-      try {
-        // Create a new RoleMapping for this Group
-        await opendistroSecurityClient.put(`rolesmapping/${tenantName}`, { body: { backend_roles: [`${tenantName}`] } });
-        logger.debug(`${groupName}: Created RoleMapping "${tenantName}"`);
-      } catch (err) {
-        logger.error(`Opendistro-Security create rolemapping error: ${err}`);
       }
     }
 


### PR DESCRIPTION
In PR #3123 I configured Lagoon to create a backend_role for every tenant. However this only works for the roles that have corresponding tenants.

There are situations where a role may not have a corresponding tenant (or be part of a global tenant). The logic in this PR therefore automatically creates a backend_role for every role created - this should allow the occasional project-default-group to get it's backend_role autocreated,