### PR TITLE
feat: add readiness sentinel file to api-data-watcher-pusher

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-watch-push.sh
+++ b/local-dev/api-data-watcher-pusher/api-watch-push.sh
@@ -65,7 +65,8 @@ watch_apidatafolder() {
                 echo "**** ERROR while re-populating $populate_kubernetes_gql_file_path, will try again."
             fi
 
-
+            # notify intial push completed
+            touch /tmp/api-data-pushed
         fi
 
         sleep 2


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Currently the `lagoon-test` chart uses a [racy readiness probe](https://github.com/uselagoon/lagoon-charts/blob/ad4e7356052b03571e2933735ddb69713600c194/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml#L52-L59) on the `api-data-watcher-pusher`. This change adds a sentinel file which is more reliable and less racy. The readiness probe in the chart will be updated after this is merged.

# Closing issues

n/a
