### PR TITLE
Only allow administrators to rename projects

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -571,6 +571,16 @@ export const updateProject: ResolverFn = async (
     }
   }
 
+  // if the name is provided in a patch, check that the user trying to rename the project is an admin.
+  // renaming projects is prohibited because lagoon uses the project name for quite a few things
+  // which if changed can have unintended consequences for any existing environments
+  if (patch.name) {
+    const canUpdateName = await isAdminCheck(hasPermission);
+    if (!canUpdateName) {
+      throw new Error('Project renaming is only available to administrators.');
+    }
+  }
+
   if (gitUrl !== undefined && !isValidGitUrl(gitUrl)) {
     throw new Error('The provided gitUrl is invalid.');
   }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Renaming a project in Lagoon can have many unintended side effects, especially if the project already has environments created.
The list is numerous, but could result in new namespaces being created, or backups of new or old environments failing.

This PR prohibits users from being able to change project names, but allows administrators to do so if required.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #2608 
