### PR TITLE
chore: use bridge for s3_files_host for local

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,6 +57,8 @@ services:
     volumes:
       - ./services/logs2s3/src:/app/services/logs2s3/src
       - ./node-packages:/app/node-packages:delegated
+    environment:
+      - S3_FILES_HOST=http://172.17.0.1:9000
   logs2microsoftteams:
     image: ${IMAGE_REPO:-lagoon}/logs2microsoftteams
     command: yarn run dev
@@ -94,6 +96,7 @@ services:
       - NODE_ENV=development
       - CI=${CI:-true}
       - REGISTRY=harbor.172.17.0.1.nip.io:18080 # Docker network bridge and forwarded port for harbor-nginx
+      - S3_FILES_HOST=http://172.17.0.1:9000
     depends_on:
       - api-db
       - keycloak


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When using `make ui-logs-development` locally, the default value for `S3_FILES_HOST` is localhost which doesn't resolve to the minio instance correctly. This fixes it to use the docker bridge network like we do for registry etc.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
