### PR TITLE
Don't update environment routes/services for cancelled/failed deployments

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -68,9 +68,32 @@ interface RestorePatch {
   restoreLocation?: string;
 }
 
+interface EnvironmnetPatch {
+  autoIdle?: number;
+  created?: string;
+  deployBaseRef?: string;
+  deployHeadRef?: string;
+  deployTitle?: string;
+  deployType?: DeployType
+  environmentType?: EnvType
+  kubernetes?: number;
+  kubernetesNamespaceName?: string;
+  kubernetesNamespacePattern?: string;
+  monitoringUrls?: string;
+  project?: number;
+  route?: string;
+  routes?: string;
+}
+
 enum EnvType {
   PRODUCTION = 'production',
   DEVELOPMENT = 'development'
+}
+
+enum DeployType {
+  BRANCH = 'branch',
+  PULLREQUEST = 'pullrequest',
+  PROMOTE = 'promote'
 }
 
 const { JWTSECRET, JWTAUDIENCE } = process.env;
@@ -1033,20 +1056,23 @@ export const addOrUpdateEnvironment = (
   );
 
 export const updateEnvironment = (
-  environmentId: number,
-  patch: string
+  id: number,
+  patch: EnvironmnetPatch
 ): Promise<any> =>
-  graphqlapi.query(`
-    mutation {
-      updateEnvironment(input: {
-        id: ${environmentId},
-        patch: ${patch}
-      }) {
-        id
-        name
-      }
+  graphqlapi.mutate(
+    `
+  ($id: Int!, $patch: UpdateEnvironmentPatchInput!) {
+    updateEnvironment(input: {
+      id: $id
+      patch: $patch
+    }) {
+      id
+      name
     }
-  `);
+  }
+`,
+    { id, patch }
+  );
 
 export async function deleteEnvironment(
   name: string,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

When a deployment is manually cancelled or fails, the `controllerhandler` would still try to update the routes and services for the deployments environment. This could result in the routes being set to the string "undefined" for example.

We don't want to change environment data if a deployment wasn't successful for any reason.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Closes https://github.com/uselagoon/lagoon-ui/issues/55
