### PR TITLE
retrieve build pod name in tests from gql query

### DIFF
--- a/tests/tasks/api/deploy-no-sha.gql
+++ b/tests/tasks/api/deploy-no-sha.gql
@@ -1,3 +1,3 @@
 mutation deploy {
-  deployEnvironmentBranch(input:{project:{name: "{{ project }}" }, branchName: "{{ branch }}"})
+  deployEnvironmentBranch(input:{project:{name: "{{ project }}" }, branchName: "{{ branch }}", returnData: true})
 }

--- a/tests/tasks/api/deploy-no-sha.yaml
+++ b/tests/tasks/api/deploy-no-sha.yaml
@@ -21,27 +21,27 @@
         msg: "api response: {{ apiresponse }}"
     - fail:
         msg: "unsuccessful deploy"
-      when: apiresponse.json.data.deployEnvironmentBranch != "success"
-    - name: Get the build pod name
-      kubernetes.core.k8s_info:
-        kind: Pod
-        wait: yes
-        namespace: "{{ namespace }}"
-        label_selectors:
-          - lagoon.sh/jobType = build
-        field_selectors:
-          - status.phase=Running
-        wait_sleep: 1
-        wait_timeout: 60
-      register: build_pod
-    - name: Print build_pod
-      ansible.builtin.debug:
-        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+      when: apiresponse.json.data.deployEnvironmentBranch is not match("lagoon-build")
+    # - name: Get the build pod name
+    #   kubernetes.core.k8s_info:
+    #     kind: Pod
+    #     wait: yes
+    #     namespace: "{{ namespace }}"
+    #     label_selectors:
+    #       - lagoon.sh/jobType = build
+    #     field_selectors:
+    #       - status.phase=Running
+    #     wait_sleep: 1
+    #     wait_timeout: 60
+    #   register: build_pod
+    # - name: Print build_pod
+    #   ansible.builtin.debug:
+    #     msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
     - name: Wait until the build pod is completed
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        name: "{{ build_pod.resources[0].metadata.name }}"
+        name: "{{ apiresponse.json.data.deployEnvironmentBranch }}"
         namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build

--- a/tests/tasks/api/deploy-pullrequest.gql
+++ b/tests/tasks/api/deploy-pullrequest.gql
@@ -1,3 +1,3 @@
 mutation deploy {
-  deployEnvironmentPullrequest(input:{project:{name: "{{ project }}" },number: {{ git_pr_number | int }}, title: "{{ git_pr_title }}", baseBranchName: "{{ git_base_branch }}", baseBranchRef: "{{ git_base_commit_hash }}", headBranchName: "{{ git_pr_branch }}", headBranchRef: "{{ git_pr_commit_hash }}" })
+  deployEnvironmentPullrequest(input:{project:{name: "{{ project }}" },number: {{ git_pr_number | int }}, title: "{{ git_pr_title }}", baseBranchName: "{{ git_base_branch }}", baseBranchRef: "{{ git_base_commit_hash }}", headBranchName: "{{ git_pr_branch }}", headBranchRef: "{{ git_pr_commit_hash }}", returnData: true })
 }

--- a/tests/tasks/api/deploy-pullrequest.yaml
+++ b/tests/tasks/api/deploy-pullrequest.yaml
@@ -21,27 +21,27 @@
         msg: "api response: {{ apiresponse }}"
     - fail:
         msg: "unsuccessful deploy"
-      when: apiresponse.json.data.deployEnvironmentPullrequest != "success"
-    - name: Get the build pod name
-      kubernetes.core.k8s_info:
-        kind: Pod
-        wait: yes
-        namespace: "{{ namespace }}"
-        label_selectors:
-          - lagoon.sh/jobType = build
-        field_selectors:
-          - status.phase=Running
-        wait_sleep: 1
-        wait_timeout: 60
-      register: build_pod
-    - name: Print build_pod
-      ansible.builtin.debug:
-        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+      when: apiresponse.json.data.deployEnvironmentPullrequest is not match("lagoon-build")
+    # - name: Get the build pod name
+    #   kubernetes.core.k8s_info:
+    #     kind: Pod
+    #     wait: yes
+    #     namespace: "{{ namespace }}"
+    #     label_selectors:
+    #       - lagoon.sh/jobType = build
+    #     field_selectors:
+    #       - status.phase=Running
+    #     wait_sleep: 1
+    #     wait_timeout: 60
+    #   register: build_pod
+    # - name: Print build_pod
+    #   ansible.builtin.debug:
+    #     msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
     - name: Wait until the build pod is completed
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        name: "{{ build_pod.resources[0].metadata.name }}"
+        name: "{{ apiresponse.json.data.deployEnvironmentPullrequest }}"
         namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build

--- a/tests/tasks/api/deploy-sha.gql
+++ b/tests/tasks/api/deploy-sha.gql
@@ -1,3 +1,3 @@
 mutation deploy {
-  deployEnvironmentBranch(input:{project:{name: "{{ project }}" }, branchName: "{{ branch }}", branchRef: "{{ sha }}" })
+  deployEnvironmentBranch(input:{project:{name: "{{ project }}" }, branchName: "{{ branch }}", branchRef: "{{ sha }}", returnData: true })
 }

