### PR TITLE
Fixes logic error in build var merging

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -1187,11 +1187,13 @@ export const bulkDeployEnvironmentLatest: ResolverFn = async (
     // these need to be merged on top of ones that come through at the bulk deploy level
     // handle that here
     let newBuildVariables = buildVariables || [];
+
     if (envInput.buildVariables != null && buildVariables != null) {
       newBuildVariables = jsonMerge(buildVariables, envInput.buildVariables, "name")
-    } else {
+    } else if (envInput.buildVariables != null) {
       newBuildVariables = envInput.buildVariables
     }
+
     const actionData = {
       type: "deployEnvironmentLatest",
       eventType: "bulkDeployment",


### PR DESCRIPTION
This PR fixes a logic error in the way that buildVariables are merged.

Currently, if there are no environment specific variables, any variables set at the top level of the `bulkDeployEnvironmentLatest` mutation will be completely ignored when there are no environment specific variable. In the example below `WILL_I_BE_USED` will not end up being sent to the deployment.

```
mutation test {
  bulkDeployEnvironmentLatest(
    input: {
      name: "test-bulk-deploy"
      environments: [
        {
          buildVariables: [
            {name:"WILL_I_BE_USED", value:"no"}
          ]
          environment: { name: "envname", project: { name: "proj-name" } }
        }
      ]
    }
  )
}

```
