### PR TITLE
Feature: add lagoon-core version to build payload

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -568,6 +568,10 @@ export const getControllerBuildData = async function(deployData: any) {
   // this way variables or new functionality can be passed into lagoon builds using the existing variables mechanism
   // avoiding the needs to hardcode them into the spec to then be consumed by the build-deploy controller
   lagoonProjectData.envVariables.push({"name":"LAGOON_SYSTEM_ROUTER_PATTERN", "value":routerPattern, "scope":"internal_system"})
+  // append the `LAGOON_SYSTEM_CORE_VERSION` variable as an `internal_system` variable that can be consumed by builds and
+  // is not user configurable, this value will eventually be consumed by `build-deploy-tool` to be able to reject
+  // builds that are not of a supported version of lagoon
+  lagoonProjectData.envVariables.push({"name":"LAGOON_SYSTEM_CORE_VERSION", "value":lagoonVersion, "scope":"internal_system"})
   if (bulkId != "") {
     // if this is a bulk deploy, add the associated bulk deploy build scope variables
     lagoonProjectData.envVariables.push({"name":"LAGOON_BULK_DEPLOY", "value":"true", "scope":"build"})


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

As #3257 describes, sending the lagoon-core version in builds could be very useful for builds to be able to consume.
This PR uses a scope of `internal_system` to inject `LAGOON_SYSTEM_CORE_VERSION` which is not able to be defined in the API by users, it is only used by internal systems and is a simple way to pass variables/values from core to builds without having to change CRDs or other resources. Builds are be able to consume these without fear that a user will have changed them.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3257 
