### PR TITLE
fix: update actions-handler to fix deployment not found error

### DIFF
--- a/services/actions-handler/go.mod
+++ b/services/actions-handler/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/cheshir/go-mq v1.2.0
-	github.com/uselagoon/machinery v0.0.6
+	github.com/uselagoon/machinery v0.0.7
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 )
 

--- a/services/actions-handler/go.sum
+++ b/services/actions-handler/go.sum
@@ -127,10 +127,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218 h1:tOESt7J50fPC9NqR0VdU1Zxk2zo5QYH70ap5TsU1bt4=
 github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218/go.mod h1:GQei++1WClbEC7AN1B9ipY1jCjzllM/7UNg0okAh/Z4=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/uselagoon/machinery v0.0.5 h1:p0KY9XpFazy/5u5VMUNRjdBYqLM/pPOhd6ErOwDs3zc=
-github.com/uselagoon/machinery v0.0.5/go.mod h1:dGAvkxWQkRu/eLQeWLrTl5HvNoFsiXlXInCptHUxzUw=
-github.com/uselagoon/machinery v0.0.6 h1:Fmos85ITxWQSa/0/cb7zo791qIlxMJ28EpAikuE8NN0=
-github.com/uselagoon/machinery v0.0.6/go.mod h1:dGAvkxWQkRu/eLQeWLrTl5HvNoFsiXlXInCptHUxzUw=
+github.com/uselagoon/machinery v0.0.7 h1:fBIURDQRVnaB/Gime1Lfp6kgQYmuQpa0gmdfPwo7dkc=
+github.com/uselagoon/machinery v0.0.7/go.mod h1:dGAvkxWQkRu/eLQeWLrTl5HvNoFsiXlXInCptHUxzUw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

A bug in machinery meant that if a deployment didn't exist, the machinery client would panic causing the actions-handler to get stuck in a crash loop.

This updates machinery to a fixed version.

https://github.com/uselagoon/machinery/pull/8 is the fix applied to machinery

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
