### PR TITLE
Feature: Extend advanced tasks with admin functionality

### DIFF
--- a/services/api/database/migrations/20230119064648_add_admin_advanced_tasks.js
+++ b/services/api/database/migrations/20230119064648_add_admin_advanced_tasks.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('advanced_task_definition', (table) => {
+        table.boolean('show_ui').notNullable().defaultTo(1);
+        table.boolean('admin_task').notNullable().defaultTo(0);
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('advanced_task_definition', (table) => {
+        table.dropColumn('show_ui');
+        table.dropColumn('admin_task');
+    })
+};

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -113,6 +113,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload = {},
       remoteId,
       execute,
+      adminTask,
     }: {
       id?: number,
       name: string,
@@ -127,6 +128,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload: object,
       remoteId?: string,
       execute: boolean,
+      adminTask: boolean,
     },
   ) => {
     let rows = await query(

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -175,7 +175,9 @@ export const Helpers = (sqlClientPool: Pool) => ({
       environment: environmentData,
       advancedTask: {
         RunnerImage: image,
-        JSONPayload: new Buffer(JSON.stringify(payload).replace(/\\n/g, "\n")).toString('base64')
+        JSONPayload: new Buffer(JSON.stringify(payload).replace(/\\n/g, "\n")).toString('base64'),
+        deployerToken: adminTask, //an admintask will have a deployer token and ssh key injected into it
+        sshKey: adminTask,
       }
     }
 

--- a/services/api/src/resources/task/models/taskRegistration.ts
+++ b/services/api/src/resources/task/models/taskRegistration.ts
@@ -38,6 +38,8 @@ export interface AdvancedTaskDefinitionInterface {
   command?: string;
   service?: string;
   image?: string;
+  showUi?: number;
+  adminTask?: number;
   advancedTaskDefinitionArguments?: Partial<AdvancedTaskDefinitionArguments>;
 }
 

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -84,6 +84,8 @@ export const Sql = {
     environment,
     permission,
     confirmation_text,
+    show_ui,
+    admin_task
     }: {
       id: number,
       name: string,
@@ -97,7 +99,10 @@ export const Sql = {
       group_name: string,
       environment: number,
       permission: string,
-      confirmation_text: string
+      confirmation_text: string,
+      show_ui: number,
+      admin_task: number,
+
     }) =>
     knex('advanced_task_definition')
       .insert({
@@ -114,6 +119,8 @@ export const Sql = {
         environment,
         permission,
         confirmation_text,
+        show_ui,
+        admin_task,
       })
     .toString(),
     insertAdvancedTaskDefinitionArgument: ({

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -85,7 +85,7 @@ export const Sql = {
     permission,
     confirmation_text,
     show_ui,
-    admin_task
+    admin_task,
     }: {
       id: number,
       name: string,
@@ -102,7 +102,6 @@ export const Sql = {
       confirmation_text: string,
       show_ui: number,
       admin_task: number,
-
     }) =>
     knex('advanced_task_definition')
       .insert({

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -235,6 +235,8 @@ export const addAdvancedTaskDefinition = async (
     advancedTaskDefinitionArguments,
     created,
     confirmationText,
+    showUi,
+    adminTask,
   } = input;
 
   const atb = advancedTaskToolbox.advancedTaskFunctions(
@@ -313,6 +315,8 @@ export const addAdvancedTaskDefinition = async (
       group_name: groupName,
       permission,
       confirmation_text: confirmationText,
+      show_ui: showUi,
+      admin_task: adminTask,
     })
   );
 
@@ -361,7 +365,8 @@ export const updateAdvancedTaskDefinition = async (
         command,
         permission,
         advancedTaskDefinitionArguments,
-        confirmationText
+        confirmationText,
+        showUi,
       }
     }
   },
@@ -400,7 +405,8 @@ export const updateAdvancedTaskDefinition = async (
         command,
         service,
         permission,
-        confirmation_text: confirmationText
+        confirmation_text: confirmationText,
+        show_ui: showUi
       }
     })
   );
@@ -566,6 +572,7 @@ export const invokeRegisteredTask = async (
           service: task.service || 'cli',
           image: task.image, //the return data here is basically what gets dropped into the DB.
           payload: payload,
+          adminTask: task.adminTask == 1,
           remoteId: undefined,
           execute: true
         });
@@ -732,7 +739,7 @@ async function checkAdvancedTaskPermissions(input:AdvancedTaskDefinitionInterfac
     //In the first release, we're not actually supporting this
     //TODO: add checks once images are officially supported - for now, throw an error
     throw Error('Adding Images and System Wide Tasks are not yet supported');
-  } else if (getAdvancedTaskDefinitionType(input) == AdvancedTaskDefinitionType.image) {
+  } else if (getAdvancedTaskDefinitionType(input) == AdvancedTaskDefinitionType.image || input.adminTask != 0) {
     //We're only going to allow administrators to add these for now ...
     await hasPermission('advanced_task', 'create:advanced');
   } else if (input.groupName) {

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -406,7 +406,7 @@ export const updateAdvancedTaskDefinition = async (
         service,
         permission,
         confirmation_text: confirmationText,
-        show_ui: showUi
+        show_ui: showUi,
       }
     })
   );

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -155,6 +155,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
+    showUi: Int
+    adminTask: Int
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -172,6 +174,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
+    showUi: Int
+    adminTask: Int
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -1416,6 +1420,8 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
+    showUi: Int
+    adminTask: Int
   }
 
   input UpdateAdvancedTaskDefinitionInput {
@@ -1436,6 +1442,7 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
+    showUi: Int
   }
 
   input DeleteTaskInput {


### PR DESCRIPTION
Remake of https://github.com/uselagoon/lagoon/pull/3184 to be inline with current codebase.
Updated migrations to be compatible with Knex.

This PR introduces two new flags to the advanced task definition system
* `adminTask`: This marks a task as requiring slightly elevated privileges within the task system (i.e. having the deployer token mounted into the task container). By default, tasks will not be set as adminTask. Details in #3182 
* `showUi`: if set to 0, the custom task will not be shown in the UI. Details in #3183 

Split out UI changes into https://github.com/uselagoon/lagoon-ui/pull/99.

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
