### PR TITLE
fix: some queries retrieve a deleted environment

### DIFF
--- a/services/api/src/resources/env-variables/sql.ts
+++ b/services/api/src/resources/env-variables/sql.ts
@@ -40,6 +40,7 @@ export const Sql = {
     knex('environment')
       .where('name', '=', name)
       .andWhere('project', '=', projectId)
+      .andWhere('deleted', '0000-00-00 00:00:00')
       .toString(),
   selectEnvVarByNameAndProjectId: (name: string, projectId: number) =>
     knex('env_vars')

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -20,11 +20,13 @@ export const Sql = {
     knex('environment')
       .where('name', '=', name)
       .andWhere('project', '=', projectId)
+      .andWhere('deleted', '0000-00-00 00:00:00')
       .toString(),
   selectEnvironmentsByProjectID: (projectId: number) =>
     knex('environment')
       .select('id', 'name')
       .where('project', '=', projectId)
+      .orderBy('id', 'desc')
       .toString(),
   truncateEnvironment: () =>
     knex('environment')


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Some of the sql queries used in environment resolvers don't retrieve environments in the right order, this can result in a deleted environment being returned in the first result.

This adjusts some of the querires to use to order by id, or select the environment that isn't deleted.

I discovered this when I had created an environment called `main2` and then deleted it. I then re-created this environment and set it up as an active/standby environment.
When triggering the active/standby switch, the task was created against the deleted environment, not the new one, so it never showed up in the API.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
