### PR TITLE
Remove (unused) foreign keys from api-db

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS project (
   deployments_disabled             int(1) NOT NULL default 0,
   production_build_priority        int NOT NULL default 6,
   development_build_priority       int NOT NULL default 5,
-  openshift                        int REFERENCES openshift (id),
+  openshift                        int,
   openshift_project_pattern        varchar(300),
   development_environments_limit   int DEFAULT NULL,
   created                          timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS project (
 CREATE TABLE IF NOT EXISTS environment (
   id                        int NOT NULL auto_increment PRIMARY KEY,
   name                      varchar(100),
-  project                   int REFERENCES project (id),
+  project                   int,
   deploy_type               ENUM('branch', 'pullrequest', 'promote') NOT NULL,
   deploy_base_ref           varchar(100),
   deploy_head_ref           varchar(100),
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS environment (
   route                     varchar(300),
   routes                    text,
   monitoring_urls           text,
-  openshift                 int REFERENCES openshift (id),
+  openshift                 int,
   openshift_project_pattern varchar(300),
   updated                   timestamp DEFAULT CURRENT_TIMESTAMP,
   created                   timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -114,17 +114,17 @@ CREATE TABLE IF NOT EXISTS environment (
 -- these are used in replacement of the default project openshift target
 CREATE TABLE IF NOT EXISTS deploy_target_config (
   id                            int NOT NULL auto_increment PRIMARY KEY,
-  project                       int REFERENCES project (id),
+  project                       int,
   weight                        int NOT NULL DEFAULT 0,
   branches                      varchar(300),
   pullrequests                  varchar(300),
-  deploy_target                  int REFERENCES openshift (id),
-  deploy_target_project_pattern  varchar(300)
+  deploy_target                 int,
+  deploy_target_project_pattern varchar(300)
 );
 
 CREATE TABLE IF NOT EXISTS environment_storage (
   id                       int NOT NULL auto_increment PRIMARY KEY,
-  environment              int REFERENCES environment (id),
+  environment              int,
   persistent_storage_claim varchar(100),
   bytes_used               bigint,
   updated                  date,
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS deployment (
   created      datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   started      datetime NULL,
   completed    datetime NULL,
-  environment  int NOT NULL REFERENCES environment (id),
+  environment  int NOT NULL,
   remote_id    varchar(50) NULL,
   priority     int NULL,
   bulk_id      varchar(50) NULL,
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS deployment (
 
 CREATE TABLE IF NOT EXISTS environment_backup (
   id                       int NOT NULL auto_increment PRIMARY KEY,
-  environment              int REFERENCES environment (id),
+  environment              int,
   source                   varchar(300),
   backup_id                varchar(300),
   created                  timestamp,
@@ -169,15 +169,15 @@ CREATE TABLE IF NOT EXISTS env_vars (
   name        varchar(300) NOT NULL,
   value       text NOT NULL,
   scope       ENUM('global', 'build', 'runtime', 'container_registry', 'internal_container_registry') NOT NULL DEFAULT 'global',
-  project     int NULL REFERENCES project (id),
-  environment int NULL REFERENCES environent (id),
+  project     int NULL,
+  environment int NULL,
   UNIQUE KEY `name_project` (`name`,`project`),
   UNIQUE KEY `name_environment` (`name`,`environment`)
 );
 
 CREATE TABLE IF NOT EXISTS environment_service (
   id          int NOT NULL auto_increment PRIMARY KEY,
-  environment int NOT NULL REFERENCES environmnet (id),
+  environment int NOT NULL,
   name        varchar(100) NOT NULL
 );
 
@@ -185,7 +185,7 @@ CREATE TABLE IF NOT EXISTS task (
   id                        int NOT NULL auto_increment PRIMARY KEY,
   name                      varchar(100) NOT NULL,
   task_name                 varchar(100) NULL,
-  environment               int NOT NULL REFERENCES environment (id),
+  environment               int NOT NULL,
   service                   varchar(100) NOT NULL,
   command                   varchar(300) NOT NULL,
   status                    ENUM('new', 'pending', 'running', 'cancelled', 'error', 'failed', 'complete', 'active', 'succeeded') NOT NULL,
@@ -208,7 +208,7 @@ CREATE TABLE IF NOT EXISTS s3_file (
 
 CREATE TABLE IF NOT EXISTS environment_problem (
   id                       int NOT NULL auto_increment PRIMARY KEY,
-  environment              int REFERENCES environment (id),
+  environment              int,
   severity                 varchar(300) DEFAULT '',
   severity_score           DECIMAL(1,1) DEFAULT 0.0,
   identifier               varchar(300) NOT NULL,
@@ -239,7 +239,7 @@ CREATE TABLE IF NOT EXISTS problem_harbor_scan_matcher (
 
 CREATE TABLE IF NOT EXISTS project_notification (
   nid      int,
-  pid      int REFERENCES project (id),
+  pid      int,
   type     ENUM('slack','rocketchat','microsoftteams','email', 'webhook') NOT NULL,
   content_type ENUM('deployment', 'problem') NOT NULL,
   notification_severity_threshold int NOT NULL default 0,
@@ -247,20 +247,20 @@ CREATE TABLE IF NOT EXISTS project_notification (
 );
 
 CREATE TABLE IF NOT EXISTS user_ssh_key (
-  usid int REFERENCES user (id),
-  skid int REFERENCES ssh_key (id),
+  usid int,
+  skid int,
   CONSTRAINT user_ssh_key_pkey PRIMARY KEY (usid, skid)
 );
 
 CREATE TABLE IF NOT EXISTS task_file (
-  tid int REFERENCES task (id),
-  fid int REFERENCES file (id),
+  tid int,
+  fid int,
   CONSTRAINT task_file_pkey PRIMARY KEY (tid, fid)
 );
 
 CREATE TABLE IF NOT EXISTS environment_fact (
   id                       int NOT NULL auto_increment PRIMARY KEY,
-  environment              int REFERENCES environment (id),
+  environment              int,
   service                  varchar(300) NULL,
   name                     varchar(300) NOT NULL,
   value                    varchar(300) NOT NULL,
@@ -275,7 +275,7 @@ CREATE TABLE IF NOT EXISTS environment_fact (
 
 CREATE TABLE IF NOT EXISTS environment_fact_reference (
   id      int NOT NULL auto_increment PRIMARY KEY,
-  fid     int NOT NULL REFERENCES environment_fact (id),
+  fid     int NOT NULL,
   name    varchar(300) NOT NULL,
   UNIQUE(fid, name)
 );
@@ -287,8 +287,8 @@ CREATE TABLE IF NOT EXISTS advanced_task_definition (
   image                    varchar(2000) DEFAULT '',
   service                  varchar(100),
   type                     varchar(100) NOT NULL,
-  environment              int NULL REFERENCES environment(id),
-  project                  int NULL REFERENCES project(id),
+  environment              int NULL,
+  project                  int NULL,
   group_name               varchar(2000) NULL,
   permission               ENUM('GUEST', 'DEVELOPER', 'MAINTAINER') DEFAULT 'GUEST',
   command                  text DEFAULT '',
@@ -300,7 +300,7 @@ CREATE TABLE IF NOT EXISTS advanced_task_definition (
 
 CREATE TABLE IF NOT EXISTS advanced_task_definition_argument (
   id                                int NOT NULL auto_increment PRIMARY KEY,
-  advanced_task_definition          int REFERENCES advanved_task_definition(id),
+  advanced_task_definition          int,
   name                              varchar(300) NOT NULL UNIQUE,
   display_name                      varchar(500) NULL,
   type                              ENUM('NUMERIC', 'STRING', 'ENVIRONMENT_SOURCE_NAME', 'ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF')
@@ -317,8 +317,8 @@ CREATE TABLE IF NOT EXISTS workflow (
   id                       int NOT NULL auto_increment PRIMARY KEY,
   name                     varchar(50) NOT NULL,
   event                    varchar(300) NOT NULL,
-  project                  int NOT NULL REFERENCES project(id),
-  advanced_task_definition int NOT NULL REFERENCES advanced_task_definition(id),
+  project                  int NOT NULL,
+  advanced_task_definition int NOT NULL,
   created                  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   deleted                  timestamp NOT NULL DEFAULT '0000-00-00 00:00:00'
 );

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -2177,7 +2177,7 @@ CREATE OR REPLACE PROCEDURE
         AND CONSTRAINT_NAME = 'user_ssh_key_ibfk_1'
     ) THEN
       ALTER TABLE `user_ssh_key`
-      MODIFY usid int, DROP FOREIGN KEY user_ssh_key_ibfk_1;
+      MODIFY usid char(36), DROP FOREIGN KEY user_ssh_key_ibfk_1;
     ELSEIF EXISTS (
     	SELECT NULL
 		  FROM INFORMATION_SCHEMA.COLUMNS
@@ -2187,7 +2187,7 @@ CREATE OR REPLACE PROCEDURE
         AND column_name = 'usid'
     ) THEN
       ALTER TABLE `user_ssh_key`
-      MODIFY usid int;
+      MODIFY usid char(36);
     END IF;
   END;
 $$

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1772,6 +1772,456 @@ CREATE OR REPLACE PROCEDURE
   END;
 $$
 
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_project()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'project'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'openshift'
+    ) THEN
+      ALTER TABLE `project`
+      MODIFY openshift int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_project_from_environment()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'project'
+    ) THEN
+      ALTER TABLE `environment`
+      MODIFY project int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_openshift_from_environment()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'openshift'
+    ) THEN
+      ALTER TABLE `environment`
+      MODIFY openshift int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_project_from_deploy_target_config()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'deploy_target_config'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'project'
+    ) THEN
+      ALTER TABLE `deploy_target_config`
+      MODIFY project int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_deploy_target_from_deploy_target_config()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'deploy_target_config'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'deploy_target'
+    ) THEN
+      ALTER TABLE `deploy_target_config`
+      MODIFY deploy_target int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_environment_storage()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_storage'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `environment_storage`
+        MODIFY environment int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_deployment()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'deployment'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `deployment`
+      MODIFY environment int NOT NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_environment_backup()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_backup'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `environment_backup`
+        MODIFY environment int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_environment_from_env_vars()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'env_vars'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `env_vars`
+        MODIFY environment int NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_project_from_env_vars()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'env_vars'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'project'
+    ) THEN
+      ALTER TABLE `env_vars`
+        MODIFY project int NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_environment_service()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_service'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `environment_service`
+        MODIFY environment int NOT NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_task()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'task'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `task`
+        MODIFY environment int NOT NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_environment_problem()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_problem'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `environment_problem`
+        MODIFY environment int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_project_notification()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'project_notification'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'pid'
+    ) THEN
+      ALTER TABLE `project_notification`
+        MODIFY pid int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_usid_from_user_ssh_key()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'user_ssh_key'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'usid'
+    ) THEN
+      ALTER TABLE `user_ssh_key`
+        MODIFY usid int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_skid_from_user_ssh_key()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'user_ssh_key'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'skid'
+    ) THEN
+      ALTER TABLE `user_ssh_key`
+        MODIFY skid int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_tid_from_task_file()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'task_file'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'tid'
+    ) THEN
+      ALTER TABLE `task_file`
+        MODIFY tid int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_fid_from_task_file()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'task_file'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'fid'
+    ) THEN
+      ALTER TABLE `task_file`
+        MODIFY fid int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_environment_fact()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_fact'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `environment_fact`
+        MODIFY environment int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_fid_from_environment_fact_reference()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'environment_fact_reference'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'fid'
+    ) THEN
+      ALTER TABLE `environment_fact_reference`
+        MODIFY fid int NOT NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_environment_from_advanced_task_definition()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'advanced_task_definition'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `advanced_task_definition`
+      MODIFY environment int NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_project_from_advanced_task_definition()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'advanced_task_definition'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'project'
+    ) THEN
+      ALTER TABLE `advanced_task_definition`
+      MODIFY project int NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_from_advanced_task_definition_argument()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'advanced_task_definition_argument'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'advanced_task_definition'
+    ) THEN
+      ALTER TABLE `advanced_task_definition_argument`
+      MODIFY advanced_task_definition int;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_project_from_workflow()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'workflow'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'project'
+    ) THEN
+      ALTER TABLE `workflow`
+      MODIFY project int NOT NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_advanced_task_definition_from_workflow()
+
+  BEGIN
+    IF NOT EXISTS (
+      SELECT NULL
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_name = 'workflow'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'advanced_task_definition'
+    ) THEN
+      ALTER TABLE `workflow`
+      MODIFY advanced_task_definition int NOT NULL;
+    END IF;
+  END;
+$$
+
 DELIMITER ;
 
 -- If adding new procedures, add them to the bottom of this list
@@ -1863,6 +2313,31 @@ CALL update_missing_tasknames();
 CALL add_build_image_to_openshift();
 CALL clean_stale_project_data();
 CALL add_environment_exclude_self_type_to_advanced_task_argument();
+CALL drop_foreign_key_from_project();
+CALL drop_foreign_key_project_from_environment();
+CALL drop_foreign_key_openshift_from_environment();
+CALL drop_foreign_key_project_from_deploy_target_config();
+CALL drop_foreign_key_deploy_target_from_deploy_target_config();
+CALL drop_foreign_key_from_environment_storage();
+CALL drop_foreign_key_from_deployment();
+CALL drop_foreign_key_from_environment_backup();
+CALL drop_foreign_key_environment_from_env_vars();
+CALL drop_foreign_key_project_from_env_vars();
+CALL drop_foreign_key_from_environment_service();
+CALL drop_foreign_key_from_task();
+CALL drop_foreign_key_from_environment_problem();
+CALL drop_foreign_key_from_project_notification();
+CALL drop_foreign_key_usid_from_user_ssh_key();
+CALL drop_foreign_key_skid_from_user_ssh_key();
+CALL drop_foreign_key_tid_from_task_file();
+CALL drop_foreign_key_fid_from_task_file();
+CALL drop_foreign_key_from_environment_fact();
+CALL drop_foreign_key_fid_from_environment_fact_reference();
+CALL drop_foreign_key_environment_from_advanced_task_definition();
+CALL drop_foreign_key_project_from_advanced_task_definition();
+CALL drop_foreign_key_from_advanced_task_definition_argument();
+CALL drop_foreign_key_project_from_workflow();
+CALL drop_foreign_key_advanced_task_definition_from_workflow();
 
 -- Drop legacy SSH key procedures
 DROP PROCEDURE IF EXISTS CreateProjectSshKey;

--- a/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/01-migrations.sql
@@ -1776,10 +1776,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_project()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'openshift'
+        AND CONSTRAINT_NAME = 'project_ibfk_1'
+    ) THEN
+      ALTER TABLE `project`
+        MODIFY openshift int, DROP FOREIGN KEY project_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'project'
         AND table_schema = 'infrastructure'
         AND column_name = 'openshift'
@@ -1794,10 +1804,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_project_from_environment()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'environment_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment`
+        MODIFY project int, DROP FOREIGN KEY environment_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment'
         AND table_schema = 'infrastructure'
         AND column_name = 'project'
@@ -1812,10 +1832,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_openshift_from_environment()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'openshift'
+        AND CONSTRAINT_NAME = 'environment_ibfk_2'
+    ) THEN
+      ALTER TABLE `environment`
+        MODIFY openshift int, DROP FOREIGN KEY environment_ibfk_2;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment'
         AND table_schema = 'infrastructure'
         AND column_name = 'openshift'
@@ -1830,10 +1860,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_project_from_deploy_target_config()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'deploy_target_config_ibfk_1'
+    ) THEN
+      ALTER TABLE `deploy_target_config`
+        MODIFY project int, DROP FOREIGN KEY deploy_target_config_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'deploy_target_config'
         AND table_schema = 'infrastructure'
         AND column_name = 'project'
