### PR TITLE
fix: updateEnvironment environment type check

### DIFF
--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -605,7 +605,7 @@ export const updateEnvironment: ResolverFn = async (
   });
 
   const newType = R.pathOr(
-    curEnv.environment_type,
+    curEnv.environmentType,
     ['patch', 'environmentType'],
     input
   );


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

The `updateEnvironment` resolver was using `environment_type` instead of `environmentType` as a fallback value in part of a permission check. ~It seems it was missed as part of #2632~ Seems like it has existed since forever

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
