### PR TITLE
change: use knex instead of raw for envvars

### DIFF
--- a/services/api/database/migrations/20230227080000_envvar_index.js
+++ b/services/api/database/migrations/20230227080000_envvar_index.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('env_vars', (table) => {
+        table.index('environment', 'environment_index');
+        table.index('project', 'project_index');
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('env_vars', (table) => {
+        table.dropIndex('environment', 'environment_index');
+        table.dropIndex('project', 'project_index');
+    })
+};

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -20,11 +20,7 @@ export const getEnvVarsByProjectId: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    `SELECT ev.*
-    FROM env_vars ev
-    JOIN project p ON ev.project = p.id
-    WHERE ev.project = :pid`,
-    { pid }
+    Sql.selectEnvVarsByProjectId(pid)
   );
 
   return rows;
@@ -49,12 +45,7 @@ export const getEnvVarsByEnvironmentId: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    `SELECT ev.*
-    FROM env_vars ev
-    JOIN environment e on ev.environment = e.id
-    JOIN project p ON e.project = p.id
-    WHERE ev.environment = :eid`,
-    { eid }
+    Sql.selectEnvVarsByEnvironmentId(eid)
   );
 
   return rows;

--- a/services/api/src/resources/env-variables/sql.ts
+++ b/services/api/src/resources/env-variables/sql.ts
@@ -45,28 +45,24 @@ export const Sql = {
   selectEnvVarByNameAndProjectId: (name: string, projectId: number) =>
     knex('env_vars')
       .select('env_vars.*')
-      .leftJoin('project', 'env_vars.project', '=', 'project.id')
       .where('env_vars.name', '=', name)
       .andWhere('env_vars.project', '=', projectId)
       .toString(),
   selectEnvVarByNameAndEnvironmentId: (name: string,  environmentId: number) =>
     knex('env_vars')
       .select('env_vars.*')
-      .leftJoin('environment', 'env_vars.environment', '=', 'environment.id')
       .where('env_vars.name', '=', name)
       .andWhere('env_vars.environment', '=', environmentId)
       .toString(),
   selectEnvVarsByProjectId: (projectId: number) =>
     knex('env_vars')
       .select('env_vars.*')
-      .leftJoin('project', 'env_vars.project', '=', 'project.id')
       .where('env_vars.project', '=', projectId)
       .orderBy('env_vars.name', 'asc')
       .toString(),
   selectEnvVarsByEnvironmentId: (environmentId: number) =>
     knex('env_vars')
       .select('env_vars.*')
-      .leftJoin('environment', 'env_vars.environment', '=', 'environment.id')
       .where('env_vars.environment', '=', environmentId)
       .orderBy('env_vars.name', 'asc')
       .toString(),


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just a simple fix to change the envvar by project and environment id resolvers to use knex instead of raw

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
