### PR TITLE
Sets strictor mandatory fields for addDeployTargetConfig

### DIFF
--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -974,9 +974,9 @@ const typeDefs = gql`
     id: Int
     project: Int!
     weight: Int
-    branches: String
-    pullrequests: String
-    deployTarget: Int
+    branches: String!
+    pullrequests: String!
+    deployTarget: Int!
     deployTargetProjectPattern: String
   }
 


### PR DESCRIPTION
Simply makes branches, pullrequests, and deployTarget required fields from the graphQL schema's perspective.

closes #3238 

"deployTarget" is included in this PR since there's already a check in the TS to ensure a value is passed for this. Adding it as required in the schema just brings this check into the typechecking.
