### PR TITLE
fix: check for disabledDeployments in webhooks too

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -9,6 +9,7 @@ interface Project {
   slack: any;
   name: string;
   openshift: any;
+  deploymentsDisabled: number;
 }
 
 interface GroupPatch {

--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -600,6 +600,7 @@ export async function getProjectsByGitUrl(gitUrl: string): Promise<Project[]> {
       allProjects(gitUrl: "${gitUrl}") {
         name
         productionEnvironment
+        deploymentsDisabled
         openshift {
           consoleUrl
           token

--- a/services/webhooks2tasks/src/handlers/bitbucketBranchDeleted.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketBranchDeleted.ts
@@ -20,6 +20,13 @@ export async function bitbucketBranchDeleted(webhook: WebhookRequestData, projec
       projectName: project.name,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/bitbucketPullRequestClosed.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketPullRequestClosed.ts
@@ -23,6 +23,13 @@ export async function bitbucketPullRequestClosed(webhook: WebhookRequestData, pr
       repoUrl: body.repository.links.html.href,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.ts
@@ -24,6 +24,13 @@ export async function bitbucketPullRequestUpdated(webhook: WebhookRequestData, p
       repoUrl: body.repository.links.html.href,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const headRepoId = body.pullrequest.source.repository.uuid;
     const headBranchName = body.pullrequest.source.branch.name
     const headSha = body.pullrequest.source.commit.hash

--- a/services/webhooks2tasks/src/handlers/bitbucketPush.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketPush.ts
@@ -33,6 +33,13 @@ export async function bitbucketPush(webhook: WebhookRequestData, project: Projec
       shortSha: sha.substring(0, 7),
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     let buildName = generateBuildId();
 
     const data: deployData = {

--- a/services/webhooks2tasks/src/handlers/giteaBranchDeleted.ts
+++ b/services/webhooks2tasks/src/handlers/giteaBranchDeleted.ts
@@ -19,6 +19,13 @@ export async function giteaBranchDeleted(webhook: WebhookRequestData, project: P
       branchName: body.ref.replace('refs/heads/','')
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/giteaPullRequestClosed.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPullRequestClosed.ts
@@ -25,6 +25,13 @@ export async function giteaPullRequestClosed(webhook: WebhookRequestData, projec
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/giteaPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPullRequestOpened.ts
@@ -31,6 +31,13 @@ export async function giteaPullRequestOpened(webhook: WebhookRequestData, projec
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     // Don't trigger deploy if the head and base repos are different
     if (!R.equals(headRepoId, baseRepoId)) {
       sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,

--- a/services/webhooks2tasks/src/handlers/giteaPullRequestSynchronize.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPullRequestSynchronize.ts
@@ -41,6 +41,13 @@ export async function giteaPullRequestSynchronize(webhook: WebhookRequestData, p
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     // Don't trigger deploy if only the PR body was edited.
     if (skipRedeploy(body)) {
       sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,

--- a/services/webhooks2tasks/src/handlers/giteaPush.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPush.ts
@@ -34,6 +34,13 @@ export async function giteaPush(webhook: WebhookRequestData, project: Project) {
       event: event,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     let buildName = generateBuildId();
 
     const data: deployData = {

--- a/services/webhooks2tasks/src/handlers/githubBranchDeleted.ts
+++ b/services/webhooks2tasks/src/handlers/githubBranchDeleted.ts
@@ -19,6 +19,13 @@ export async function githubBranchDeleted(webhook: WebhookRequestData, project: 
       branchName: body.ref.replace('refs/heads/','')
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/githubPullRequestClosed.ts
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestClosed.ts
@@ -25,6 +25,13 @@ export async function githubPullRequestClosed(webhook: WebhookRequestData, proje
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/githubPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestOpened.ts
@@ -31,6 +31,13 @@ export async function githubPullRequestOpened(webhook: WebhookRequestData, proje
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     // Don't trigger deploy if the head and base repos are different
     if (!R.equals(headRepoId, baseRepoId)) {
       sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,

--- a/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.ts
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.ts
@@ -41,6 +41,13 @@ export async function githubPullRequestSynchronize(webhook: WebhookRequestData, 
       repoUrl: body.repository.html_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     // Don't trigger deploy if only the PR body was edited.
     if (skipRedeploy(body)) {
       sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,

--- a/services/webhooks2tasks/src/handlers/githubPush.ts
+++ b/services/webhooks2tasks/src/handlers/githubPush.ts
@@ -33,6 +33,13 @@ export async function githubPush(webhook: WebhookRequestData, project: Project) 
       event: event,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     let buildName = generateBuildId();
 
     const data: deployData = {

--- a/services/webhooks2tasks/src/handlers/gitlabBranchDeleted.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabBranchDeleted.ts
@@ -21,6 +21,13 @@ export async function gitlabBranchDeleted(webhook: WebhookRequestData, project: 
       repoFullName: body.project.path_with_namespace,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestClosed.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestClosed.ts
@@ -23,6 +23,13 @@ export async function gitlabPullRequestClosed(webhook: WebhookRequestData, proje
       repoUrl: body.object_attributes.target.web_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const result = await getOpenShiftInfoForProject(project.name);
     const projectOpenShift = result.project;
 

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.ts
@@ -24,6 +24,13 @@ export async function gitlabPullRequestOpened(webhook: WebhookRequestData, proje
       repoUrl: body.object_attributes.target.web_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const headRepoId = body.object_attributes.source.git_ssh_url
     const headBranchName = body.object_attributes.source_branch
     const headSha = body.object_attributes.last_commit.id

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.ts
@@ -24,6 +24,13 @@ export async function gitlabPullRequestUpdated(webhook: WebhookRequestData, proj
       repoUrl: body.object_attributes.target.web_url,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     const headRepoId = body.object_attributes.source.git_ssh_url
     const headBranchName = body.object_attributes.source_branch
     const headSha = body.object_attributes.last_commit.id

--- a/services/webhooks2tasks/src/handlers/gitlabPush.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPush.ts
@@ -34,6 +34,13 @@ export async function gitlabPush(webhook: WebhookRequestData, project: Project) 
       event: event,
     }
 
+    if (project.deploymentsDisabled == 1) {
+      sendToLagoonLogs('info', project.name, uuid, `${webhooktype}:${event}:handledButNoTask`, meta,
+        `*[${project.name}]* No deploy task created, reason: deployments are disabled`
+      )
+      return;
+    }
+
     let buildName = generateBuildId();
 
     const data: deployData = {

--- a/services/webhooks2tasks/src/types.ts
+++ b/services/webhooks2tasks/src/types.ts
@@ -47,6 +47,7 @@ export interface WebhookRequestData {
 export interface Project {
   slack: any,
   name: string,
+  deploymentsDisabled: number,
   openshift: any,
   productionEnvironment?: string
 };


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When `deploymentsDisabled` was introduced, the webhooks were missed.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

I verified this by setting deploymentsDisabled on a project in local lagoon `lagoon update project -p high-cotton --deploymentsDisabled 1` and then running a [curl against the webhook-handler to try start a build](https://gist.github.com/shreddedbacon/fd806546f843f1d7d0f0cbdc4646962b)