@@ -1848,10 +1888,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_deploy_target_from_deploy_target_config()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'openshift'
+        AND CONSTRAINT_NAME = 'deploy_target_config_ibfk_2'
+    ) THEN
+      ALTER TABLE `deploy_target_config`
+        MODIFY deploy_target int, DROP FOREIGN KEY deploy_target_config_ibfk_2;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'deploy_target_config'
         AND table_schema = 'infrastructure'
         AND column_name = 'deploy_target'
@@ -1866,16 +1916,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_environment_storage()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'environment_storage_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_storage`
+        MODIFY environment int, DROP FOREIGN KEY environment_storage_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_storage'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `environment_storage`
-        MODIFY environment int;
+      MODIFY environment int;
     END IF;
   END;
 $$
@@ -1884,10 +1944,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_deployment()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'deployment_ibfk_1'
+    ) THEN
+      ALTER TABLE `deployment`
+        MODIFY environment int NOT NULL, DROP FOREIGN KEY deployment_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'deployment'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
@@ -1902,34 +1972,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_environment_backup()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'environment_backup_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_backup`
+        MODIFY environment int, DROP FOREIGN KEY environment_backup_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_backup'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `environment_backup`
-        MODIFY environment int;
-    END IF;
-  END;
-$$
-
-CREATE OR REPLACE PROCEDURE
-  drop_foreign_key_environment_from_env_vars()
-
-  BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
-      WHERE
-        table_name = 'env_vars'
-        AND table_schema = 'infrastructure'
-        AND column_name = 'environment'
-    ) THEN
-      ALTER TABLE `env_vars`
-        MODIFY environment int NULL;
+      MODIFY environment int;
     END IF;
   END;
 $$
