### PR TITLE
Feature: Configure remote target build image in API

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -1084,6 +1084,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
           projectUser
           routerPattern
           monitoringConfig
+          buildImage
         }
         autoIdle
         branches
@@ -1129,6 +1130,7 @@ export const getDeployTargetConfigsForProject = (project: number): Promise<any> 
           projectUser
           routerPattern
           monitoringConfig
+          buildImage
         }
       }
     }
@@ -1149,6 +1151,7 @@ export const getOpenShiftInfoForEnvironment = (environment: number): Promise<any
           projectUser
           routerPattern
           monitoringConfig
+          buildImage
         }
         project {
           envVariables {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -116,8 +116,8 @@ const registry = process.env.REGISTRY || "registry.lagoon.svc:5000"
 const lagoonGitSafeBranch = process.env.LAGOON_GIT_SAFE_BRANCH || "master"
 const lagoonVersion = process.env.LAGOON_VERSION
 const lagoonEnvironmentType = process.env.LAGOON_ENVIRONMENT_TYPE || "development"
-const overwriteOCBuildDeployDindImage = process.env.OVERWRITE_OC_BUILD_DEPLOY_DIND_IMAGE
-const overwriteKubectlBuildDeployDindImage = process.env.OVERWRITE_KUBECTL_BUILD_DEPLOY_DIND_IMAGE
+const defaultBuildDeployImage = process.env.DEFAULT_BUILD_DEPLOY_IMAGE
+const edgeBuildDeployImage = process.env.EDGE_BUILD_DEPLOY_IMAGE
 const overwriteActiveStandbyTaskImage = process.env.OVERWRITE_ACTIVESTANDBY_TASK_IMAGE
 const jwtSecretString = process.env.JWTSECRET || "super-secret-string"
 const projectSeedString = process.env.PROJECTSEED || "super-secret-string"
@@ -512,11 +512,22 @@ export const getControllerBuildData = async function(deployData: any) {
   }
 
   let buildImage = ""
-  // work out the build image from the deploytarget if defined
+  // if a default build image is defined by `DEFAULT_BUILD_DEPLOY_IMAGE` in api and webhooks2tasks, use it
+  if (defaultBuildDeployImage) {
+    buildImage = defaultBuildDeployImage
+  }
+  if (edgeBuildDeployImage) {
+    // if an edge build image is defined by `EDGE_BUILD_DEPLOY_IMAGE` in api and webhooks2tasks, use it
+    buildImage = edgeBuildDeployImage
+  }
+  // otherwise work out the build image from the deploytarget if defined
   if (deployTarget.openshift.buildImage != null) {
     // set the build image here if one is defined in the api
     buildImage = deployTarget.openshift.buildImage
   }
+  // if no build image is determined, the `remote-controller` defined default image will be used
+  // once it reaches the remote cluster.
+
 
   var alertContact = ""
   if (alertContactHA != undefined && alertContactSA != undefined){

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -511,6 +511,13 @@ export const getControllerBuildData = async function(deployData: any) {
     }
   }
 
+  let buildImage = ""
+  // work out the build image from the deploytarget if defined
+  if (deployTarget.openshift.buildImage != null) {
+    // set the build image here if one is defined in the api
+    buildImage = deployTarget.openshift.buildImage
+  }
+
   var alertContact = ""
   if (alertContactHA != undefined && alertContactSA != undefined){
     if (availability == "HIGH") {
@@ -604,7 +611,7 @@ export const getControllerBuildData = async function(deployData: any) {
     spec: {
       build: {
         type: type,
-        image: {}, // the controller will know which image to use
+        image: buildImage, // the controller will know which image to use
         ci: CI,
         priority: priority, // add the build priority
         bulkId: bulkId, // add the bulk id if present

--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS openshift (
   friendly_name       varchar(100),
   cloud_provider      varchar(100),
   cloud_region        varchar(100),
+  build_image         varchar(2000),
   created             timestamp DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1719,6 +1719,24 @@ $$
 --   END;
 -- $$
 
+CREATE OR REPLACE PROCEDURE
+  add_build_image_to_openshift()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'openshift'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'build_image'
+    ) THEN
+      ALTER TABLE `openshift`
+      ADD `build_image`       varchar(2000);
+    END IF;
+  END;
+$$
+
 DELIMITER ;
 
 -- If adding new procedures, add them to the bottom of this list
@@ -1807,6 +1825,7 @@ CALL add_task_name_to_tasks();
 CALL add_new_task_status_types();
 CALL update_active_succeeded_tasks();
 CALL update_missing_tasknames();
+CALL add_build_image_to_openshift();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api/src/resources/openshift/sql.ts
+++ b/services/api/src/resources/openshift/sql.ts
@@ -12,7 +12,8 @@ export const Sql = {
     monitoringConfig,
     friendlyName,
     cloudProvider,
-    cloudRegion
+    cloudRegion,
+    buildImage
   }: {
     id?: number;
     name: string;
@@ -25,6 +26,7 @@ export const Sql = {
     friendlyName?: string;
     cloudProvider?: string;
     cloudRegion?: string;
+    buildImage?: string;
   }) =>
     knex('openshift')
       .insert({
@@ -38,7 +40,8 @@ export const Sql = {
         monitoringConfig,
         friendlyName,
         cloudProvider,
-        cloudRegion
+        cloudRegion,
+        buildImage
       })
       .toString(),
   updateOpenshift: ({

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -478,6 +478,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   type Kubernetes {
@@ -494,6 +495,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   type NotificationMicrosoftTeams {
@@ -1442,6 +1444,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   input AddKubernetesInput {
@@ -1460,6 +1463,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   input DeleteOpenshiftInput {
@@ -1612,6 +1616,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   input UpdateOpenshiftInput {
@@ -1634,6 +1639,7 @@ const typeDefs = gql`
     friendlyName: String
     cloudProvider: String
     cloudRegion: String
+    buildImage: String
   }
 
   input UpdateKubernetesInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds support for being able to define the build image to use on a particular remote in the API.
This allows for a specific target to use a different image without having to apply a change directly to the remote-controller in that target.

This image will override whatever the remote-controller has defined.

Two environment variables are introduced in this
* `DEFAULT_BUILD_DEPLOY_IMAGE`
  * This will define the default image to use in lagoon, this will by default be set in the `lagoon-core` chart matching the core version
* `EDGE_BUILD_DEPLOY_IMAGE`
  * This will define an edge image to use, this will override the default image and will be a more frequently released version of the build image but still constrained to a supported core version. The idea with edge is that it is a helm option that will set this to an edge image version in `lagoon-core` that is also matched to the core version, but this image tag will receive more frequent updates for the supported version of core, where the default image will not.

Eventually the image that is defined in the `remote-controller` helm chart will only be used as a fall back if no other image determined by core is applied. The goal being that core will be the source of image truth.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
