### PR TITLE
k8up to not dump tablespaces to avoid warning

### DIFF
--- a/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/images/kubectl-build-deploy-dind/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -12,7 +12,7 @@ spec:
     /bin/sh -c "dump=$(mktemp)
     && mysqldump --max-allowed-packet=500M --events --routines --quick
     --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data
+    --no-data --no-tablespaces
     -h $BACKUP_DB_HOST
     -u $BACKUP_DB_USERNAME
     -p$BACKUP_DB_PASSWORD
@@ -21,7 +21,7 @@ spec:
     && mysqldump --max-allowed-packet=500M --events --routines --quick
     --add-locks --no-autocommit --single-transaction --no-create-db
     --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info
+    --no-create-info --no-tablespaces
     -h $BACKUP_DB_HOST
     -u $BACKUP_DB_USERNAME
     -p$BACKUP_DB_PASSWORD


### PR DESCRIPTION
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

This prevents the warning from appearing in the container logs for the daily backups.

# Closing issues

Partially closes #2645
