### PR TITLE
Feature: add image size information for built images

### DIFF
--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -695,6 +695,24 @@ if [[ "$BUILD_TYPE" == "pullrequest"  ||  "$BUILD_TYPE" == "branch" ]]; then
 fi
 
 set +x
+# print information about built image sizes
+function printBytes {
+    local -i bytes=$1;
+    echo "$(( (bytes + 1000000)/1000000 ))MB"
+}
+if [[ "${IMAGES_BUILD[@]}" ]]; then
+  echo "##############################################"
+  echo "Built image sizes:"
+  echo "##############################################"
+fi
+for IMAGE_NAME in "${!IMAGES_BUILD[@]}"
+do
+  TEMPORARY_IMAGE_NAME="${IMAGES_BUILD[${IMAGE_NAME}]}"
+  echo -e "Image ${TEMPORARY_IMAGE_NAME}\t\t$(printBytes $(docker inspect ${TEMPORARY_IMAGE_NAME} | jq -r '.[0].Size'))"
+done
+set -x
+
+set +x
 currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
 patchBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "imageBuildComplete" "Image Builds"
 previousStepEnd=${currentStepEnd}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Display information about image sizes in builds:
```
##############################################
Built image sizes:
##############################################
Image ci-nginx-control-k8s-nginx-nginx		119MB
Image ci-nginx-control-k8s-nginx-nginx-basic-auth		119MB
Image ci-nginx-control-k8s-nginx-nginx-basic-auth-disable		119MB
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3224 
