### PR TITLE
fix: build required task-activestandby image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,7 +624,7 @@ ifeq ($(ARCH), darwin)
       tcp-listen:32080,fork,reuseaddr tcp-connect:target:32080
 endif
 
-KIND_SERVICES = api api-db api-redis auth-server actions-handler broker controllerhandler docker-host drush-alias keycloak keycloak-db logs2s3 webhook-handler webhooks2tasks kubectl-build-deploy-dind local-api-data-watcher-pusher local-git ssh tests ui workflows
+KIND_SERVICES = api api-db api-redis auth-server actions-handler broker controllerhandler docker-host drush-alias keycloak keycloak-db logs2s3 webhook-handler webhooks2tasks kubectl-build-deploy-dind local-api-data-watcher-pusher local-git ssh tests ui workflows $(TASK_IMAGES)
 KIND_TESTS = local-api-data-watcher-pusher local-git tests
 KIND_TOOLS = kind helm kubectl jq stern
 


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Without this change the `make kind/test` command will fail with:
```
Error response from daemon: No such image: lagoon/task-activestandby:latest
make[1]: *** [Makefile:739: kind/push-images] Error 1
make[1]: Leaving directory '/home/scott/dev/amazee/lagoon'
make: *** [Makefile:634: kind/test] Error 2
```

The fix is to ensure that the `lagoon/task-activestandby` image is built along with all the other kind service images.

# Closing issues

n/a