### PR TITLE
fix: remove lagoonadmin group

### DIFF
--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -68,11 +68,6 @@ function configure_lagoon_realm {
 
         /opt/jboss/keycloak/bin/kcadm.sh add-roles --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} --uid ${user_id} --rolename admin
         echo "Gave user '$KEYCLOAK_LAGOON_ADMIN_USERNAME' the role 'admin'"
-
-        local group_name="lagoonadmin"
-        local group_id=$(/opt/jboss/keycloak/bin/kcadm.sh create groups --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -s name=${group_name} 2>&1 | sed -e 's/Created new group with id //g' -e "s/'//g")
-        /opt/jboss/keycloak/bin/kcadm.sh update users/${user_id}/groups/${group_id} --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master}
-        echo "Created group '$group_name' and made user '$KEYCLOAK_LAGOON_ADMIN_USERNAME' member of it"
     fi
 }
 


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

This group is not used in Lagoon, and it being there creates extra work for other Lagoon tooling.

# Closing issues

n/a
