### PR TITLE
feature: support for disabling a deploytarget

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -463,6 +463,7 @@ mutation PopulateApi {
     input: {
       name: "build-1"
       status: COMPLETE
+      remoteId: "86358316-a755-11ed-8206-032901f4c7e3"
       environment: 3
       created: "2018-10-07 23:02:41"
       started: "2018-10-07 23:03:41"
@@ -474,6 +475,7 @@ mutation PopulateApi {
   UIProject1Environment1addDeployment2: addDeployment(
     input: {
       name: "build-2"
+      remoteId: "85e36e3c-a755-11ed-abf6-df28d8a74109"
       status: FAILED
       environment: 3
       created: "2018-10-07 23:02:41"
@@ -486,6 +488,7 @@ mutation PopulateApi {
   UIProject1Environment1addDeployment3: addDeployment(
     input: {
       name: "build-3"
+      remoteId: "84e1dc8a-a755-11ed-a37d-770f36aa3d4e"
       status: RUNNING
       environment: 3
       created: "2018-10-07 23:02:41"

--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -1084,6 +1084,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
           routerPattern
           monitoringConfig
           buildImage
+          disabled
         }
         autoIdle
         branches
@@ -1130,6 +1131,7 @@ export const getDeployTargetConfigsForProject = (project: number): Promise<any> 
           routerPattern
           monitoringConfig
           buildImage
+          disabled
         }
       }
     }
@@ -1151,6 +1153,7 @@ export const getOpenShiftInfoForEnvironment = (environment: number): Promise<any
           routerPattern
           monitoringConfig
           buildImage
+          disabled
         }
         project {
           envVariables {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -143,6 +143,13 @@ class NoNeedToRemoveBranch extends Error {
   }
 }
 
+class DeployTargetDisabled extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'DeployTargetDisabled';
+  }
+}
+
 class CannotDeleteProductionEnvironment extends Error {
   constructor(message) {
     super(message);
@@ -480,6 +487,11 @@ export const getControllerBuildData = async function(deployData: any) {
   }
   // end working out the target information
   let openshiftId = deployTarget.openshift.id;
+
+  if (deployTarget.openshift.disabled) {
+    logger.error(`Couldn't deploy environment, the selected deploytarget '${deployTarget.openshift.name}' is disabled`)
+    throw new DeployTargetDisabled(`Couldn't deploy environment, the selected deploytarget '${deployTarget.openshift.name}' is disabled`)
+  }
 
   var openshiftProject = openshiftProjectPattern ? openshiftProjectPattern.replace('${environment}',environmentName).replace('${project}', projectName) : `${projectName}-${environmentName}`
 

--- a/services/api/database/migrations/20230208080000_disabled_deploytargets.js
+++ b/services/api/database/migrations/20230208080000_disabled_deploytargets.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('openshift', (table) => {
+        table.boolean('disabled').notNullable().defaultTo(0);
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('openshift', (table) => {
+        table.dropColumn('disabled');
+    })
+};

--- a/services/api/src/resources/deployment/sql.ts
+++ b/services/api/src/resources/deployment/sql.ts
@@ -63,6 +63,10 @@ export const Sql = {
       .where('id', id)
       .update(patch)
       .toString(),
+  selectDeployTarget: (id: number) =>
+    knex('openshift')
+      .where('id', '=', id)
+      .toString(),
   selectPermsForDeployment: (id: number) =>
     knex('deployment')
       .select({ pid: 'environment.project' })

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -491,6 +491,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   type Kubernetes {
@@ -508,6 +509,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   type NotificationMicrosoftTeams {
@@ -1484,6 +1486,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   input AddKubernetesInput {
@@ -1503,6 +1506,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   input DeleteOpenshiftInput {
@@ -1656,6 +1660,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   input UpdateOpenshiftInput {
@@ -1679,6 +1684,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    disabled: Boolean
   }
 
   input UpdateKubernetesInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

If a deploytarget (openshift/kubernetes) is no longer used, but remains in the API for historical purposes, there is now a flag to mark it as `disabled`.

This will prevent new builds from being started on it, but it also allows for builds that were started on it that are still new, pending, or running, to be cancelled if the disabled flag is set.

If a user attempts to deploy via the CLI they will receive an error.
```
$ lagoon -l local deploy latest -p high-cotton -e Master
✔ Yes
Error: Couldn't deploy environment, the selected deploytarget 'ui-openshift' is disabled
```

Cancelling an existing running deployment on a disabled deploytarget will update the status of that deployment to cancelled and populate the build log with a message to indicate why it was cancelled.
![image](https://user-images.githubusercontent.com/9973880/217414764-2b4884dd-b078-4b6f-ab88-caecafb6a50d.png)

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

I thought there was an issue for this, but I can't find it
