### PR TITLE
chore: support buildstatus and buildname in actions and logs2notifications

### DIFF
--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -22,6 +22,10 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue mq.MQ, message
 	}
 	prefix := fmt.Sprintf("(messageid:%s) %s/%s: ", messageID, message.Namespace, message.Meta.BuildName)
 	buildStatus := message.Meta.BuildPhase // eventually use message.Meta.BuildStatus
+	if message.Meta.BuildStatus != "" {
+		// use BuildStatus so BuildPhase can be removed
+		buildStatus = message.Meta.BuildStatus
+	}
 	log.Println(fmt.Sprintf("%sreceived deployment status update - %s", prefix, buildStatus))
 	// generate a lagoon token with a expiry of 60 seconds from now
 	token, err := jwt.GenerateAdminToken(m.LagoonAPI.TokenSigningKey, m.LagoonAPI.JWTAudience, m.LagoonAPI.JWTSubject, m.LagoonAPI.JWTIssuer, time.Now().Unix(), 60)

--- a/services/logs2notifications/internal/handler/s3_events.go
+++ b/services/logs2notifications/internal/handler/s3_events.go
@@ -28,7 +28,7 @@ func (h *Messaging) SendToS3(notification *Notification, msgType MessageType) {
 			fmt.Sprintf("buildlogs/%s/%s/%s-%s.txt",
 				notification.Project,
 				notification.Meta.BranchName,
-				notification.Meta.JobName,
+				notification.Meta.BuildName,
 				notification.Meta.RemoteID,
 			),
 		)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just a minor update to support checking the `buildstatus` field in the metadata as `buildphase` will go away soon

Also changing `jobname` to `buildname` in logs2notifications, as this has been sent by `remote-controller` for some time

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