@@ -1938,16 +2000,54 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_project_from_env_vars()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'env_vars_ibfk_1'
+    ) THEN
+      ALTER TABLE `env_vars`
+        MODIFY project int NULL, DROP FOREIGN KEY env_vars_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'env_vars'
         AND table_schema = 'infrastructure'
         AND column_name = 'project'
     ) THEN
       ALTER TABLE `env_vars`
-        MODIFY project int NULL;
+      MODIFY project int NULL;
+    END IF;
+  END;
+$$
+
+CREATE OR REPLACE PROCEDURE
+  drop_foreign_key_environment_from_env_vars()
+
+  BEGIN
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+      WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'env_vars_ibfk_2'
+    ) THEN
+      ALTER TABLE `env_vars`
+        MODIFY environment int NULL, DROP FOREIGN KEY env_vars_ibfk_2;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
+        table_name = 'env_vars'
+        AND table_schema = 'infrastructure'
+        AND column_name = 'environment'
+    ) THEN
+      ALTER TABLE `env_vars`
+      MODIFY environment int NULL;
     END IF;
   END;
 $$
@@ -1956,16 +2056,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_environment_service()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'environment_service_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_service`
+      MODIFY environment int NOT NULL, DROP FOREIGN KEY environment_service_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_service'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `environment_service`
-        MODIFY environment int NOT NULL;
+      MODIFY environment int NOT NULL;
     END IF;
   END;
 $$
