### PR TITLE
change: task visibility improvements and changes to admin tasks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     #   - NEW_RELIC_LICENSE_KEY=
     #   - NEW_RELIC_APP_NAME=api-local
   ui:
-    image: uselagoon/ui:main
+    image: uselagoon/ui:pr-102
     command: yarn run dev
     environment:
       - NODE_ENV=development

--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -542,6 +542,69 @@ mutation PopulateApi {
     id
   }
 
+  UIProjectAdvancedTask1: addAdvancedTaskDefinition(
+    input:{
+      name: "Admin only task"
+      description: "A task that only admins can see and run (logs also only visible to admin)"
+      type: COMMAND
+      service: "cli"
+      command: "env"
+      permission: MAINTAINER
+      project: 18
+      adminOnlyView: true
+      deployTokenInjection: true
+      projectKeyInjection: true
+    }
+  ){
+    ... on AdvancedTaskDefinitionCommand {
+      id
+      name
+      description
+      service
+      command
+    }
+  }
+
+  UIProjectAdvancedTask2: addAdvancedTaskDefinition(
+    input:{
+      name: "Mainter task"
+      description: "A task that maintainers can run"
+      type: COMMAND
+      service: "cli"
+      command: "env"
+      permission: MAINTAINER
+      project: 18
+    }
+  ){
+    ... on AdvancedTaskDefinitionCommand {
+      id
+      name
+      description
+      service
+      command
+    }
+  }
+
+  UIProjectAdvancedTask3: addAdvancedTaskDefinition(
+    input:{
+      name: "Developer task"
+      description: "A task that developers can run"
+      type: COMMAND
+      service: "cli"
+      command: "env"
+      permission: DEVELOPER
+      project: 18
+    }
+  ){
+    ... on AdvancedTaskDefinitionCommand {
+      id
+      name
+      description
+      service
+      command
+    }
+  }
+
   UIProject1Environment1addServices: setEnvironmentServices(input:{environment:3, services:["cli", "nginx", "mariadb"]}) {
     id
   }

--- a/services/api/database/migrations/20230207210000_task_admin_fields.js
+++ b/services/api/database/migrations/20230207210000_task_admin_fields.js
@@ -1,0 +1,30 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('task', (table) => {
+        table.boolean('admin_task').notNullable().defaultTo(0);
+        table.boolean('admin_only_view').notNullable().defaultTo(0);
+    })
+    .alterTable('advanced_task_definition', (table) => {
+        table.dropColumn('show_ui');
+        table.boolean('admin_only_view').notNullable().defaultTo(0);
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('task', (table) => {
+        table.dropColumn('admin_task');
+        table.dropColumn('admin_only_view');
+    })
+    .alterTable('advanced_task_definition', (table) => {
+        table.dropColumn('admin_only_view');
+    })
+};

--- a/services/api/database/migrations/20230207210000_task_admin_fields.js
+++ b/services/api/database/migrations/20230207210000_task_admin_fields.js
@@ -5,12 +5,16 @@
 exports.up = async function(knex) {
     return knex.schema
     .alterTable('task', (table) => {
-        table.boolean('admin_task').notNullable().defaultTo(0);
         table.boolean('admin_only_view').notNullable().defaultTo(0);
+        table.boolean('deploy_token_injection').notNullable().defaultTo(0);
+        table.boolean('project_key_injection').notNullable().defaultTo(0);
     })
     .alterTable('advanced_task_definition', (table) => {
         table.dropColumn('show_ui');
+        table.dropColumn('admin_task');
         table.boolean('admin_only_view').notNullable().defaultTo(0);
+        table.boolean('deploy_token_injection').notNullable().defaultTo(0);
+        table.boolean('project_key_injection').notNullable().defaultTo(0);
     })
 };
 
@@ -21,10 +25,13 @@ exports.up = async function(knex) {
 exports.down = async function(knex) {
     return knex.schema
     .alterTable('task', (table) => {
-        table.dropColumn('admin_task');
         table.dropColumn('admin_only_view');
+        table.dropColumn('deploy_token_injection');
+        table.dropColumn('project_key_injection');
     })
     .alterTable('advanced_task_definition', (table) => {
         table.dropColumn('admin_only_view');
+        table.dropColumn('deploy_token_injection');
+        table.dropColumn('project_key_injection');
     })
 };

--- a/services/api/src/resources/task/filters.ts
+++ b/services/api/src/resources/task/filters.ts
@@ -1,0 +1,26 @@
+import * as R from 'ramda';
+
+export const Filters = {
+    filterAdminTasks: async (hasPermission, rows) => {
+        let adminTasks = false
+        // do a check of all returned tasks for any that are admin tasks
+        for (const row of rows) {
+          if (row.adminOnlyView == true) {
+            adminTasks = true;
+            break;
+          }
+        }
+
+        // if any of the tasks are admin tasks, check the user has admin permission
+        if (adminTasks) {
+          // we do this so we only check admin permission once, instead of on all tasks
+          try {
+            await hasPermission('project', 'viewAll');
+          } catch (err) {
+            return rows.filter((row) => row.adminOnlyView != true);
+          }
+        }
+        // else we simply return the rows untouched
+        return rows;
+    }
+}

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -23,6 +23,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
     service,
     command,
     remoteId,
+    adminTask,
+    adminOnlyView,
     execute
   }: {
     id?: number;
@@ -36,6 +38,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
     service: string;
     command: string;
     remoteId?: string;
+    adminTask: boolean;
+    adminOnlyView: boolean;
     execute: boolean;
   }) => {
     const { insertId } = await query(
@@ -51,6 +55,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
         environment,
         service,
         command,
+        adminTask,
+        adminOnlyView,
         remoteId,
       }),
     );
