### PR TITLE
chore: add support for basic templates to get autogenerated routes

### DIFF
--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -24,7 +24,7 @@ ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
 RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.7.0/lagoon-linter_0.7.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
-RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.15.0/build-deploy-tool_0.15.0_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.15.1/build-deploy-tool_0.15.1_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin build-deploy-tool
 
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

We recently added basic and basic-persistent template types. This updates the build-deploy-tool to a version which supports creating autogenerated routes for these services.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