--- a/tests/tasks/api/deploy-sha.yaml
+++ b/tests/tasks/api/deploy-sha.yaml
@@ -21,27 +21,27 @@
         msg: "api response: {{ apiresponse }}"
     - fail:
         msg: "unsuccessful deploy"
-      when: apiresponse.json.data.deployEnvironmentBranch != "success"
-    - name: Get the build pod name
-      kubernetes.core.k8s_info:
-        kind: Pod
-        wait: yes
-        namespace: "{{ namespace }}"
-        label_selectors:
-          - lagoon.sh/jobType = build
-        field_selectors:
-          - status.phase=Running
-        wait_sleep: 1
-        wait_timeout: 60
-      register: build_pod
-    - name: Print build_pod
-      ansible.builtin.debug:
-        msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
+      when: apiresponse.json.data.deployEnvironmentBranch is not match("lagoon-build")
+    # - name: Get the build pod name
+    #   kubernetes.core.k8s_info:
+    #     kind: Pod
+    #     wait: yes
+    #     namespace: "{{ namespace }}"
+    #     label_selectors:
+    #       - lagoon.sh/jobType = build
+    #     field_selectors:
+    #       - status.phase=Running
+    #     wait_sleep: 1
+    #     wait_timeout: 60
+    #   register: build_pod
+    # - name: Print build_pod
+    #   ansible.builtin.debug:
+    #     msg: "build_pod: {{ build_pod.resources[0].metadata.name }} {{ build_pod.resources[0].status.phase }}"
     - name: Wait until the build pod is completed
       kubernetes.core.k8s_info:
         kind: Pod
         wait: yes
-        name: "{{ build_pod.resources[0].metadata.name }}"
+        name: "{{ apiresponse.json.data.deployEnvironmentBranch }}"
         namespace: "{{ namespace }}"
         label_selectors:
           - lagoon.sh/jobType = build

--- a/tests/tests/active-standby/deploy-active-standby.yaml
+++ b/tests/tests/active-standby/deploy-active-standby.yaml
@@ -11,10 +11,10 @@
         body: '{ "query": "mutation($projectName: String!) {switchActiveStandby(input:{project:{name:$projectName}}){id}}", "variables": {"projectName":"{{ project }}"}}'
       register: apiresponse
       until:
-    - name: "{{ testname }} - POST api switchActiveStandby with target project {{ project }} (no sha) to {{ graphql_url }}"
+    - name: apiresponse debug
       debug:
         msg: "api response: {{ apiresponse.json }}"
-    - name: "{{ testname }} - POST api taskById with ID {{ apiresponse.json.data.switchActiveStandby.id }} for migration status to {{ graphql_url }}"
+    - name: "{{ testname }} - POST api taskById with ID {{ apiresponse.json.data.switchActiveStandby.id }} for task success to {{ graphql_url }}"
       uri:
         url: "{{ graphql_url }}"
         method: POST
@@ -23,12 +23,19 @@
         body_format: json
         body: '{ "query": "query($id: Int!) {taskById(id: $id){status}}", "variables": {"id":{{ apiresponse.json.data.switchActiveStandby.id }}}}'
       register: taskresult
-      until: taskresult.json.data is defined and (taskresult.json.data.taskById.status == "complete" or taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed")
-      retries: 20
+      until:
+        - taskresult.json.data is defined
+        - taskresult.json.data.taskById is defined
+        - taskresult.json.data.taskById.status is defined
+        - taskresult.json.data.taskById.status == "complete" or taskresult.json.data.taskById.status == "succeeded" or taskresult.json.data.taskById.status == "failed"
+      retries: 30
       delay: 10
+    - name: taskresult debug
+      debug:
+        msg: "taskresult: {{ taskresult.json }}"
     - name: "{{ testname }} - fail if task fails"
       fail:
-        msg: "The route migration failed for some reason"
+        msg: "The route migration task failed for some reason"
       when: taskresult.json.data.taskById.status == "failed"
     - name: "{{ testname }} - POST api projectByName with project {{ project }} for final migration status to {{ graphql_url }}"
       uri:
@@ -40,5 +47,5 @@
         body: '{ "query": "query($projectName: String!) {projectByName(name:$projectName){productionEnvironment,standbyProductionEnvironment}}", "variables": {"projectName":"{{ project }}"}}'
       register: switchresult
       until: switchresult.json.data.projectByName.productionEnvironment == standby_branch or switchresult.json.data.projectByName.standbyProductionEnvironment == prod_branch
-      retries: 20
+      retries: 30
       delay: 10


### PR DESCRIPTION
This fixes up two issues with responses from the GraphQL API for builds and retries:

* Builds now return the build id, which enables specific targeting of the correct build pod
* Tasks (specifically Active Standby) now actually retry if they don't succeed immediately.