@@ -1974,16 +2084,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_task()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'task_ibfk_1'
+    ) THEN
+      ALTER TABLE `task`
+        MODIFY environment int NOT NULL, DROP FOREIGN KEY task_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'task'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `task`
-        MODIFY environment int NOT NULL;
+      MODIFY environment int NOT NULL;
     END IF;
   END;
 $$
@@ -1992,16 +2112,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_environment_problem()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'environment_problem_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_problem`
+        MODIFY environment int, DROP FOREIGN KEY environment_problem_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_problem'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `environment_problem`
-        MODIFY environment int;
+      MODIFY environment int;
     END IF;
   END;
 $$
@@ -2010,16 +2140,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_project_notification()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'project_notification_ibfk_1'
+    ) THEN
+      ALTER TABLE `project_notification`
+      MODIFY pid int, DROP FOREIGN KEY project_notification_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'project_notification'
         AND table_schema = 'infrastructure'
         AND column_name = 'pid'
     ) THEN
       ALTER TABLE `project_notification`
-        MODIFY pid int;
+      MODIFY pid int;
     END IF;
   END;
 $$
@@ -2028,16 +2168,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_usid_from_user_ssh_key()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'user'
+        AND CONSTRAINT_NAME = 'user_ssh_key_ibfk_1'
+    ) THEN
+      ALTER TABLE `user_ssh_key`
+      MODIFY usid int, DROP FOREIGN KEY user_ssh_key_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'user_ssh_key'
         AND table_schema = 'infrastructure'
         AND column_name = 'usid'
     ) THEN
       ALTER TABLE `user_ssh_key`
