### PR TITLE
fix: add custom dnsConfig to all cronjobs

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/basic-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/basic-persistent/templates/cronjob.yaml
@@ -76,4 +76,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/basic/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/basic/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli-persistent/templates/cronjob.yaml
@@ -83,4 +83,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/cli/templates/cronjob.yaml
@@ -78,4 +78,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/elasticsearch/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/kibana/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/kibana/templates/cronjob.yaml
@@ -82,4 +82,10 @@ spec:
               key: lagoon.sh/build
               operator: Exists
             {{- toYaml $.Values.tolerations | nindent 12 }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/logstash/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-single/templates/cronjob.yaml
@@ -76,4 +76,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mongodb-single/templates/cronjob.yaml
@@ -76,4 +76,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php-persistent/templates/cronjob.yaml
@@ -83,4 +83,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx-php/templates/cronjob.yaml
@@ -78,4 +78,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/nginx/templates/cronjob.yaml
@@ -78,4 +78,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node-persistent/templates/cronjob.yaml
@@ -83,4 +83,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/node/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/postgres-single/templates/cronjob.yaml
@@ -76,4 +76,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/python-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/python-persistent/templates/cronjob.yaml
@@ -83,4 +83,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/python/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/python/templates/cronjob.yaml
@@ -70,4 +70,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/rabbitmq/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/rabbitmq/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis-persistent/templates/cronjob.yaml
@@ -79,4 +79,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/redis/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/redis/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/solr/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/solr/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish-persistent/templates/cronjob.yaml
@@ -76,4 +76,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/varnish/templates/cronjob.yaml
@@ -69,4 +69,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/worker-persistent/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/worker-persistent/templates/cronjob.yaml
@@ -83,4 +83,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}

--- a/images/kubectl-build-deploy-dind/helmcharts/worker/templates/cronjob.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/worker/templates/cronjob.yaml
@@ -78,4 +78,10 @@ spec:
           tolerations:
             {{- toYaml $ | nindent 12 }}
         {{- end }}
+          dnsConfig:
+            options:
+              - name: timeout
+                value: "60"
+              - name: attempts
+                value: "10"
 {{- end }}


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

This is an attempt to fix the problem where cronjobs intermittently fail
with getaddrinfo() error EAI_AGAIN. The problem appears to be that the
lookup times out due to dropped UDP packets.

The default for timeout is 5 seconds and attempts is 2 for both musl and
glibc. This change bumps the configured values to the maximum values for
musl: 60s timeout and 10 attempts.

For any custom cronjobs running glibc-based images the maximum values
are silently capped at half those values: 30s timeout and 5 attempts.

References:
https://git.musl-libc.org/cgit/musl/tree/src/network/resolvconf.c#n17
https://manpages.debian.org/buster/manpages/resolv.conf.5.en.html

# Closing issues

There is no issue for this - we have seen the problem on managed clusters.
