### PR TITLE
Deprecate `monitoringUrls`

### DIFF
--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -210,16 +210,6 @@ routes:
 
 Environment names match your deployed branches or pull requests. This allows for each environment to have a different config. In our example it will apply to the `main` and `staging` environment.
 
-### `environments.[name].monitoring_urls`
-
-!!! Danger "Danger:"
-    This feature will be removed in an upcoming release of Lagoon. Please use the newer `monitoring-path` method on your specific route.
-
-!!! Note "Note:"
-    Please note, Lagoon does not provide any direct integration to a monitoring service, this just adds the URLs to the API. On amazee.io, we take the `monitoring_urls` and add them to our StatusCake account.
-
-At the end of a deploy, Lagoon will check this field for any URLs which you have specified to add to the API for the purpose of monitoring. The default value for this field is the first route for a project. It is useful for adding specific paths of a project to the API, for consumption by a monitoring service.
-
 ### `environments.[name].routes`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/vQxh87F3fW4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -590,3 +580,9 @@ environments:
         command: drush cron
         service: cli
 ```
+
+## Deprecated
+
+These settings have been deprecated and should be removed from use in your `.lagoon.yml`.
+
+* `environments.[name].monitoring_urls`

--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -139,10 +139,6 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue mq.MQ, message
 			routes := strings.Join(message.Meta.Routes, ",")
 			updateEnvironmentPatch.Routes = &routes
 		}
-		if message.Meta.MonitoringURLs != nil {
-			monitoring := strings.Join(message.Meta.MonitoringURLs, ",")
-			updateEnvironmentPatch.MonitoringURLs = &monitoring
-		}
 		updateEnvironmentPatch.ProjectID = message.Meta.ProjectID
 	}
 	// only update the api with the status etc on pending, complete, failed, or cancelled

--- a/services/api/database/migrations/20230202013434_remove_monitoring_urls.js
+++ b/services/api/database/migrations/20230202013434_remove_monitoring_urls.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema
+  .alterTable('environment', (table) => {
+    table.dropColumn('monitoring_urls');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema
+  .alterTable('environment', (table) => {
+    table.text('monitoring_urls');
+  });
+};

--- a/services/api/src/mocks.js
+++ b/services/api/src/mocks.js
@@ -304,7 +304,7 @@ mocks.Environment = (parent, args = {}, context, info) => {
     envVariables: [ mocks.EnvKeyValue() ],
     route: name === 'master' ? `https://${project.name}.org` : `https://${name}.${project.name}.org`,
     routes: `https://${project.name}.org,https://varnish-${project.name}-org-prod.us.amazee.io,https://nginx-${project.name}-org-prod.us.amazee.io`,
