### PR TITLE
Fix: active/standby support for environments with slash in the name

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -332,7 +332,7 @@ export const createTaskMonitor = async function(task: string, payload: any) {
 }
 
 // makes strings "safe" if it is to be used in something dns related
-const makeSafe = string => string.toLocaleLowerCase().replace(/[^0-9a-z-]/g,'-')
+export const makeSafe = string => string.toLocaleLowerCase().replace(/[^0-9a-z-]/g,'-')
 
 // @TODO: make sure if it fails, it does so properly
 export const getControllerBuildData = async function(deployData: any) {

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -1071,15 +1071,15 @@ export const switchActiveStandby: ResolverFn = async (
           environmentProdId = parseInt(environmentProd.id);
         }
         if (makeSafe(envForProject.name) == project.standbyProductionEnvironment) {
-          // const environmentRows = await query(
-          //   sqlClientPool,
-          //   environmentSql.selectEnvironmentByNameAndProject(
-          //     envForProject.name,
-          //     project.id
-          //   )
-          // );
-          // environmentStandby = environmentRows[0];
-          // environmentStandbyId = parseInt(environmentStandby.id);
+          const environmentRows = await query(
+            sqlClientPool,
+            environmentSql.selectEnvironmentByNameAndProject(
+              envForProject.name,
+              project.id
+            )
+          );
+          environmentStandby = environmentRows[0];
+          environmentStandbyId = parseInt(environmentStandby.id);
         }
       }
     } catch (err) {

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -1,10 +1,14 @@
+// @ts-ignore
 import * as R from 'ramda';
+// @ts-ignore
 import { sendToLagoonLogs } from '@lagoon/commons/dist/logs';
 import {
   createDeployTask,
   createMiscTask,
   createPromoteTask,
-  sendToLagoonActions
+  sendToLagoonActions,
+  makeSafe
+  // @ts-ignore
 } from '@lagoon/commons/dist/tasks';
 import { ResolverFn } from '../';
 import {
@@ -18,18 +22,28 @@ import { Helpers } from './helpers';
 import { EVENTS } from './events';
 import { Helpers as environmentHelpers } from '../environment/helpers';
 import { Helpers as projectHelpers } from '../project/helpers';
+// @ts-ignore
 import { addTask } from '@lagoon/commons/dist/api';
 import { Sql as environmentSql } from '../environment/sql';
+// @ts-ignore
 import S3 from 'aws-sdk/clients/s3';
+// @ts-ignore
 import sha1 from 'sha1';
+// @ts-ignore
 import { generateBuildId, jsonMerge } from '@lagoon/commons/dist/util';
 import { logger } from '../../loggers/logger';
+// @ts-ignore
 import uuid4 from 'uuid4';
 
+// @ts-ignore
 const accessKeyId =  process.env.S3_FILES_ACCESS_KEY_ID || 'minio'
+// @ts-ignore
 const secretAccessKey =  process.env.S3_FILES_SECRET_ACCESS_KEY || 'minio123'
+// @ts-ignore
 const bucket = process.env.S3_FILES_BUCKET || 'lagoon-files'
+// @ts-ignore
 const region = process.env.S3_FILES_REGION
+// @ts-ignore
 const s3Origin = process.env.S3_FILES_HOST || 'http://docker.for.mac.localhost:9000'
 
 const config = {
@@ -88,6 +102,7 @@ export const getBuildLog: ResolverFn = async (
     if (!data) {
       return null;
     }
+    // @ts-ignore
     let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('ascii');
     return logMsg;
   } catch (e) {
@@ -736,7 +751,6 @@ export const deployEnvironmentBranch: ResolverFn = async (
           meta,
           `*[${deployData.projectName}]* Error deploying \`${deployData.branchName}\`: ${error}`
         );
-        console.log(error);
         return `Error: ${error}`;
     }
   }
@@ -1008,28 +1022,74 @@ export const switchActiveStandby: ResolverFn = async (
     );
     return `Error: no standbyProductionEnvironment configured`;
   }
-
+  var environmentStandbyId
+  var environmentProdId
+  var environmentProd
+  var environmentStandby
   // we want the task to show in the standby environment, as this is where the task will be initiated.
-  const environmentRows = await query(
-    sqlClientPool,
-    environmentSql.selectEnvironmentByNameAndProject(
-      project.standbyProductionEnvironment,
-      project.id
-    )
-  );
-  const environment = environmentRows[0];
-  var environmentId = parseInt(environment.id);
-  // we need to pass some additional information about the production environment
-  const environmentRowsProd = await query(
-    sqlClientPool,
-    environmentSql.selectEnvironmentByNameAndProject(
-      project.productionEnvironment,
-      project.id
-    )
-  );
-  const environmentProd = environmentRowsProd[0];
-  var environmentProdId = parseInt(environmentProd.id);
+  try {
+    const environmentRows = await query(
+      sqlClientPool,
+      environmentSql.selectEnvironmentByNameAndProject(
+        project.standbyProductionEnvironment,
+        project.id
+      )
+    );
+    environmentStandby = environmentRows[0];
+    environmentStandbyId = parseInt(environmentStandby.id);
+    // we need to pass some additional information about the production environment
+    const environmentRowsProd = await query(
+      sqlClientPool,
+      environmentSql.selectEnvironmentByNameAndProject(
+        project.productionEnvironment,
+        project.id
+      )
+    );
+    environmentProd = environmentRowsProd[0];
+    environmentProdId = parseInt(environmentProd.id);
+  } catch (err) {
+    try {
+      // maybe the environments have slashes in their names
+      // get all the environments for this project
+      const environmentsForProject = await query(
+        sqlClientPool,
+        environmentSql.selectEnvironmentsByProjectID(
+          project.id
+        )
+      );
+      for (const envForProject of environmentsForProject) {
+        // check the environments to see if their name when made "safe" matches what is defined in the `production` or `standbyProduction` environment
+        if (makeSafe(envForProject.name) == project.productionEnvironment) {
+          const environmentRowsProd = await query(
+            sqlClientPool,
+            environmentSql.selectEnvironmentByNameAndProject(
+              envForProject.name,
+              project.id
+            )
+          );
+          environmentProd = environmentRowsProd[0];
+          environmentProdId = parseInt(environmentProd.id);
+        }
+        if (makeSafe(envForProject.name) == project.standbyProductionEnvironment) {
+          // const environmentRows = await query(
+          //   sqlClientPool,
+          //   environmentSql.selectEnvironmentByNameAndProject(
+          //     envForProject.name,
+          //     project.id
+          //   )
+          // );
+          // environmentStandby = environmentRows[0];
+          // environmentStandbyId = parseInt(environmentStandby.id);
+        }
+      }
+    } catch (err) {
+      throw new Error(`Unable to determine active standby environments: ${err}`);
+    }
+  }
 
+  if (environmentStandbyId === undefined || environmentProdId === undefined) {
+    throw new Error(`Unable to determine active standby environments`);
+  }
   // construct the data for the misc task
   // set up the task data payload
   const data = {
@@ -1045,9 +1105,9 @@ export const switchActiveStandby: ResolverFn = async (
       openshiftProjectName: environmentProd.openshiftProjectName
     },
     environment: {
-      id: environmentId,
-      name: environment.name,
-      openshiftProjectName: environment.openshiftProjectName
+      id: environmentStandbyId,
+      name: environmentStandby.name,
+      openshiftProjectName: environmentStandby.openshiftProjectName
     },
     task: {
       id: '0',
@@ -1064,7 +1124,7 @@ export const switchActiveStandby: ResolverFn = async (
       'Active/Standby Switch',
       'ACTIVE',
       created,
-      environmentId,
+      environmentStandbyId,
       null,
       null,
       null,
@@ -1081,7 +1141,7 @@ export const switchActiveStandby: ResolverFn = async (
     // return the task id and remote id
     var retData = {
       id: data.task.id,
-      environment: environmentId
+      environment: environmentStandbyId
     };
     return retData;
   } catch (error) {

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -21,6 +21,11 @@ export const Sql = {
       .where('name', '=', name)
       .andWhere('project', '=', projectId)
       .toString(),
+  selectEnvironmentsByProjectID: (projectId: number) =>
+    knex('environment')
+      .select('id', 'name')
+      .where('project', '=', projectId)
+      .toString(),
   truncateEnvironment: () =>
     knex('environment')
       .truncate()

--- a/services/ui/src/components/Environment/index.js
+++ b/services/ui/src/components/Environment/index.js
@@ -9,6 +9,7 @@ import { bp, color } from 'lib/variables';
 import Router from 'next/router';
 import ActiveStandbyConfirm from 'components/ActiveStandbyConfirm';
 import SwitchActiveStandbyMutation from 'lib/mutation/SwitchActiveStandby';
+import { makeSafe } from 'lib/util';
 
 /**
  * Displays the environment information.
@@ -26,8 +27,8 @@ const Environment = ({ environment }) => {
           <label>Environment Type</label>
           <div className="field">
           {environment.environmentType}
-          {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.productionEnvironment == environment.name &&
-          (" (active)")}{environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == environment.name && (" (standby)")}
+          {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.productionEnvironment == makeSafe(environment.name) &&
+          (" (active)")}{environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == makeSafe(environment.name) && (" (standby)")}
           </div>
         </div>
       </div>
@@ -74,7 +75,7 @@ const Environment = ({ environment }) => {
         </div>
       </div>
       <div className="field-wrapper routes">
-        {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.productionEnvironment == environment.name && (
+        {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.productionEnvironment == makeSafe(environment.name) && (
         <div>
           <label>Active Environment Routes</label>
           <div className="field">
@@ -89,7 +90,7 @@ const Environment = ({ environment }) => {
               : ''}
           </div>
         </div>)}
-        {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == environment.name && (
+        {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == makeSafe(environment.name) && (
         <div>
           <label>Standby Environment Routes</label>
           <div className="field">
@@ -119,7 +120,7 @@ const Environment = ({ environment }) => {
           </div>
         </div>
       </div>
-      {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == environment.name && (
+      {environment.project.productionEnvironment && environment.project.standbyProductionEnvironment && environment.environmentType == 'production' && environment.project.standbyProductionEnvironment == makeSafe(environment.name) && (
       <Mutation mutation={SwitchActiveStandbyMutation}>
         {(switchActiveStandby, { loading, called, error, data }) => {
           const switchActiveBranch = () => {

--- a/services/ui/src/components/Environments/index.js
+++ b/services/ui/src/components/Environments/index.js
@@ -4,6 +4,7 @@ import css from 'styled-jsx/css';
 import EnvironmentLink from 'components/link/Environment';
 import Box from 'components/Box';
 import { bp, color, fontSize } from 'lib/variables';
+import { makeSafe } from 'lib/util';
 
 const bgImages = {
   branch: {
@@ -69,12 +70,12 @@ const Environments = ({ environments = [], project }) => {
                     <span>Production</span>
                   </div>
                 )}
-                {project.productionEnvironment && project.standbyProductionEnvironment && project.productionEnvironment == environment.name && (
+                {project.productionEnvironment && project.standbyProductionEnvironment && project.productionEnvironment == makeSafe(environment.name) && (
                   <div className="activeLabel">
                     <span>Active</span>
                   </div>
                 )}
-                {project.productionEnvironment && project.standbyProductionEnvironment && project.standbyProductionEnvironment == environment.name && (
+                {project.productionEnvironment && project.standbyProductionEnvironment && project.standbyProductionEnvironment == makeSafe(environment.name) && (
                   <div className="standbyLabel">
                     <span>Standby</span>
                   </div>

--- a/services/ui/src/lib/util.js
+++ b/services/ui/src/lib/util.js
@@ -7,3 +7,5 @@ export const queryStringToObject = R.pipe(
   R.map(R.split('=')),
   R.fromPairs
 );
+
+export const makeSafe = string => string.toLocaleLowerCase().replace(/[^0-9a-z-]/g,'-')


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

As #3212 describes, if a production or standby production environment have slashes in their names, they don't work correctly with active/standby. This refactors the activestandby switch to first check environments that don't have slashes, if this fails it checks all environments for the project to try and find the environment with the name that is made safe.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3212 
