### PR TITLE
update docs to remove Openshift references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ![](./lagoon-logo.png)
 
-## Lagoon - Docker Build and Deploy System for Kubernetes
+## Lagoon - the Open Source Application Delivery Platform for Kubernetes
 
 Lagoon gives developers what they dream about. It's a system that allows developers to run the exact same code in their local and production environment. The same Docker images, the same service configurations, and the same code.
 
@@ -30,13 +30,13 @@ Head to `#lagoon` in the amazee.io RocketChat: [https://amazeeio.rocket.chat](ht
 
 ## A couple of things about Lagoon
 
-1. **Lagoon is based on microservices**. The deployment and build workflow is very complex. We have multiple version control sources, multiple OpenShift servers, and multiple notification systems. Each deployment is unique and can take from seconds to hours. It's built with flexibility and robustness in mind. Microservices communicate through a messaging system, which allows us to scale individual services up and down. It allows us to survive down times of individual services. It also allows us to try out new parts of Lagoon in production without affecting others.
+1. **Lagoon is based on microservices**. The deployment and build workflow is very complex. We have multiple version control sources, multiple clusters, and multiple notification systems. Each deployment is unique and can take from seconds to hours. It's built with flexibility and robustness in mind. Microservices communicate through a messaging system, which allows us to scale individual services up and down. It allows us to survive down times of individual services. It also allows us to try out new parts of Lagoon in production without affecting others.
 2. **Lagoon uses many programming languages**. Each programming language has specific strengths. We try to decide which language makes the most sense for each service. Currently, a lot of Lagoon is built in Node.js. This is partly because we started with Node.js, but also because Node.js allows asynchronous processing of webhooks, tasks and more. We are likely going to change the programming language of some services. This is what is great about microservices! We can replace a single service with another language without worrying about other parts of the platform.
 3. **Lagoon is not Drupal-specific**. Everything has been built so that it can run any Docker image. There are existing Docker images for Drupal, and support for Drupal-specific tools like Drush. But that's it!
 4. **Lagoon is DevOps**. It allows developers to define the services they need and customize them as they need. You might think this is not the right way to do it, and gives too much power to developers. We believe that as system engineers, we need to empower developers. If we allow developers to define services locally, and test them locally, they will find bugs and mistakes themselves.
 5. **Lagoon runs on Docker and Kubernetes.** \(That one should be obvious, right?\)
 6. **Lagoon can be completely locally developed and tested.**
-7. **Lagoon is completely integration tested**. This means we can test the whole process. From receiving Git webhooks to deploying into a Docker container, the same Git hash is deployed in OpenShift.
+7. **Lagoon is completely integration tested**. This means we can test the whole process. From receiving Git webhooks to deploying into a Docker container, the same Git hash is deployed in the cluster.
 8. **Most important: It's a work in progress**. It's not done yet. At amazee.io, we believe that as a hosting community, we need to work together and share code where we can.
 
 We want you to understand the Lagoon infrastructure and how the services work together. Here is a schema \(it's a little out of date - it doesn't include some of the more recent services we've added, or cover Kubernetes, so we're working on an update!\): [https://www.lucidchart.com/documents/view/a3cf0c4f-1bc1-438f-977d-4b26f235ceac](https://www.lucidchart.com/documents/view/a3cf0c4f-1bc1-438f-977d-4b26f235ceac) ‌

--- a/docs/administering-lagoon/create-project.gql
+++ b/docs/administering-lagoon/create-project.gql
@@ -1,18 +1,18 @@
 # See the docs for a detailed explanation about this file:
-# https://lagoon.readthedocs.io/en/latest/administering_lagoon/graphql_api/#create-first-project
+# https://docs.lagoon.sh/administering-lagoon/graphql-queries/#creating-the-first-project
 
-# 1. Create an OpenShift
+# 1. Create a cluster (Kubernetes or Openshift)
 mutation {
-  addOpenshift(
+  addKubernetes(
     input: {
       # TODO: Fill in the name field
-      # This is the unique identifier of the OpenShift
+      # This is the unique identifier of the Kubernetes cluster
       name: ""
       # TODO: Fill in consoleUrl field
-      # This is the URL of the OpenShift console (without any `/console` suffix)
+      # This is the URL of the Kubernetes cluster
       consoleUrl: ""
       # TODO: Fill in the token field
-      # This is the token of the `lagoon` service account created in this OpenShift (this is the same token that we also used during installation of Lagoon)
+      # This is the token of the `lagoon` service account created in this cluster (this is the same token that we also used during installation of Lagoon)
       token: ""
     }
   ) {
@@ -22,7 +22,7 @@ mutation {
   }
 }
 
-# 2. Create a project and assign it the OpenShift
+# 2. Create a project and assign it the Cluster
 mutation {
   addProject(
     input: {
@@ -32,9 +32,9 @@ mutation {
       # TODO: Fill in the private key field (replace newlines with '\n')
       # This is the private key for a project, which is used to access the git code.  If no private key is added, Lagoon will create a private key, which can later be accessed by loading the project.
       privateKey: ""
-      # TODO: Fill in the openshift field
+      # TODO: Fill in the kubernetes field
       # This is the id of the OpenShift or Kubernetes to assign to the project
-      openshift: 0
+      kubernetes: 0
       # TODO: Fill in the name field
       # This is the project name
       gitUrl: ""
@@ -45,7 +45,7 @@ mutation {
     }
   ) {
     name
-    openshift {
+    kubernetes {
       name
       id
     }

--- a/docs/administering-lagoon/create-project.gql
+++ b/docs/administering-lagoon/create-project.gql
@@ -33,7 +33,7 @@ mutation {
       # This is the private key for a project, which is used to access the git code.  If no private key is added, Lagoon will create a private key, which can later be accessed by loading the project.
       privateKey: ""
       # TODO: Fill in the kubernetes field
-      # This is the id of the OpenShift or Kubernetes to assign to the project
+      # This is the id of the Kubernetes or OpenShift to assign to the project
       kubernetes: 0
       # TODO: Fill in the name field
       # This is the project name

--- a/docs/administering-lagoon/graphql-queries.md
+++ b/docs/administering-lagoon/graphql-queries.md
@@ -47,7 +47,7 @@ Let's create the first project for Lagoon to deploy! For this we'll use the quer
 
 For each of the queries \(the blocks starting with `mutation {`\), fill in all of the empty fields marked by TODO comments and run the queries in GraphiQL.app. This will create one of each of the following two objects:
 
-1. `openshift` : The OpenShift or Kubernetes cluster to which Lagoon should deploy. Lagoon is not only capable of deploying to its own Kubernetes cluster, but also to any Kubernetes cluster anywhere in the world.
+1. `kubernetes` : The Kubernetes (or Openshift) cluster to which Lagoon should deploy. Lagoon is not only capable of deploying to its own Kubernetes cluster, but also to any Kubernetes cluster anywhere in the world.
 2. `project` : The Lagoon project to be deployed, which is a Git repository with a `.lagoon.yml` configuration file committed in the root.
 
 ## Allowing access to the project
@@ -211,25 +211,25 @@ Now for every deployment you will receive messages in your defined channel.
 
 ## Example GraphQL queries
 
-### Adding a new OpenShift target
+### Adding a new Kubernetes target
 
 !!! Note "Note:"
-    In Lagoon 1.x `addOpenshift` is used for both OpenShift and Kubernetes targets. In Lagoon 2.x this will change.
+    In Lagoon, both `addOpenshift` and `addKubernetes` can be used for both OpenShift and Kubernetes targets - either will work interchangeably.
 
-The OpenShift cluster to which Lagoon should deploy. Lagoon is not only capable of deploying to its own OpenShift, but also to any OpenShift anywhere in the world.
+The cluster to which Lagoon should deploy.
 
 ```graphql
 mutation {
-  addOpenshift(
+  addKubernetes(
     input: {
       # TODO: Fill in the name field.
-      # This is the unique identifier of the OpenShift.
+      # This is the unique identifier of the cluster.
       name: ""
       # TODO: Fill in consoleUrl field.
-      # This is the URL of the OpenShift console (without any `/console` suffix).
+      # This is the URL of the Kubernetes cluster
       consoleUrl: ""
       # TODO: Fill in the token field.
-      # This is the token of the `lagoon` service account created in this OpenShift (this is the same token that we also used during installation of Lagoon).
+      # This is the token of the `lagoon` service account created in this cluster (this is the same token that we also used during installation of Lagoon).
       token: ""
     }
   ) {
@@ -280,9 +280,9 @@ mutation {
       # TODO: Fill in the private key field (replace newlines with '\n').
       # This is the private key for a project, which is used to access the Git code.
       privateKey: ""
-      # TODO: Fill in the OpenShift field.
-      # This is the id of the OpenShift or Kubernetes to assign to the project.
-      openshift: 0
+      # TODO: Fill in the Kubernetes field.
+      # This is the id of the Kubernetes or Openshift to assign to the project.
+      kubernetes: 0
       # TODO: Fill in the name field.
       # This is the project name.
       gitUrl: ""
@@ -293,7 +293,7 @@ mutation {
     }
   ) {
     name
-    openshift {
+    kubernetes {
       name
       id
     }
@@ -308,7 +308,7 @@ mutation {
 
 ### List projects and groups
 
-This is a good query to see an overview of all projects, OpenShifts and groups that exist within our Lagoon.
+This is a good query to see an overview of all projects, clusters and groups that exist within our Lagoon.
 
 ```graphql
 query {
@@ -316,7 +316,7 @@ query {
     name
     gitUrl
   }
-  allOpenshifts {
+  allKubernetes {
     name
     id
   }
@@ -368,7 +368,7 @@ query {
       deployType
       environmentType
     }
-    openshift {
+    kubernetes {
       id
     }
   }
@@ -471,7 +471,7 @@ query search{
     productionEnvironment,
     pullrequests,
     gitUrl,
-    openshift {
+    kubernetes {
       id
     },
      groups{

--- a/docs/administering-lagoon/graphql-queries.md
+++ b/docs/administering-lagoon/graphql-queries.md
@@ -214,7 +214,7 @@ Now for every deployment you will receive messages in your defined channel.
 ### Adding a new Kubernetes target
 
 !!! Note "Note:"
-    In Lagoon, both `addOpenshift` and `addKubernetes` can be used for both OpenShift and Kubernetes targets - either will work interchangeably.
+    In Lagoon, both `addKubernetes` and `addOpenshift` can be used for both Kubernetes and OpenShift targets - either will work interchangeably.
 
 The cluster to which Lagoon should deploy.
 

--- a/docs/administering-lagoon/ssl-ciphers.md
+++ b/docs/administering-lagoon/ssl-ciphers.md
@@ -22,7 +22,3 @@ In order to allow more relaxed settings, we also support an `old` config:
 ## Custom Cipher Suites
 
 If particular cipher settings are required, these can be provided via the environment vairable directly. TLS `1.0` and `SSLv3` will not be allowed no matter which cipher suites are requested.
-
-## Version Information
-
-Lagoon currently runs its router service based on OpenShift's `openshift3/ose-haproxy-router` image. This runs HAProxy version `1.8.1` and OpenSSL version `1.0.2k-fips`.

--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -173,8 +173,6 @@ The individual routines relevant to Kubernetes are:
 * `nginx`, `node` and `python` run basic tests against those project types.
 * `node-mongodb` runs a single-pod MongoDB test and a MongoDB DBaaS test against a Node.js app.
 
-There are a few other legacy Openshift-specific tests in there that may or may not work with Openshift-based clients.
-
 ## Local Development
 
 Most services are written in [Node.js](https://nodejs.org/en/docs/). As many of these services share similar Node.js code and Node.js packages, we're using a feature of [Yarn](https://yarnpkg.com/en/docs), called [Yarn workspaces](https://yarnpkg.com/en/docs/workspaces). Yarn workspaces need a `package.json` in the project's root directory that defines the workspaces.

--- a/docs/contributing-to-lagoon/tests.md
+++ b/docs/contributing-to-lagoon/tests.md
@@ -35,27 +35,14 @@ Or only for a specific service:
 make logs service=webhook-handler
 ```
 
-Sometimes you will want to see what is happening inside of [Jenkins](https://jenkins.io/doc/). Your Jenkins instance can be found here:
-<!-- markdown-link-check-disable-next-line -->
-[http://localhost:8888/](http://localhost:8888/) \(`admin`:`admin`\)
-
-Sometimes you just want to create another push webhook without having to wait for the Git repository to be initialized and pushed.
-
-In this case, there is a small helper script, `tests/playbooks/helpers/just-push.yaml,` that will get the current HEAD of the Git repository and push a webhook push. It needs to know which Git repository and branch you would like to check and push:
-
-```text
-docker-compose -p lagoon exec tests ansible-playbook /ansible/tests/tests/helpers/just-push.yaml -e git_repo_name=node.git -e branch=develop
-```
-
 ## 2. Automated integration testing
 
-In order to test pull requests that are created against Lagoon, we have a fully automatic integration test running on [`TravisCI`](https://docs.travis-ci.com/): [https://travis-ci.org/amazeeio/lagoon](https://travis-ci.org/amazeeio/lagoon). It is defined inside the `.travis.yml` file, and runs automatically for every pull request that is opened.
+In order to test pull requests that are created against Lagoon, we have a fully automatic integration test running on a dedicated Jenkins instance: [https://ci.lagoon.sh](https://ci.lagoon.sh). It is defined inside the `.Jenkinsfile`, and runs automatically for every pull request that is opened.
 
-This will build all images, start an OpenShift and run all tests.
+This will build all images, start a Kubernetes cluster and run a series of tests.
 
 The tests can be found here:
 
 <!-- markdown-link-check-disable -->
-* `develop` branch: [https://lagoon-ci.amazeeio.cloud/blue/organizations/jenkins/lagoon/activity/?branch=develop](https://lagoon-ci.amazeeio.cloud/blue/organizations/jenkins/lagoon/activity/?branch=develop)
-* `main` branch: [https://lagoon-ci.amazeeio.cloud/blue/organizations/jenkins/lagoon/activity/?branch=main](https://lagoon-ci.amazeeio.cloud/blue/organizations/jenkins/lagoon/activity/?branch=main)
+* https://ci.lagoon.sh/blue/organizations/jenkins/lagoon/activity
 <!-- markdown-link-check-enable -->

--- a/docs/docker-images/mongodb.md
+++ b/docs/docker-images/mongodb.md
@@ -12,4 +12,4 @@ This Dockerfile is intended to be used to set up a standalone MongoDB database s
 
 This image is prepared to be used on Lagoon. There are therefore some things already done:
 
-* Folder permissions are automatically adapted with [`fix-permissions`](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/fix-permissions), so this image will work with a random user, and therefore also on OpenShift/Kubernetes.
+* Folder permissions are automatically adapted with [`fix-permissions`](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/fix-permissions), so this image will work with a random user, and therefore also on Kubernetes or Openshift.

--- a/docs/docker-images/mongodb.md
+++ b/docs/docker-images/mongodb.md
@@ -8,8 +8,8 @@
 
 This Dockerfile is intended to be used to set up a standalone MongoDB database server.
 
-## Lagoon & OpenShift adaptions
+## Lagoon adaptions
 
-This image is prepared to be used on Lagoon, which leverages OpenShift. There are therefore some things already done:
+This image is prepared to be used on Lagoon. There are therefore some things already done:
 
-* Folder permissions are automatically adapted with [`fix-permissions`](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/fix-permissions), so this image will work with a random user, and therefore also on OpenShift.
+* Folder permissions are automatically adapted with [`fix-permissions`](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/fix-permissions), so this image will work with a random user, and therefore also on OpenShift/Kubernetes.

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -38,7 +38,7 @@ description: >-
 | k8s | Numeronym for Kubernetes \(K + 8 letters + s\) |
 | Kibana | An open-source data visualization plugin for Elasticsearch. It provides visualization capabilities on top of the content indexed on an Elasticsearch cluster. |
 | Kubernetes | An open-source system for automating deployment, scaling, and management of containerized applications. |
-| Lagoon | An open-source continuous delivery system for OpenShift and Kubernetes. |
+| Lagoon | An open-source application delivery platform for Kubernetes. |
 | Laravel | A free, open-source PHP web framework, following the model–view–controller \(MVC\) architectural pattern and based on Symfony. |
 | MariaDB | A community-developed, commercially supported fork of the MySQL relational database management system, intended to remain free and open-source software under the GNU General Public License. |
 | Master node | A single node in the cluster on which a collection of processes which manage the cluster state are running. |

--- a/docs/using-lagoon-advanced/deploytarget-configs.md
+++ b/docs/using-lagoon-advanced/deploytarget-configs.md
@@ -15,17 +15,17 @@ The basic idea of a DeployTarget configuration is that it is a way to easily def
 
 Before going in to how to configure a project to leverage DeployTarget configurations, there are some things you need to know.
 
-1. Environments now have two new fields available to them to identify which DeployTarget(Openshift or Kubernetes) they have been created on.
-    1. openshiftProjectPattern
-    2. openshift
+1. Environments now have two new fields available to them to identify which DeployTarget(Kubernetes or Openshift) they have been created on.
+    1. kubernetesNamespacePattern
+    2. kubernetes
 2. Once an environment has been deployed to a specific DeployTarget, it will always deploy to this target, even if the DeployTarget configuration, or project configuration is modified.
     1. This offers some safety to existing environments by preventing changes to DeployTarget configurations from creating new environments on different clusters.
     2. This is a new feature that is part of Lagoon, not specifically for DeployTarget configurations.
 3. By default, if no DeployTarget configurations are associated to a project, that project will continue to use the existing methods to determine which environments to deploy. These are the following fields used for this.
     1. branches
     2. pullrequests
-    3. openshiftProjectPattern
-    4. openshift
+    3. kubernetesNamespacePattern
+    4. kubernetes
 4. As soon as any DeployTarget configurations are added to a project, then all future deployments for this project will use these configurations. What is defined in the project is ignored, and overwritten to inform users that DeployTarget configurations are in use.
 5. DeployTarget configurations are weighted, which means that a DeployTarget configuration with a larger weight is prioritised over one with lower weight.
     1. The order in which they are returned by the query is the order they are used to determine where an environment should be deployed.
@@ -69,7 +69,7 @@ mutation addDeployTargetConfig{
 ```
 
 !!! Note "Note:"
-    `deployTarget` is an alias to openshift or kubernetes ID in the Lagoon API
+    `deployTarget` is an alias the Kubernetes or Openshift ID in the Lagoon API
 
 It is also possible to configure multiple DeployTarget configurations.
 

--- a/docs/using-lagoon-the-basics/build-and-deploy-process.md
+++ b/docs/using-lagoon-the-basics/build-and-deploy-process.md
@@ -56,9 +56,9 @@ Also, if this is a pull request build:
 
 Additionally, for each already built image, its name is also injected. If your `docker-compose.yml` is configured to first build the `cli` image and then the `nginx` image, the name of the `nginx` image is injected as `NGINX_IMAGE`.
 
-## 4. Configure OpenShift/Kubernetes Services and Routes
+## 4. Configure Kubernetes or Openshift Services and Routes
 
-Next, Lagoon will configure OpenShift/Kubernetes with all services and routes that are defined from the service types, plus possible additional custom routes that you have defined in `.lagoon.yml`.
+Next, Lagoon will configure Kubernetes or Openshift with all services and routes that are defined from the service types, plus possible additional custom routes that you have defined in `.lagoon.yml`.
 
 In this step it will expose all defined routes in the `LAGOON_ROUTES` as comma separated URLs. It will also define one route as the "main" route, in this order:
 
@@ -94,7 +94,7 @@ This is probably the most important step. Based on the defined service type, Lag
 
 It will include all previously gathered information like the cron jobs, the location of persistent storage, the pushed images and so on.
 
-Creation of these objects will also automatically cause OpenShift/Kubernetes to trigger new deployments of the pods if necessary, like when an environment variable has changed or an image has changed. But if there is no change, there will be no deployment! This means if you only update the PHP code in your application, the Varnish, Solr, MariaDB, Redis and any other service that is defined but does not include your code will not be deployed. This makes everything much much faster.
+Creation of these objects will also automatically cause Kubernetes or Openshift to trigger new deployments of the pods if necessary, like when an environment variable has changed or an image has changed. But if there is no change, there will be no deployment! This means if you only update the PHP code in your application, the Varnish, Solr, MariaDB, Redis and any other service that is defined but does not include your code will not be deployed. This makes everything much much faster.
 
 ## 10. Wait for all rollouts to be done
 

--- a/docs/using-lagoon-the-basics/docker-compose-yml.md
+++ b/docs/using-lagoon-the-basics/docker-compose-yml.md
@@ -119,7 +119,7 @@ If you don't need to build a Dockerfile and just want to use an existing Dockerf
 
 ### Types
 
-Lagoon needs to know what type of service you are deploying in order to configure the correct Kubernetes and OpenShift objects.
+Lagoon needs to know what type of service you are deploying in order to configure the correct Kubernetes or OpenShift objects.
 
 This is done via the `lagoon.type` label. There are many different types to choose from. Check [Service Types](../using-lagoon-advanced/service-types.md) to see all of them and their additional configuration possibilities.
 
@@ -185,7 +185,7 @@ Lagoon uses [Helm](https://helm.sh/) for templating on Kubernetes. To do this, a
 
 ## **Custom Rollout Monitor Types**
 
-By default , Lagoon expects that services from custom templates are rolled out via a [`DeploymentConfig`](https://docs.openshift.com/container-platform/4.4/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are) object within Openshift/Kubernetes. It monitors the rollout based on this object. In some cases, the services that are defined via custom deployment need a different way of monitoring. This can be defined via `lagoon.rollout`:
+By default , Lagoon expects that services from custom templates are rolled out via a [`DeploymentConfig`](https://docs.openshift.com/container-platform/4.4/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are) object within Kubernetes or Openshift. It monitors the rollout based on this object. In some cases, the services that are defined via custom deployment need a different way of monitoring. This can be defined via `lagoon.rollout`:
 
 * `deploymentconfig` - This is the default. Expects a [`DeploymentConfig`](https://docs.openshift.com/container-platform/4.4/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are) object in the template for the service.
 * `statefulset` - Expects a [`Statefulset`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) object in the template for the service.

--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -457,7 +457,7 @@ With the key `ssh` you can define another SSH endpoint that should be used by th
 
 ### `additional-yaml`
 
-The `additional-yaml` has some super powers. Basically, it allows you to define any arbitrary YAML configuration file to be inserted before the build step \(it still needs to be valid Kubernetes/OpenShift YAML, though ☺\).
+The `additional-yaml` has some super powers. Basically, it allows you to define any arbitrary YAML configuration file to be inserted before the build step \(it still needs to be valid Kubernetes YAML, though ☺\).
 
 Example:
 

--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -455,31 +455,6 @@ With the key `api` you can define another URL that should be used by the Lagoon 
 
 With the key `ssh` you can define another SSH endpoint that should be used by the Lagoon CLI and `drush` to connect to the Lagoon remote shell service. This needs to be a hostname and a port separated by a colon, like: `localhost:2020` This usually does not need to be changed, but there might be situations where your Lagoon administrator tells you to do so.
 
-### `additional-yaml`
-
-The `additional-yaml` has some super powers. Basically, it allows you to define any arbitrary YAML configuration file to be inserted before the build step \(it still needs to be valid Kubernetes YAML, though ☺\).
-
-Example:
-
-```yaml title=".lagoon.yml"
-additional-yaml:
-  secrets:
-    path: .lagoon.secrets.yml
-    command: create
-    ignore_error: true
-
-  logs-db-secrets:
-    path: .lagoon.logs-db-secrets.yml
-    command: create
-    ignore_error: true
-```
-
-Each definition is keyed by a unique name \(`secrets` and `logs-db-secrets` in the example above\), and takes these keys:
-
-* `path` - the path to the YAML file.
-* `command` - can either be `create` or `apply`, depending on whether you want to run. `kubectl create -f [yamlfile]` or `kubectl apply -f [yamlfile]`.
-* `ignore_error` - either `true` or `false` \(default\).  This allows you to instruct the Lagoon build script to ignore any errors that might be returned during running the command. \(This can be useful to handle the case where you want to run `create` during every build, so that new configurations are created, but don't fail if they already exist\).
-
 ### `container-registries`
 
 The `container-registries` block allows you to define your own private container registries to pull custom or private images. To use a private container registry, you will need a `username`, `password`, and optionally the `url` for your registry. If you don't specify a `url` in your YAML, it will default to using Docker Hub.

--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -241,7 +241,7 @@ In the `"www.example.com"` example repeated below, we see two more options \(als
 
 ### **Monitoring a specific path**
 
-When [UptimeRobot](https://uptimerobot.com/) is configured for your cluster \(OpenShift or Kubernetes\), Lagoon will inject annotations to each route/ingress for use by the `stakater/IngressControllerMonitor`. The default action is to monitor the homepage of the route. If you have a specific route to be monitored, this can be overridden by adding a `monitoring-path` to your route specification. A common use is to set up a path for monitoring which bypasses caching to give a more real-time monitoring of your site.
+When [UptimeRobot](https://uptimerobot.com/) is configured for your cluster \(Kubernetes or OpenShift\), Lagoon will inject annotations to each route/ingress for use by the `stakater/IngressControllerMonitor`. The default action is to monitor the homepage of the route. If you have a specific route to be monitored, this can be overridden by adding a `monitoring-path` to your route specification. A common use is to set up a path for monitoring which bypasses caching to give a more real-time monitoring of your site.
 
 ```yaml title=".lagoon.yml"
      - "www.example.com":

--- a/docs/using-lagoon-the-basics/setup-project.md
+++ b/docs/using-lagoon-the-basics/setup-project.md
@@ -8,7 +8,7 @@ Until then, the setup of a new project involves talking to your Lagoon administr
 Please have the following information ready for your Lagoon administrator:
 
 * A name you would like the project to be know by
-  * This nmame can only contain lowercase characters, numbers and dashes
+  * This name can only contain lowercase characters, numbers and dashes
   * Double dashes (`--`) are not allowed within a project name
 * SSH public keys, email addresses and the names of everybody that will work on this project. Here are instructions for generating and copying SSH keys for [GitHub](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh), [GitLab](https://docs.gitlab.com/ee/ssh/), and [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html).
 * The URL of the Git repository where your code is hosted \(`git@example.com:test/test.git`\).


### PR DESCRIPTION
Now that we have Kubernetes Aliases in the API, we should use them

(and other tidyups)