### PR TITLE
Revert "chore: remove random wait from test suite"

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -8,3 +8,4 @@ callback_whitelist = profile_tasks
 
 [persistent_connection]
 command_timeout = 60
+connect_timeout = 60

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -5,3 +5,6 @@ host_key_checking = False
 deprecation_warnings = False
 interpreter_python = auto_silent
 callback_whitelist = profile_tasks
+
+[persistent_connection]
+command_timeout = 60

--- a/tests/tasks/api/add-project.yaml
+++ b/tests/tasks/api/add-project.yaml
@@ -11,6 +11,9 @@
         body:
           query: '{{ lookup("template", "./add-project.gql") }}'
       register: apiresponse
+      until: api.response.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Add project {{ project }} to openshift {{ openshift }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"

--- a/tests/tasks/api/add-project.yaml
+++ b/tests/tasks/api/add-project.yaml
@@ -11,7 +11,7 @@
         body:
           query: '{{ lookup("template", "./add-project.gql") }}'
       register: apiresponse
-      until: api.response.status == 200
+      until: apiresponse.status == 200
       retries: 10
       delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Add project {{ project }} to openshift {{ openshift }}"

--- a/tests/tests/active-standby-kubernetes.yaml
+++ b/tests/tests/active-standby-kubernetes.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/active-standby-openshift.yaml
+++ b/tests/tests/active-standby-openshift.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/api.yaml
+++ b/tests/tests/api.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/bitbucket.yaml
+++ b/tests/tests/bitbucket.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: api/add-project.yaml
   vars:
     project: ci-bitbucket-{{ cluster_type }}

--- a/tests/tests/bulk-deployment.yaml
+++ b/tests/tests/bulk-deployment.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/dbaas.yaml
+++ b/tests/tests/dbaas.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/deploytarget.yaml
+++ b/tests/tests/deploytarget.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-php74.yaml
+++ b/tests/tests/drupal-php74.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-php80.yaml
+++ b/tests/tests/drupal-php80.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drupal-postgres.yaml
+++ b/tests/tests/drupal-postgres.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/drush.yaml
+++ b/tests/tests/drush.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/elasticsearch.yaml
+++ b/tests/tests/elasticsearch.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-api-variables.yaml
+++ b/tests/tests/features-api-variables.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-kubernetes-2.yaml
+++ b/tests/tests/features-kubernetes-2.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-kubernetes.yaml
+++ b/tests/tests/features-kubernetes.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features-openshift.yaml
+++ b/tests/tests/features-openshift.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/features/random-wait.yaml
+++ b/tests/tests/features/random-wait.yaml
@@ -1,0 +1,7 @@
+- name: "{{ testname }} - wait for >5 seconds to give an eventual running deployment time to run, after that check again if the first commit is still there"
+  hosts: localhost
+  serial: 1
+  vars:
+    seconds: "{{ 30 | random(start=5, step=5) }}"
+  tasks:
+  - include: ../../tasks/pause.yaml

--- a/tests/tests/generic.yaml
+++ b/tests/tests/generic.yaml
@@ -1,4 +1,6 @@
 ---
+# - include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/github.yaml
+++ b/tests/tests/github.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: api/add-project.yaml
   vars:
     project: ci-github-{{ cluster_type }}

--- a/tests/tests/gitlab.yaml
+++ b/tests/tests/gitlab.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: api/add-project.yaml
   vars:
     project: ci-gitlab-{{ cluster_type }}

--- a/tests/tests/image-cache.yaml
+++ b/tests/tests/image-cache.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/nginx.yaml
+++ b/tests/tests/nginx.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node-mongodb.yaml
+++ b/tests/tests/node-mongodb.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node-various.yaml
+++ b/tests/tests/node-various.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/node.yaml
+++ b/tests/tests/node.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/python.yaml
+++ b/tests/tests/python.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/ssh-portal.yaml
+++ b/tests/tests/ssh-portal.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/tasks.yaml
+++ b/tests/tests/tasks.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"

--- a/tests/tests/workflows.yaml
+++ b/tests/tests/workflows.yaml
@@ -1,4 +1,6 @@
 ---
+- include: features/random-wait.yaml
+
 - include: features/api-token.yaml
   vars:
     testname: "API TOKEN"


### PR DESCRIPTION
This reverts commit 56a3bd5549f1b72847f0ff401e06ea40bf757a16.

api-db lockouts are being observed in CI when multiple projects process in the same second. Not replicatable in a prod env.