### PR TITLE
point to new helmfiles repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,10 +168,10 @@ pipeline {
         }
       }
       environment {
-        TOKEN = credentials('vshn-gitlab-helmfile-ci-trigger')
+        TOKEN = credentials('git-amazeeio-helmfile-ci-trigger')
       }
       steps {
-        sh script: "curl -X POST -F token=$TOKEN -F ref=master https://git.vshn.net/api/v4/projects/1263/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
+        sh script: "curl -X POST -F token=$TOKEN -F ref=master https://git.amazeeio.cloud/api/v4/projects/86/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
       }
     }
     stage ('push images to uselagoon/*') {

--- a/yarn-workspace-builder/Dockerfile
+++ b/yarn-workspace-builder/Dockerfile
@@ -2,9 +2,6 @@ ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/node-16-builder:${UPSTREAM_TAG:-latest}
 
-RUN apk add --no-cache \
-        libexecinfo-dev
-
 COPY package.json yarn.lock .env.defaults tsconfig.json /app/
 COPY node-packages /app/node-packages
 


### PR DESCRIPTION
The location of the helmfile trigger used to build the amazeeio-hosted Lagoon test clusters has changed - this PR updates the URL and the secret used to trigger it