### PR TITLE
feat: extend webhook notification with buildname, loglink, and routes

### DIFF
--- a/services/logs2notifications/internal/handler/testdata/deployError/webhook.txt
+++ b/services/logs2notifications/internal/handler/testdata/deployError/webhook.txt
@@ -1,1 +1,1 @@
-{"type":"DEPLOYMENT","event":"task:builddeploy-kubernetes:failed","project":"ci-github-openshift","environment":"lagoon-type-override"}
+{"type":"DEPLOYMENT","event":"task:builddeploy-kubernetes:failed","project":"ci-github-openshift","environment":"lagoon-type-override","buildName":"lagoon-build-1234","logLink":"https://logs"}

--- a/services/logs2notifications/internal/handler/testdata/deployFinished/webhook.txt
+++ b/services/logs2notifications/internal/handler/testdata/deployFinished/webhook.txt
@@ -1,1 +1,1 @@
-{"type":"DEPLOYMENT","event":"task:deploy-openshift:finished","project":"ci-github-openshift","environment":"lagoon-type-override"}
+{"type":"DEPLOYMENT","event":"task:deploy-openshift:finished","project":"ci-github-openshift","environment":"lagoon-type-override","buildName":"lagoon-build-1234","route":"https://route1","routes":["https://route1","https://route2","https://route3"],"logLink":"https://logs"}

--- a/services/logs2notifications/internal/handler/webhook_events.go
+++ b/services/logs2notifications/internal/handler/webhook_events.go
@@ -13,10 +13,14 @@ import (
 
 // WebhookData .
 type WebhookData struct {
-	Type        string `json:"type"`
-	Event       string `json:"event"`
-	Project     string `json:"project"`
-	Environment string `json:"environment"`
+	Type        string   `json:"type"`
+	Event       string   `json:"event"`
+	Project     string   `json:"project"`
+	Environment string   `json:"environment"`
+	BuildName   string   `json:"buildName,omitempty"`
+	Route       string   `json:"route,omitempty"`
+	Routes      []string `json:"routes,omitempty"`
+	LogLink     string   `json:"logLink,omitempty"`
 }
 
 // SendToWebhook .
@@ -66,6 +70,10 @@ func (h *Messaging) processWebhookTemplate(notification *Notification) (*Webhook
 		Event:       notification.Event,
 		Project:     notification.Meta.ProjectName,
 		Environment: notification.Meta.BranchName,
+		BuildName:   notification.Meta.BuildName,
+		Route:       notification.Meta.Route,
+		Routes:      notification.Meta.Routes,
+		LogLink:     notification.Meta.LogLink,
 	}
 
 	switch tpl {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

The webhook notification payload currently contains a small amount of information relating to the project and environment. This PR extends the payload to contain more information like the `buildName`, the `route` and `routes`, and `logLink`. Similarly to how the slack notification provides this information.

The `route`, `routes` and `logLink` are omitempty, so they will only be present in the payload if the the build contains this information (not all builds fail at the same time so routes can be missing sometimes). 

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

