### PR TITLE
fail builds early for invalid docker-compose files

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -24,7 +24,7 @@ ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
 RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.7.0/lagoon-linter_0.7.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
-RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.13.1/build-deploy-tool_0.13.1_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.13.2/build-deploy-tool_0.13.2_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin build-deploy-tool
 
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -186,7 +186,7 @@ set +ex
 ### RUN docker compose config check against the provided docker-compose file
 ### use the `build-validate` built in validater to run over the provided docker-compose file
 ##############################################
-dccOutput=$(bash -c 'build-validate validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}'; exit $?' 2>&1)
+dccOutput=$(bash -c 'build-deploy-tool validate docker-compose --docker-compose '${DOCKER_COMPOSE_YAML}'; exit $?' 2>&1)
 dccExit=$?
 echo "docker-compose validate exit code ${dccExit}: ${dccOutput}"
 


### PR DESCRIPTION
This changes the logic for docker-compose validation to no longer warn, but fail earlier if the docker-compose is invalid.
Lagoon requires a somewhat valid docker-compose file to function, and future releases will utilise the docker-compose spec more than we currently do to handle builds, so it is important that docker-compose file is valid.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

