### PR TITLE
Fixes thinko in api error

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -262,7 +262,7 @@ export const addProject = async (
   }
   const openshift = input.kubernetes || input.openshift;
   if (!openshift) {
-    throw new Error('Must provide keycloak or openshift field');
+    throw new Error('Must provide kubernetes or openshift field');
   }
 
   let keyPair: any = {};


### PR DESCRIPTION
When creating a new project via the api, if you don't add either the `kubernetes` or `openshift` fields, you get the error :

`Must provide keycloak or openshift field`

This PR just fixes this thinko/slipup.