@@ -114,6 +120,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       remoteId,
       execute,
       adminTask,
+      adminOnlyView,
     }: {
       id?: number,
       name: string,
@@ -129,6 +136,7 @@ export const Helpers = (sqlClientPool: Pool) => ({
       remoteId?: string,
       execute: boolean,
       adminTask: boolean,
+      adminOnlyView: boolean,
     },
   ) => {
     let rows = await query(
@@ -157,6 +165,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
         environment,
         service,
         command: image,
+        adminTask,
+        adminOnlyView,
         remoteId,
         type: 'advanced',
         advanced_image: image,

--- a/services/api/src/resources/task/helpers.ts
+++ b/services/api/src/resources/task/helpers.ts
@@ -23,7 +23,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
     service,
     command,
     remoteId,
-    adminTask,
+    deployTokenInjection,
+    projectKeyInjection,
     adminOnlyView,
     execute
   }: {
@@ -38,7 +39,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
     service: string;
     command: string;
     remoteId?: string;
-    adminTask: boolean;
+    deployTokenInjection: boolean;
+    projectKeyInjection: boolean;
     adminOnlyView: boolean;
     execute: boolean;
   }) => {
@@ -55,7 +57,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
         environment,
         service,
         command,
-        adminTask,
+        deployTokenInjection,
+        projectKeyInjection,
         adminOnlyView,
         remoteId,
       }),
@@ -119,7 +122,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload = {},
       remoteId,
       execute,
