### PR TITLE
move test api retries into api stage

### DIFF
--- a/tests/tasks/api/add-deploytarget.yaml
+++ b/tests/tasks/api/add-deploytarget.yaml
@@ -26,8 +26,9 @@
         body:
           query: '{{ lookup("template", "./add-deploytarget.gql") }}'
       register: apiresponse
+      until: apiresponse.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Add deploytarget to project {{ project }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"
-      retries: 10
-      delay: 30

--- a/tests/tasks/api/add-environment.yaml
+++ b/tests/tasks/api/add-environment.yaml
@@ -26,8 +26,9 @@
         body:
           query: '{{ lookup("template", "./add-environment.gql") }}'
       register: apiresponse
+      until: apiresponse.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Add environment {{ name }} to project {{ project }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"
-      retries: 10
-      delay: 30

--- a/tests/tasks/api/add-project.yaml
+++ b/tests/tasks/api/add-project.yaml
@@ -11,9 +11,9 @@
         body:
           query: '{{ lookup("template", "./add-project.gql") }}'
       register: apiresponse
+      until: apiresponse.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Add project {{ project }} to openshift {{ openshift }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"
-#      until: apiresponse.json.data.addProject.id > 0
-      retries: 10
-      delay: 30

--- a/tests/tasks/api/delete-project.yaml
+++ b/tests/tasks/api/delete-project.yaml
@@ -11,9 +11,10 @@
         body:
           query: '{{ lookup("template", "./delete-project.gql") }}'
       register: apiresponse
+      until: apiresponse.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Delete project {{ project }} from openshift {{ openshift }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"
       until: apiresponse.json.data.CiDeleteProject == "success"
-      retries: 10
-      delay: 30

--- a/tests/tasks/api/update-project-routerpattern.yaml
+++ b/tests/tasks/api/update-project-routerpattern.yaml
@@ -26,8 +26,9 @@
         body:
           query: '{{ lookup("template", "./update-project-routerpattern.gql") }}'
       register: apiresponse
+      until: apiresponse.status == 200
+      retries: 10
+      delay: "{{ 30 | random(start=15, step=5) }}"
     - name: "Update project routerpattern for {{ project }} to openshift {{ openshift }}"
       debug:
         msg: "api response: {{ apiresponse.json }}"
-      retries: 10
-      delay: 30

--- a/tests/tests/tasks/create-register-and-test-image-task.yaml
+++ b/tests/tests/tasks/create-register-and-test-image-task.yaml
@@ -13,7 +13,6 @@
         body_format: json
         body: '{ "query": "query($openshiftProjectName: String!) {environmentByOpenshiftProjectName(openshiftProjectName:$openshiftProjectName) {id}}", "variables": {"openshiftProjectName":"{{ openshift_project_name }}"}}'
       register: environmentByOSProjectNameApiResponse
-      until:
     - name: "{{ testname }} - environmentByOSProjectNameApiResponse"
       debug:
         msg: "api response: {{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}"
@@ -33,7 +32,6 @@
         body_format: json
         body: '{ "query": "mutation($environment: Int!, $advancedTaskDefinition: Int!) {invokeRegisteredTask(environment:$environment, advancedTaskDefinition: $advancedTaskDefinition) {id}}", "variables": {"environment":{{ environmentByOSProjectNameApiResponse.json.data.environmentByOpenshiftProjectName.id }}, "advancedTaskDefinition":{{ taskCreateApiResponse.json.data.addAdvancedTaskDefinition.id }}}}'
       register: invokeRegisteredTaskApiResponse
-      until:
     - name: "{{ testname }} - POST api invokeRegisteredTask to {{ graphql_url }}"
       debug:
         msg: "api response: {{ invokeRegisteredTaskApiResponse.json }}"


### PR DESCRIPTION
previously, if the api encountered a delay or an error, it wouldn't attempt a retry, as the retries/delay code was added to the debug stage. This PR moves the logic into the correct stage, and introduces a slight jitter into the delay to avoid more potential race conditions.