### PR TITLE
Fixes thinkos in lagoon remote installation docs

### DIFF
--- a/docs/installing-lagoon/install-lagoon-remote.md
+++ b/docs/installing-lagoon/install-lagoon-remote.md
@@ -63,6 +63,6 @@ Now we will install Lagoon Remote into the Lagoon namespace. The [RabbitMQ](../d
     ```
     helm upgrade --install --create-namespace \
       --namespace lagoon \
-      -f remote-values.yaml
+      -f remote-values.yaml \
       lagoon-remote lagoon/lagoon-remote
     ```

--- a/docs/installing-lagoon/install-lagoon-remote.md
+++ b/docs/installing-lagoon/install-lagoon-remote.md
@@ -59,7 +59,7 @@ Now we will install Lagoon Remote into the Lagoon namespace. The [RabbitMQ](../d
           port: '3306'
           user: root
     ```
-3. Install Harbor:
+3. Install Lagoon Remote:
     ```
     helm upgrade --install --create-namespace \
       --namespace lagoon \


### PR DESCRIPTION
The Lagoon installation docs say `3. Install Harbor` when, presumably, they should say `3. Install Lagoon Remote` as the third step.

Also, missing slash to properly do a multiline command.