### PR TITLE
Makes the opensearch api integration feature flaggable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - /app/node-packages/commons/dist
     environment:
       - NODE_ENV=development
+      - OPENSEARCH_INTEGRATION_ENABLED=false
       - CI=${CI:-true}
       - REGISTRY=harbor.172.17.0.1.nip.io:18080 # Docker network bridge and forwarded port for harbor-nginx
     depends_on:

--- a/services/api/src/resources/group/opendistroSecurity.ts
+++ b/services/api/src/resources/group/opendistroSecurity.ts
@@ -16,22 +16,22 @@ export const OpendistroSecurityOperations = (
   const opensearchIntegrationEnabled = getConfigFromEnv('OPENSEARCH_INTEGRATION_ENABLED', 'true');
 
   if (opensearchIntegrationEnabled == "false") {
-    logger.info("OPENSEARCH_INTEGRATION_ENABLED is 'false' - disabling and returning log only object");
+    logger.debug("OPENSEARCH_INTEGRATION_ENABLED is 'false' - disabling and returning log only object");
     return {
       syncGroup: async function(groupName, groupProjectIDs) {
-        logger.info("[OpendistroSecurityOperations].syncGroup called");
+        logger.debug("[OpendistroSecurityOperations].syncGroup called");
       },
       syncGroupWithSpecificTenant: async (groupName, tenantName, groupProjectIDs) => {
-        logger.info("[OpendistroSecurityOperations].syncGroupWithSpecificTenant called");
+        logger.debug("[OpendistroSecurityOperations].syncGroupWithSpecificTenant called");
       },
       deleteTenant: async tenantName => {
-        logger.info("[OpendistroSecurityOperations].deleteTenant called");
+        logger.debug("[OpendistroSecurityOperations].deleteTenant called");
       },
       deleteGroup: async function(groupName) {
-        logger.info("[OpendistroSecurityOperations].deleteGroup called");
+        logger.debug("[OpendistroSecurityOperations].deleteGroup called");
       },
       deleteGroupWithSpecificTenant: async function(groupName, tenantName) {
-        logger.info("[OpendistroSecurityOperations].deleteGroupWithSpecificTenant called");
+        logger.debug("[OpendistroSecurityOperations].deleteGroupWithSpecificTenant called");
       },
     }
   } else {


### PR DESCRIPTION
This PR makes the opensearch api integration for the lagoon api service flaggable via an environment variable OPENSEARCH_INTEGRATION_ENABLED

if set to "false" it returns a mock object that simply logs the calls to the functions used for opensearch integration - this prevents us from getting integration errors in the logs, as well as preventing startup slowness in some circumstances (such as local docker-compose development and in testing).

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