-        MODIFY usid int;
+      MODIFY usid int;
     END IF;
   END;
 $$
@@ -2046,16 +2196,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_skid_from_user_ssh_key()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'ssh_key'
+        AND CONSTRAINT_NAME = 'user_ssh_key_ibfk_1'
+    ) THEN
+      ALTER TABLE `user_ssh_key`
+      MODIFY skid int, DROP FOREIGN KEY user_ssh_key_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'user_ssh_key'
         AND table_schema = 'infrastructure'
         AND column_name = 'skid'
     ) THEN
       ALTER TABLE `user_ssh_key`
-        MODIFY skid int;
+      MODIFY skid int;
     END IF;
   END;
 $$
@@ -2064,16 +2224,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_tid_from_task_file()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'task'
+        AND CONSTRAINT_NAME = 'task_file_ibfk_1'
+    ) THEN
+      ALTER TABLE `task_file`
+      MODIFY tid int, DROP FOREIGN KEY task_file_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'task_file'
         AND table_schema = 'infrastructure'
         AND column_name = 'tid'
     ) THEN
       ALTER TABLE `task_file`
-        MODIFY tid int;
+      MODIFY tid int;
     END IF;
   END;
 $$
@@ -2082,16 +2252,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_fid_from_task_file()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'file'
+        AND CONSTRAINT_NAME = 'task_file_ibfk_1'
+    ) THEN
+      ALTER TABLE `task_file`
+      MODIFY fid int, DROP FOREIGN KEY task_file_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'task_file'
         AND table_schema = 'infrastructure'
         AND column_name = 'fid'
     ) THEN
       ALTER TABLE `task_file`
