### PR TITLE
Enables system wide task registration

### DIFF
--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -183,6 +183,12 @@ export const Sql = {
       knex('advanced_task_definition')
         .where('advanced_task_definition.name', '=', name)
         .toString(),
+    selectSystemwideAdvancedTaskDefinition: () =>
+      knex('advanced_task_definition')
+        .whereNull('advanced_task_definition.environment')
+        .whereNull('advanced_task_definition.project')
+        .whereNull('advanced_task_definition.group_name')
+        .toString(),
     selectAdvancedTaskDefinitionByNameProjectEnvironmentAndGroup:(name: string, project: number, environment: number, group: string) => {
       let query = knex('advanced_task_definition')
         .where('advanced_task_definition.name', '=', name);


### PR DESCRIPTION
On the first iteration of custom tasks, we disallowed the creation of system wide tasks.

Now we need to enable it in order to expunge the default Drupal based tasks from the UI.

This PR updates the resolvers for custom tasks to allow and resolve these kinds of system wide tasks.


<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

