### PR TITLE
Fix insecure registries running k3d/test on docker desktop for mac

### DIFF
--- a/k3d.config.yaml.tpl
+++ b/k3d.config.yaml.tpl
@@ -19,7 +19,7 @@ registries:
     configs:
         "registry.${K3D_NODE_IP}.nip.io:32080":
             tls:
-            insecure_skip_verify: true
+              insecure_skip_verify: true
 options:
   k3s: # options passed on to K3s itself
     extraArgs: # additional arguments passed to the `k3s server|agent` command; same as `--k3s-arg`


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Some minor fixes to the Makefile to fix running `k3d/test` on Docker Desktop for Mac. Fixes insecure registries and cleans up the k3d proxy.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
