### PR TITLE
fix: use restore bucket protocol from the restore url

### DIFF
--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -87,12 +87,14 @@ export const getRestoreLocation: ResolverFn = async (
 
     // We have to generate a new client every time because the endpoint is parsed
     // from the s3 url.
+    const URL = require('url').URL;
+    const restoreLocationURL = new URL(restoreLocation);
     const s3Client = new S3({
       accessKeyId,
       secretAccessKey,
       s3ForcePathStyle: true,
       signatureVersion: 'v4',
-      endpoint: `https://${R.prop(1, s3Parts)}`,
+      endpoint: `${restoreLocationURL.protocol}//${R.prop(1, s3Parts)}`,
       region: awsS3Parts ? R.prop(1, awsS3Parts) : ''
     });
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When working locally if a restore is in a local minio for example, the minio may not have https on it. As https is hardcoded, the restore fails to work, instead use the protocol from the restore itself.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
