### PR TITLE
use longer varchar for self exclude migration

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1358,7 +1358,7 @@ CREATE OR REPLACE PROCEDURE
   add_environment_exclude_self_type_to_advanced_task_argument()
 
   BEGIN
-    DECLARE column_type_argument_type varchar(74);
+    DECLARE column_type_argument_type varchar(120);
 
     SELECT COLUMN_TYPE INTO column_type_argument_type
     FROM INFORMATION_SCHEMA.COLUMNS


### PR DESCRIPTION
the migration for #3276 used a temporary column to check the enum. On subsequent runs, this column isn't long enough to hold the complete length of the enum already in the table. As this hasn't been released (and is only a temporary table), we can modify this length