### PR TITLE
WIP: Use a single queue per remote instead of 4 queues.

### DIFF
--- a/node-packages/commons/src/deploy-tasks.ts
+++ b/node-packages/commons/src/deploy-tasks.ts
@@ -49,9 +49,7 @@ const deployBranch = async function(data: any) {
             const branchBuildDeployData = await getControllerBuildData(deployData);
             const branchPayload = {
                 eventType: "lagoon:build",
-                payload: {
-                    branchBuildDeployData
-                }
+                payload: branchBuildDeployData
             }
             const sendBranch = await sendToLagoonControllers(branchBuildDeployData.spec.project.deployTarget, branchPayload);
             return true
@@ -63,9 +61,7 @@ const deployBranch = async function(data: any) {
             const buildDeployData = await getControllerBuildData(deployData);
             const payload = {
                 eventType: "lagoon:build",
-                payload: {
-                    buildDeployData
-                }
+                payload: buildDeployData
             }
             const sendTasks = await sendToLagoonControllers(buildDeployData.spec.project.deployTarget, payload);
             return true
@@ -88,9 +84,7 @@ const deployBranch = async function(data: any) {
                 const buildDeployData = await getControllerBuildData(deployData);
                 const payload = {
                     eventType: "lagoon:build",
-                    payload: {
-                        buildDeployData
-                    }
+                    payload: buildDeployData
                 }
                 const sendTasks = await sendToLagoonControllers(buildDeployData.spec.project.deployTarget, payload);
                 return true
@@ -128,9 +122,7 @@ const deployPullrequest = async function(data: any) {
             const prBuildDeployData = await getControllerBuildData(deployData);
             const prPayload = {
                 eventType: "lagoon:build",
-                payload: {
-                    prBuildDeployData
-                }
+                payload: prBuildDeployData
             }
             const prSendTasks = await sendToLagoonControllers(prBuildDeployData.spec.project.deployTarget, prPayload);
             return true
@@ -142,9 +134,7 @@ const deployPullrequest = async function(data: any) {
             const buildDeployData = await getControllerBuildData(deployData);
             const payload = {
                 eventType: "lagoon:build",
-                payload: {
-                    buildDeployData
-                }
+                payload: buildDeployData
             }
             const sendTasks = await sendToLagoonControllers(buildDeployData.spec.project.deployTarget, payload);
             return true
@@ -167,9 +157,7 @@ const deployPullrequest = async function(data: any) {
                 const buildDeployData = await getControllerBuildData(deployData);
                 const payload = {
                     eventType: "lagoon:build",
-                    payload: {
-                        buildDeployData
-                    }
+                    payload: buildDeployData
                 }
                 const sendTasks = await sendToLagoonControllers(buildDeployData.spec.project.deployTarget, payload);
                 return true
@@ -429,9 +417,7 @@ export const deployTargetPromote = async function(data: any) {
     const buildDeployData = await getControllerBuildData(promoteData);
     const payload = {
         eventType: "lagoon:build",
-        payload: {
-            buildDeployData
-        }
+        payload: buildDeployData
     }
     const sendTasks = await sendToLagoonControllers(buildDeployData.spec.project.deployTarget, payload);
     return true

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -820,9 +820,7 @@ export const createRemoveTask = async function(removeData: any) {
     // use the targetname as the routing key with the action
     const payload = {
       eventType: "lagoon:removal",
-      payload: {
-        removeData
-      }
+      payload: removeData
     }
     return sendToLagoonControllers(deployTarget, payload);
   } else if (type === 'pullrequest') {
@@ -859,9 +857,7 @@ export const createRemoveTask = async function(removeData: any) {
     );
     const payload = {
       eventType: "lagoon:removal",
-      payload: {
-        removeData
-      }
+      payload: removeData
     }
     return sendToLagoonControllers(deployTarget, payload);
   } else if (type === 'promote') {
@@ -891,9 +887,7 @@ export const createRemoveTask = async function(removeData: any) {
     const deployTarget = result.environment.openshift.name
     const payload = {
       eventType: "lagoon:removal",
-      payload: {
-        removeData
-      }
+      payload: removeData
     }
     return sendToLagoonControllers(deployTarget, payload);
   }
@@ -954,9 +948,7 @@ export const createTaskTask = async function(taskData: any) {
   const deployTarget = result.environment.openshift.name
   const payload = {
     eventType: "lagoon:task",
-    payload: {
-      taskData
-    }
+    payload: taskData
   }
   return sendToLagoonControllers(deployTarget, payload);
 }
@@ -1148,9 +1140,7 @@ export const createMiscTask = async function(taskData: any) {
   // send the task to the queue
   const payload = {
     eventType: "lagoon:misc",
-    payload: {
-      miscTaskData
-    }
+    payload: miscTaskData
   }
   return sendToLagoonControllers(deployTarget, payload);
 }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

The remote-controller has a stability improvement PR (https://github.com/uselagoon/remote-controller/pull/140) that enables a single queue per remote-controller. 

NOTE: This has not been released yet in the remote-controller, so this PR is a WIP and will fail until `remote-controller` is released with the single-queue support update.

To support this, Lagoon needs to be updated to send all the messages to the new single queue.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