-    monitoringUrls: '',
+    monitoringUrls: null,
     deployments: [
       mocks.Deployment(null, {environment: { created: new Date(mocks.Date()) }}),
       mocks.Deployment(null, {environment: {}})

--- a/services/api/src/models/environment.ts
+++ b/services/api/src/models/environment.ts
@@ -16,7 +16,6 @@ export interface Environment {
   deleted?: string; // timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   route?: string; // varchar(300) COLLATE utf8_bin DEFAULT NULL,
   routes?: string; // text COLLATE utf8_bin DEFAULT NULL,
-  monitoringUrls?: string; // text COLLATE utf8_bin DEFAULT NULL,
   autoIdle?: Boolean; // int(1) NOT NULL DEFAULT 1,
   deployBaseRef?: string; // varchar(100) COLLATE utf8_bin DEFAULT NULL,
   deployHeadRef?: string; // varchar(100) COLLATE utf8_bin DEFAULT NULL,

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -635,7 +635,6 @@ export const updateEnvironment: ResolverFn = async (
         openshiftProjectName,
         route: input.patch.route,
         routes: input.patch.routes,
-        monitoringUrls: input.patch.monitoringUrls,
         autoIdle: input.patch.autoIdle,
         created: input.patch.created
       }
@@ -661,7 +660,6 @@ export const updateEnvironment: ResolverFn = async (
         openshiftProjectName,
         route: input.patch.route,
         routes: input.patch.routes,
-        monitoringUrls: input.patch.monitoringUrls,
         autoIdle: input.patch.autoIdle,
         created: input.patch.created
       },

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -846,7 +846,7 @@ const typeDefs = gql`
     envVariables: [EnvKeyValue]
     route: String
     routes: String
-    monitoringUrls: String
+    monitoringUrls: String @deprecated(reason: "No longer in use")
     deployments(name: String, limit: Int): [Deployment]
     insights(type: String, limit: Int): [Insight]
     backups(includeDeleted: Boolean, limit: Int): [Backup]

--- a/services/workflows/internal/handler/main.go
+++ b/services/workflows/internal/handler/main.go
@@ -46,27 +46,26 @@ type Action struct {
 }
 
 type LagoonLogMeta struct {
-	BranchName     string   `json:"branchName,omitempty"`
-	BuildName      string   `json:"buildName,omitempty"`
-	BuildPhase     string   `json:"buildPhase,omitempty"`
-	EndTime        string   `json:"endTime,omitempty"`
-	Environment    string   `json:"environment,omitempty"`
-	EnvironmentID  *uint    `json:"environmentId,omitempty"`
-	JobName        string   `json:"jobName,omitempty"`
-	JobStatus      string   `json:"jobStatus,omitempty"`
-	LogLink        string   `json:"logLink,omitempty"`
-	MonitoringURLs []string `json:"monitoringUrls,omitempty"`
-	Project        string   `json:"project,omitempty"`
-	ProjectID      *uint    `json:"projectId,omitempty"`
-	ProjectName    string   `json:"projectName,omitempty"`
-	RemoteID       string   `json:"remoteId,omitempty"`
-	Route          string   `json:"route,omitempty"`
-	Routes         []string `json:"routes,omitempty"`
-	StartTime      string   `json:"startTime,omitempty"`
-	Services       []string `json:"services,omitempty"`
-	Key            string   `json:"key,omitempty"`
-	AdvancedData   string   `json:"advancedData,omitempty"`
-	Cluster        string   `json:"clusterName,omitempty"`
+	BranchName    string   `json:"branchName,omitempty"`
+	BuildName     string   `json:"buildName,omitempty"`
+	BuildPhase    string   `json:"buildPhase,omitempty"`
+	EndTime       string   `json:"endTime,omitempty"`
+	Environment   string   `json:"environment,omitempty"`
+	EnvironmentID *uint    `json:"environmentId,omitempty"`
+	JobName       string   `json:"jobName,omitempty"`
+	JobStatus     string   `json:"jobStatus,omitempty"`
+	LogLink       string   `json:"logLink,omitempty"`
+	Project       string   `json:"project,omitempty"`
+	ProjectID     *uint    `json:"projectId,omitempty"`
+	ProjectName   string   `json:"projectName,omitempty"`
+	RemoteID      string   `json:"remoteId,omitempty"`
+	Route         string   `json:"route,omitempty"`
+	Routes        []string `json:"routes,omitempty"`
+	StartTime     string   `json:"startTime,omitempty"`
+	Services      []string `json:"services,omitempty"`
+	Key           string   `json:"key,omitempty"`
+	AdvancedData  string   `json:"advancedData,omitempty"`
+	Cluster       string   `json:"clusterName,omitempty"`
 }
 
 type LagoonLog struct {

--- a/services/workflows/internal/lagoonclient/schema.graphql
+++ b/services/workflows/internal/lagoonclient/schema.graphql
@@ -765,7 +765,6 @@ type Environment {
   envVariables: [EnvKeyValue]
   route: String
   routes: String
-  monitoringUrls: String
   deployments(name: String, limit: Int): [Deployment]
   backups(includeDeleted: Boolean, limit: Int): [Backup]
   tasks(id: Int, limit: Int): [Task]
@@ -1940,7 +1939,6 @@ input UpdateEnvironmentPatchInput {
   kubernetesNamespaceName: String
   route: String
   routes: String
-  monitoringUrls: String
   autoIdle: Int
   openshift: Int
   openshiftProjectPattern: String


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Removes the storage and usage of `monitoringUrls` in the api. The schema hasn't changed, we just return `null` all the time now. Also removes usage in actions-handler and workflows services.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Part of #2975 
