### PR TITLE
Filters out deleted environments in getDeploymentsByFilter

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -175,7 +175,8 @@ export const getDeploymentsByFilter: ResolverFn = async (
 
   let queryBuilder = knex.select("deployment.*").from('deployment').
       join('environment', 'deployment.environment', '=', 'environment.id').
-      join('project', 'environment.project', '=', 'project.id');
+      join('project', 'environment.project', '=', 'project.id').
+      where('environment.deleted', '=', '0000-00-00 00:00:00');
 
   if(openshifts) {
     queryBuilder = queryBuilder.whereIn('environment.openshift', openshifts);


### PR DESCRIPTION
Currently getDeploymentsByFilter returns all deployments, including those of deleted environments. This filters out the latter

It's an addendum to #3293 