### PR TITLE
API app logging improvements

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -21,8 +21,11 @@ app.use(json());
 // Add custom configured logger (morgan through winston).
 app.use(
   morgan('combined', {
+    skip: (req, res) => {
+      return req.originalUrl.startsWith('/status');
+    },
     stream: {
-      write: message => logger.info(message)
+      write: message => logger.info(message.trim())
     }
   })
 );

--- a/services/auth-server/src/index.ts
+++ b/services/auth-server/src/index.ts
@@ -21,8 +21,8 @@ const app = express();
 app.use(
   morgan('combined', {
     stream: {
-      write: message => logger.info(message),
-    },
+      write: message => logger.info(message.trim())
+    }
   }),
 );
 


### PR DESCRIPTION
This PR reduces noise in the API app logs by:
* not logging the 10-second healthchecks to /status
* removing the unnecessary newline after every morgan log