### PR TITLE
fix: avoid empty items in lagoon-project attribute list

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -597,15 +597,13 @@ export const Group = (clients: {
     groupInput: any
   ): Promise<void> => {
     const group = await loadGroupById(groupInput.id);
+    const groupProjectIds = getProjectIdsFromGroup(group)
     const newGroupProjects = R.pipe(
-      // @ts-ignore
-      R.view(attrLagoonProjectsLens),
-      R.defaultTo(`${projectId}`),
-      R.split(','),
-      R.append(`${projectId}`),
+      R.append(projectId),
       R.uniq,
       R.join(',')
-    )(group);
+      // @ts-ignore
+    )(groupProjectIds);
 
     try {
       await keycloakAdminClient.groups.update(
@@ -649,15 +647,13 @@ export const Group = (clients: {
     projectId: number,
     group: Group
   ): Promise<void> => {
+    const groupProjectIds = getProjectIdsFromGroup(group)
     const newGroupProjects = R.pipe(
-      // @ts-ignore
-      R.view(attrLagoonProjectsLens),
-      R.defaultTo(''),
-      R.split(','),
-      R.without([`${projectId}`]),
+      R.without([projectId]),
       R.uniq,
       R.join(',')
-    )(group);
+      // @ts-ignore
+    )(groupProjectIds);
 
     try {
       await keycloakAdminClient.groups.update(


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

The lagoon-projects group attribute in keycloak can sometimes end up with a leading comma separator. This seems to happen if somehow the list of project IDs has an empty string: "".

![screenshot_2022-12-01-110446](https://user-images.githubusercontent.com/861778/205064112-952362e8-3432-42d0-a891-3d6b3eeb0c9b.png)


This change ensures that the empty entries are stripped from keycloak attributes before writing them, by reusing the groupID parsing pipeline which already has the correct logic.

# Closing issues

n/a