-      adminTask,
+      deployTokenInjection,
+      projectKeyInjection,
       adminOnlyView,
     }: {
       id?: number,
@@ -135,7 +139,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
       payload: object,
       remoteId?: string,
       execute: boolean,
-      adminTask: boolean,
+      deployTokenInjection: boolean,
+      projectKeyInjection: boolean,
       adminOnlyView: boolean,
     },
   ) => {
@@ -165,7 +170,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
         environment,
         service,
         command: image,
-        adminTask,
+        deployTokenInjection,
+        projectKeyInjection,
         adminOnlyView,
         remoteId,
         type: 'advanced',
@@ -188,8 +194,8 @@ export const Helpers = (sqlClientPool: Pool) => ({
       advancedTask: {
         RunnerImage: image,
         JSONPayload: new Buffer(JSON.stringify(payload).replace(/\\n/g, "\n")).toString('base64'),
-        deployerToken: adminTask, //an admintask will have a deployer token and ssh key injected into it
-        sshKey: adminTask,
+        deployerToken: deployTokenInjection, //an admintask will have a deployer token and ssh key injected into it
+        sshKey: projectKeyInjection,
       }
     }
 

--- a/services/api/src/resources/task/models/taskRegistration.ts
+++ b/services/api/src/resources/task/models/taskRegistration.ts
@@ -38,7 +38,8 @@ export interface AdvancedTaskDefinitionInterface {
   command?: string;
   service?: string;
   image?: string;
-  adminTask?: boolean;
+  deployTokenInjection?: boolean;
+  projectKeyInjection?: boolean;
   adminOnlyView?: boolean;
   advancedTaskDefinitionArguments?: Partial<AdvancedTaskDefinitionArguments>;
 }

--- a/services/api/src/resources/task/models/taskRegistration.ts
+++ b/services/api/src/resources/task/models/taskRegistration.ts
@@ -38,8 +38,8 @@ export interface AdvancedTaskDefinitionInterface {
   command?: string;
   service?: string;
   image?: string;
-  showUi?: number;
-  adminTask?: number;
+  adminTask?: boolean;
+  adminOnlyView?: boolean;
   advancedTaskDefinitionArguments?: Partial<AdvancedTaskDefinitionArguments>;
 }
 

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -131,9 +131,6 @@ export const getTasksByEnvironmentId: ResolverFn = async (
   let adminTasks = false
   // do a check of all returned tasks for any that are admin tasks
   for (const row of rows) {
-    if (row.adminTask == true) {
-      adminTasks = true
-    }
     if (row.adminOnlyView == true) {
       adminTasks = true
     }
@@ -146,7 +143,7 @@ export const getTasksByEnvironmentId: ResolverFn = async (
     } catch (err) {
       for (const row in rows) {
         // then remove any admintasks from the result
-        if (rows.hasOwnProperty(row) && rows[row].adminTask == true) {
+        if (rows.hasOwnProperty(row) && rows[row].adminOnlyView == true) {
             delete rows[row];
         }
       }
@@ -172,7 +169,7 @@ export const getTaskByTaskName: ResolverFn = async (
   }
 
   const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
-  if (R.path(['0', 'admin_only_view'], rowsPerms) || R.path(['0', 'admin_task'], rowsPerms)) {
+  if (R.path(['0', 'admin_only_view'], rowsPerms)) {
     await hasPermission('project', 'viewAll');
   } else {
     await hasPermission('task', 'view', {
@@ -200,7 +197,7 @@ export const getTaskByRemoteId: ResolverFn = async (
   }
 
   const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
-  if (R.path(['0', 'admin_only_view'], rowsPerms) || R.path(['0', 'admin_task'], rowsPerms)) {
+  if (R.path(['0', 'admin_only_view'], rowsPerms)) {
     await hasPermission('project', 'viewAll');
   } else {
     await hasPermission('task', 'view', {
@@ -228,7 +225,7 @@ export const getTaskById: ResolverFn = async (
   }
 
   const rowsPerms = await query(sqlClientPool, Sql.selectPermsForTask(task.id));
-  if (R.path(['0', 'admin_only_view'], rowsPerms) || R.path(['0', 'admin_task'], rowsPerms)) {
+  if (R.path(['0', 'admin_only_view'], rowsPerms)) {
     await hasPermission('project', 'viewAll');
   } else {
     await hasPermission('task', 'view', {
@@ -253,7 +250,8 @@ export const addTask: ResolverFn = async (
       service,
       command,
       remoteId,
-      adminTask,
+      deployTokenInjection,
+      projectKeyInjection,
       adminOnlyView,
       execute: executeRequest
     }
@@ -313,7 +311,8 @@ export const addTask: ResolverFn = async (
     service,
     command,
     remoteId,
-    adminTask,
+    deployTokenInjection,
+    projectKeyInjection,
     adminOnlyView,
     execute
   });
@@ -361,7 +360,7 @@ export const updateTask: ResolverFn = async (
         environment,
         service,
         command,
-        adminTask,
+        deployTokenInjection,
         remoteId
       }
     }
@@ -401,7 +400,7 @@ export const updateTask: ResolverFn = async (
         environment,
         service,
         command,
-        adminTask,
+        deployTokenInjection,
         remoteId
       }
     })
@@ -425,7 +424,7 @@ export const updateTask: ResolverFn = async (
         environment,
         service,
         command,
-        adminTask,
+        deployTokenInjection,
         remoteId
       }
     }
@@ -473,7 +472,8 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
     environment: environmentId,
     service: 'cli',
     command,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -521,7 +521,8 @@ TOKEN="$(ssh -p $TASK_SSH_PORT -t lagoon@$TASK_SSH_HOST token)" && curl -sS "$TA
     environment: environmentId,
     service: 'cli',
     command,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -571,7 +572,8 @@ export const taskDrushCacheClear: ResolverFn = async (
     environment: environmentId,
     service: 'cli',
     command,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -610,7 +612,8 @@ export const taskDrushCron: ResolverFn = async (
     environment: environmentId,
     service: 'cli',
     command: `drush cron`,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -681,7 +684,8 @@ export const taskDrushSqlSync: ResolverFn = async (
     environment: destinationEnvironmentId,
     service: 'cli',
     command: command,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -752,7 +756,8 @@ export const taskDrushRsyncFiles: ResolverFn = async (
     environment: destinationEnvironmentId,
     service: 'cli',
     command: command,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });
@@ -791,7 +796,8 @@ export const taskDrushUserLogin: ResolverFn = async (
     environment: environmentId,
     service: 'cli',
     command: `drush uli`,
-    adminTask: false,
+    deployTokenInjection: false,
+    projectKeyInjection: false,
     adminOnlyView: false,
     execute: true
   });

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -171,7 +171,8 @@ export const Sql = {
         .toString(),
     selectTaskRegistrationsByEnvironmentId:(id: number) =>
       knex('advanced_task_definition')
-        .select('advanced_task_definition.*', 'task_registration.id')
+        // .select('advanced_task_definition.*', 'task_registration.id')
+        .select(knex.raw(`advanced_task_definition.*, task_registration.id, advanced_task_definition.admin_only_view XOR 1 as "advanced_task_definition.show_ui", advanced_task_definition.deploy_token_injection as "advanced_task_definition.admin_task"`)) //use admin_only_view as show_ui for backwards compatability
         .join('task_registration', 'task_registration.advanced_task_definition', '=', 'advanced_task_definition.id')
         .where('task_registration.environment', '=', id)
         .toString(),
@@ -182,7 +183,7 @@ export const Sql = {
         .toString(),
     selectAdvancedTaskDefinition:(id: number) =>
       knex('advanced_task_definition')
-        // .select(knex.raw(`*, true as "show_ui"`)) //synthetic true
+        .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
         .where('advanced_task_definition.id', '=', id)
         .toString(),
     selectAdvancedTaskDefinitionArguments:(id: number) =>
@@ -200,7 +201,7 @@ export const Sql = {
         .toString(),
     selectAdvancedTaskDefinitionByName:(name: string) =>
       knex('advanced_task_definition')
-        // .select(knex.raw(`*, true as "show_ui"`))
+      .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
         .where('advanced_task_definition.name', '=', name)
         .toString(),
     selectAdvancedTaskDefinitionByNameProjectEnvironmentAndGroup:(name: string, project: number, environment: number, group: string) => {
@@ -219,21 +220,21 @@ export const Sql = {
     },
   selectAdvancedTaskDefinitions:() =>
     knex('advanced_task_definition')
-    // .select(knex.raw(`*, true as "show_ui"`))
+    .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
     .toString(),
   selectAdvancedTaskDefinitionsForEnvironment:(id: number) =>
     knex('advanced_task_definition')
-    // .select(knex.raw(`*, true as "show_ui"`))
+    .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
     .where('environment', '=', id)
     .toString(),
   selectAdvancedTaskDefinitionsForProject:(id: number) =>
     knex('advanced_task_definition')
-    // .select(knex.raw(`*, true as "show_ui"`))
+    .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
     .where('project', '=', id)
     .toString(),
   selectAdvancedTaskDefinitionsForGroups:(groups) =>
     knex('advanced_task_definition')
-    // .select(knex.raw(`*, true as "show_ui"`))
+    .select(knex.raw(`*, advanced_task_definition.admin_only_view XOR 1 as "show_ui", advanced_task_definition.deploy_token_injection as "admin_task"`)) //use admin_only_view as show_ui for backwards compatability
     .where('group_name', 'in', groups)
     .toString(),
   deleteAdvancedTaskDefinition:(id: number) =>

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -17,7 +17,8 @@ export const Sql = {
     service,
     command,
     remoteId,
-    adminTask,
+    deployTokenInjection,
+    projectKeyInjection,
     adminOnlyView,
     type = null,
     advanced_image = null,
@@ -34,7 +35,8 @@ export const Sql = {
     service: string;
     command: string;
     remoteId: string;
-    adminTask: boolean;
+    deployTokenInjection: boolean;
+    projectKeyInjection: boolean;
     adminOnlyView: boolean;
     type?: string;
     advanced_image?: string;
@@ -52,7 +54,8 @@ export const Sql = {
         environment,
         service,
         command,
-        adminTask,
+        deployTokenInjection,
+        projectKeyInjection,
         adminOnlyView,
         remoteId,
         type,
@@ -72,7 +75,7 @@ export const Sql = {
       .toString(),
   selectPermsForTask: (id: number) =>
     knex('task')
-      .select({ pid: 'environment.project', adminOnlyView: 'task.admin_only_view', adminTask: 'task.admin_task' })
+      .select({ pid: 'environment.project', adminOnlyView: 'task.admin_only_view', deployTokenInjection: 'task.deploy_token_injection', projectKeyInjection: 'task.project_key_injection' })
       .join('environment', 'task.environment', '=', 'environment.id')
       .where('task.id', id)
       .toString(),
@@ -90,7 +93,8 @@ export const Sql = {
     environment,
     permission,
     confirmation_text,
-    admin_task,
+    deploy_token_injection,
+    project_key_injection,
     admin_only_view,
     }: {
       id: number,
@@ -106,7 +110,8 @@ export const Sql = {
       environment: number,
       permission: string,
       confirmation_text: string,
-      admin_task: boolean,
+      deploy_token_injection: boolean,
+      project_key_injection: boolean,
       admin_only_view: boolean,
     }) =>
     knex('advanced_task_definition')
@@ -124,7 +129,8 @@ export const Sql = {
         environment,
         permission,
         confirmation_text,
-        admin_task,
+        deploy_token_injection,
+        project_key_injection,
         admin_only_view,
       })
     .toString(),

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -17,6 +17,8 @@ export const Sql = {
     service,
     command,
     remoteId,
+    adminTask,
+    adminOnlyView,
     type = null,
     advanced_image = null,
     advanced_payload = null,
@@ -32,6 +34,8 @@ export const Sql = {
     service: string;
     command: string;
     remoteId: string;
+    adminTask: boolean;
+    adminOnlyView: boolean;
     type?: string;
     advanced_image?: string;
     advanced_payload?: string;
@@ -48,6 +52,8 @@ export const Sql = {
         environment,
         service,
         command,
+        adminTask,
+        adminOnlyView,
         remoteId,
         type,
         advanced_image,
@@ -66,7 +72,7 @@ export const Sql = {
       .toString(),
   selectPermsForTask: (id: number) =>
     knex('task')
-      .select({ pid: 'environment.project' })
+      .select({ pid: 'environment.project', adminOnlyView: 'task.admin_only_view', adminTask: 'task.admin_task' })
       .join('environment', 'task.environment', '=', 'environment.id')
       .where('task.id', id)
       .toString(),
@@ -84,8 +90,8 @@ export const Sql = {
     environment,
     permission,
     confirmation_text,
-    show_ui,
     admin_task,
+    admin_only_view,
     }: {
       id: number,
       name: string,
@@ -100,8 +106,8 @@ export const Sql = {
       environment: number,
       permission: string,
       confirmation_text: string,
-      show_ui: number,
-      admin_task: number,
+      admin_task: boolean,
+      admin_only_view: boolean,
     }) =>
     knex('advanced_task_definition')
       .insert({
@@ -118,8 +124,8 @@ export const Sql = {
         environment,
         permission,
         confirmation_text,
-        show_ui,
         admin_task,
+        admin_only_view,
       })
     .toString(),
     insertAdvancedTaskDefinitionArgument: ({
@@ -170,6 +176,7 @@ export const Sql = {
         .toString(),
     selectAdvancedTaskDefinition:(id: number) =>
       knex('advanced_task_definition')
+        // .select(knex.raw(`*, true as "show_ui"`)) //synthetic true
         .where('advanced_task_definition.id', '=', id)
         .toString(),
     selectAdvancedTaskDefinitionArguments:(id: number) =>
@@ -187,6 +194,7 @@ export const Sql = {
         .toString(),
     selectAdvancedTaskDefinitionByName:(name: string) =>
       knex('advanced_task_definition')
+        // .select(knex.raw(`*, true as "show_ui"`))
         .where('advanced_task_definition.name', '=', name)
         .toString(),
     selectAdvancedTaskDefinitionByNameProjectEnvironmentAndGroup:(name: string, project: number, environment: number, group: string) => {
@@ -205,17 +213,21 @@ export const Sql = {
     },
   selectAdvancedTaskDefinitions:() =>
     knex('advanced_task_definition')
+    // .select(knex.raw(`*, true as "show_ui"`))
     .toString(),
   selectAdvancedTaskDefinitionsForEnvironment:(id: number) =>
     knex('advanced_task_definition')
+    // .select(knex.raw(`*, true as "show_ui"`))
     .where('environment', '=', id)
     .toString(),
   selectAdvancedTaskDefinitionsForProject:(id: number) =>
     knex('advanced_task_definition')
+    // .select(knex.raw(`*, true as "show_ui"`))
     .where('project', '=', id)
     .toString(),
   selectAdvancedTaskDefinitionsForGroups:(groups) =>
     knex('advanced_task_definition')
+    // .select(knex.raw(`*, true as "show_ui"`))
     .where('group_name', 'in', groups)
     .toString(),
   deleteAdvancedTaskDefinition:(id: number) =>

--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -400,6 +400,9 @@ export const updateAdvancedTaskDefinition = async (
         permission,
         advancedTaskDefinitionArguments,
         confirmationText,
+        deployTokenInjection,
+        projectKeyInjection,
+        adminOnlyView,
       }
     }
   },
@@ -439,6 +442,9 @@ export const updateAdvancedTaskDefinition = async (
         service,
         permission,
         confirmation_text: confirmationText,
+        deploy_token_injection: deployTokenInjection,
+        project_key_injection: projectKeyInjection,
+        admin_only_view: adminOnlyView,
       }
     })
   );

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -158,6 +158,8 @@ const typeDefs = gql`
     deployTokenInjection: Boolean
     projectKeyInjection: Boolean
     adminOnlyView: Boolean
+    showUi: Boolean @deprecated(reason: "Use adminOnlyView instead")
+    adminTask: Boolean @deprecated(reason: "Use deployTokenInjection and projectKeyInjection instead")
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -178,6 +180,8 @@ const typeDefs = gql`
     deployTokenInjection: Boolean
     projectKeyInjection: Boolean
     adminOnlyView: Boolean
+    showUi: Boolean @deprecated(reason: "Use adminOnlyView instead")
+    adminTask: Boolean @deprecated(reason: "Use deployTokenInjection and projectKeyInjection instead")
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -1448,6 +1452,9 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
+    deployTokenInjection: Boolean
+    projectKeyInjection: Boolean
+    adminOnlyView: Boolean
   }
 
   input DeleteTaskInput {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -155,7 +155,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
-    adminTask: Boolean
+    deployTokenInjection: Boolean
+    projectKeyInjection: Boolean
     adminOnlyView: Boolean
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
@@ -174,7 +175,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
-    adminTask: Boolean
+    deployTokenInjection: Boolean
+    projectKeyInjection: Boolean
     adminOnlyView: Boolean
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
@@ -958,7 +960,8 @@ const typeDefs = gql`
     environment: Environment
     service: String
     command: String
-    adminTask: Boolean
+    deployTokenInjection: Boolean
+    projectKeyInjection: Boolean
     adminOnlyView: Boolean
     remoteId: String
     logs: String
@@ -1422,7 +1425,8 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
-    adminTask: Boolean
+    deployTokenInjection: Boolean
+    projectKeyInjection: Boolean
     adminOnlyView: Boolean
   }
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -155,8 +155,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
-    showUi: Int
-    adminTask: Int
+    adminTask: Boolean
+    adminOnlyView: Boolean
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -174,8 +174,8 @@ const typeDefs = gql`
     environment: Int
     project: Int
     permission: TaskPermission
-    showUi: Int
-    adminTask: Int
+    adminTask: Boolean
+    adminOnlyView: Boolean
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
     created: String
     deleted: String
@@ -958,6 +958,8 @@ const typeDefs = gql`
     environment: Environment
     service: String
     command: String
+    adminTask: Boolean
+    adminOnlyView: Boolean
     remoteId: String
     logs: String
     files: [File]
@@ -1420,8 +1422,8 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
-    showUi: Int
-    adminTask: Int
+    adminTask: Boolean
+    adminOnlyView: Boolean
   }
 
   input UpdateAdvancedTaskDefinitionInput {
@@ -1442,7 +1444,6 @@ const typeDefs = gql`
     permission: TaskPermission
     advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
     confirmationText: String
-    showUi: Int
   }
 
   input DeleteTaskInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

The current showUi implementation processes what can be seen in the UI, it only hides the options from the dropdown menu, but doesn't prevent them from being shown elsewhere. It also doesn't prevent the logs for these tasks being hidden.

This moves all the hiding functionality to behind RBAC in the API.

It removes `showUi` and creates `adminOnlyView` instead. These are used by resolvers to check if the user is admin or not, and will filter out tasks in resolvers if these are set to true.

Setting `adminOnlyView` to true on a task will hide this task from the drop down menu, and also hide the item in the task view thus preventing access to the logs for non-admin users.

`adminTask` is split into:
* `deployTokenInjection`, as this is used as an identifier to inject the lagoon-deployer token into tasks. Only admins can set this flag.
* `projectKeyInjection` as a second option, this can be used to control the injection of the projects ssh key used for tasks etc.

It leaves `showUi` and `adminTask`, but these reflect the value of the replacements to an extent.
* showUi is the inverted value of adminViewOnly
* adminTask is the same as deployTokenInjection

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3392 
