### PR TITLE
fix: add additional metadata to pullrequests triggered by the API

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -628,7 +628,13 @@ export const deployEnvironmentLatest: ResolverFn = async (
       };
       meta = {
         ...meta,
-        pullrequestTitle: deployData.pullrequestTitle
+        pullrequestTitle: deployData.pullrequestTitle,
+        pullrequestNumber: environment.name.replace('pr-', ''),
+        headBranchName: environment.deployHeadRef,
+        headSha: `origin/${environment.deployHeadRef}`,
+        baseBranchName: environment.deployBaseRef,
+        baseSha: `origin/${environment.deployBaseRef}`,
+        branchName: environment.name
       };
       taskFunction = createDeployTask;
       break;


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

An issue discovered with logs2notifications is that now that it is processing the `meta` data of messages to create notifications, it has uncovered that some fields that would normally be in the `message` that is created in the resolvers, are not provided in the metadata of the log message itself.

When triggering a pullrequest deployment from the API, it is missing the `branchName` in the metadata, for PRs this is just the `pr-#`, but it is also missing other meta that could be useful. This adds additional metadata for pullrequests so that logs2notifications can consume it.
