### PR TITLE
Feature/add metadata to environment filters

### DIFF
--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -527,7 +527,6 @@ const buildConditionsForFactSearchQuery = (filterDetails: any, factQuery: any, p
           innerBuilder = innerBuilder.orWhere(builderFactory(filter, i));
         }
       });
-      console.log(innerBuilder.toString());
       return innerBuilder;
     })
   }

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -509,6 +509,8 @@ const buildConditionsForFactSearchQuery = (filterDetails: any, factQuery: any, p
           builder = builder.andWhere(`project.${name}`, 'like', `${predicateRHSProcess('CONTAINS', contains)}`);
       } else if (lhsTarget == "PROJECT_METADATA") {
         builder = builder.whereRaw('JSON_CONTAINS(project.metadata, ?, ?)', [`"${contains}"`, `$.${name}`]);
+      } else if (lhsTarget == "ENVIRONMENT") {
+        builder = builder.andWhere(`environment.${name}`, 'like', `${predicateRHSProcess('CONTAINS', contains)}`);
       } else {
         let tabName = `env${i}`;
         builder = builder.andWhere(`${tabName}.name`, '=', `${name}`);

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -490,13 +490,11 @@ const buildConditionsForFactSearchQuery = (filterDetails: any, factQuery: any, p
       if (lhsTarget == "project") {
         switch (name) {
           case ("id"):
-            break;
           case ("name"):
-            break;
           default:
             throw Error(`lhsTarget "${name}" unsupported`);
         }
-      } else {
+      } else if(lhsTarget == "FACT") {
         if (filterDetails.filterConnective == 'AND') {
           factQuery = factQuery.innerJoin(`environment_fact as ${tabName}`, 'environment.id', `${tabName}.environment`);
         } else {
@@ -508,7 +506,9 @@ const buildConditionsForFactSearchQuery = (filterDetails: any, factQuery: any, p
     const builderFactory = (filter, i) => (builder) => {
       let { lhsTarget, name, contains } = filter;
       if (lhsTarget == "PROJECT") {
-        builder = builder.andWhere(`project.${name}`, 'like', `${predicateRHSProcess('CONTAINS', contains)}`);
+          builder = builder.andWhere(`project.${name}`, 'like', `${predicateRHSProcess('CONTAINS', contains)}`);
+      } else if (lhsTarget == "PROJECT_METADATA") {
+        builder = builder.whereRaw('JSON_CONTAINS(project.metadata, ?, ?)', [`"${contains}"`, `$.${name}`]);
       } else {
         let tabName = `env${i}`;
         builder = builder.andWhere(`${tabName}.name`, '=', `${name}`);
@@ -525,6 +525,7 @@ const buildConditionsForFactSearchQuery = (filterDetails: any, factQuery: any, p
           innerBuilder = innerBuilder.orWhere(builderFactory(filter, i));
         }
       });
+      console.log(innerBuilder.toString());
       return innerBuilder;
     })
   }

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -399,6 +399,7 @@ const typeDefs = gql`
     FACT
     ENVIRONMENT
     PROJECT
+    PROJECT_METADATA
   }
 
   input FactFilterAtom {


### PR DESCRIPTION
This PR introduces a small extension to the project/environmentsByFactSearch queries, allowing both to search on project metadata.

The queries now support the following

```query environmentbymetadata {
  environmentsByFactSearch(input: {
    filterConnective: AND
    filters: [
      {lhsTarget: PROJECT_METADATA, name: "exampleKey", contains: "exampleValue" }
    ]
  }) {
		environments {
      id
      name
    }
  }
}
```

It introduces a `lhsTarget` of `PROJECT_METADATA` and, as with the other target types, allows one to specify a key and value for the search. The above will match any environments with the metadata key/value pair "exampleKey:exampleValue".
This can, further, be combined with the existing filters.