-        MODIFY fid int;
+      MODIFY fid int;
     END IF;
   END;
 $$
@@ -2100,16 +2280,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_environment_fact()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'environment_fact_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_fact`
+      MODIFY environment int, DROP FOREIGN KEY environment_fact_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_fact'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
     ) THEN
       ALTER TABLE `environment_fact`
-        MODIFY environment int;
+      MODIFY environment int;
     END IF;
   END;
 $$
@@ -2118,16 +2308,26 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_fid_from_environment_fact_reference()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment_fact'
+        AND CONSTRAINT_NAME = 'environment_fact_reference_ibfk_1'
+    ) THEN
+      ALTER TABLE `environment_fact_reference`
+      MODIFY fid int NOT NULL, DROP FOREIGN KEY environment_fact_reference_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'environment_fact_reference'
         AND table_schema = 'infrastructure'
         AND column_name = 'fid'
     ) THEN
       ALTER TABLE `environment_fact_reference`
-        MODIFY fid int NOT NULL;
+      MODIFY fid int NOT NULL;
     END IF;
   END;
 $$
@@ -2136,10 +2336,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_environment_from_advanced_task_definition()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'environment'
+        AND CONSTRAINT_NAME = 'advanced_task_definition_ibfk_1'
+    ) THEN
+      ALTER TABLE `advanced_task_definition`
+      MODIFY environment int NULL, DROP FOREIGN KEY advanced_task_definition_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'advanced_task_definition'
         AND table_schema = 'infrastructure'
         AND column_name = 'environment'
@@ -2154,10 +2364,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_project_from_advanced_task_definition()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'advanced_task_definition_ibfk_2'
+    ) THEN
+      ALTER TABLE `advanced_task_definition`
+      MODIFY project int NULL, DROP FOREIGN KEY advanced_task_definition_ibfk_2;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'advanced_task_definition'
         AND table_schema = 'infrastructure'
         AND column_name = 'project'
@@ -2172,10 +2392,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_from_advanced_task_definition_argument()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
+    IF EXISTS (
+      SELECT *
+      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
       WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+        AND REFERENCED_TABLE_NAME = 'advanced_task_definition'
+        AND CONSTRAINT_NAME = 'advanced_task_definition_argument_ibfk_1'
+    ) THEN
+      ALTER TABLE `advanced_task_definition_argument`
+      MODIFY advanced_task_definition int, DROP FOREIGN KEY advanced_task_definition_argument_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'advanced_task_definition_argument'
         AND table_schema = 'infrastructure'
         AND column_name = 'advanced_task_definition'
@@ -2190,10 +2420,20 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_project_from_workflow()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
-      WHERE
+    IF EXISTS (
+		  SELECT *
+		  FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+		  WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+		    AND REFERENCED_TABLE_NAME = 'project'
+        AND CONSTRAINT_NAME = 'workflow_ibfk_1'
+    ) THEN
+      ALTER TABLE `workflow`
+      MODIFY project int NOT NULL, DROP FOREIGN KEY workflow_ibfk_1;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'workflow'
         AND table_schema = 'infrastructure'
         AND column_name = 'project'
@@ -2208,17 +2448,27 @@ CREATE OR REPLACE PROCEDURE
   drop_foreign_key_advanced_task_definition_from_workflow()
 
   BEGIN
-    IF NOT EXISTS (
-      SELECT NULL
-      FROM INFORMATION_SCHEMA.COLUMNS
-      WHERE
+    IF EXISTS (
+		  SELECT *
+		  FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+		  WHERE
+        CONSTRAINT_SCHEMA = 'infrastructure'
+		    AND REFERENCED_TABLE_NAME = 'advanced_task_definition'
+		    AND CONSTRAINT_NAME = 'workflow_ibfk_2'
+    ) THEN
+      ALTER TABLE `workflow`
+      MODIFY advanced_task_definition int NOT NULL, DROP FOREIGN KEY workflow_ibfk_2;
+    ELSEIF EXISTS (
+    	SELECT NULL
+		  FROM INFORMATION_SCHEMA.COLUMNS
+		  WHERE
         table_name = 'workflow'
         AND table_schema = 'infrastructure'
         AND column_name = 'advanced_task_definition'
     ) THEN
       ALTER TABLE `workflow`
       MODIFY advanced_task_definition int NOT NULL;
-    END IF;
+   END IF;
   END;
 $$
 


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

A migration to remove all unused foreign key references from the database to allow for an easier transition to Knex migrations in a future release.

# Closing issues

N/A
