### PR TITLE
set .erlang.cookie permission to 400

### DIFF
--- a/services/broker-single/cluster-rabbit.sh
+++ b/services/broker-single/cluster-rabbit.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# set the correct permissions on the erlang cookie in case Kubernetes changed it
+if [ -e /var/lib/rabbitmq/.erlang.cookie ]; then
+  echo "setting .erlang.cookie permission correctly"
+	chmod 400 /var/lib/rabbitmq/.erlang.cookie
+fi
 
 # Replace ENV values in definitions.json
 if [ -e /etc/rabbitmq/definitions.json ]; then


### PR DESCRIPTION
Kubernetes can change the permissions of files mounted into PVs, this PR ensures that the erlang.cookie used by RabbitMQ has the correct permissions. It uses the same process that the upstream startup scripts [use](https://github.com/rabbitmq/rabbitmq-server-release/pull/86)

https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recursive-permission-changes-on-mount