### PR TITLE
fix: groups in opensearch client token so that group-tenant association works

### DIFF
--- a/services/keycloak/javascript/mappers/groups-and-roles.js
+++ b/services/keycloak/javascript/mappers/groups-and-roles.js
@@ -24,6 +24,9 @@ forEach.call(user.getGroups().toArray(), function(group) {
       }
     } else {
       if(projectIds !== null) {
+        // add the group so group-tenant association works properly
+        groupsAndRoles.add(groupName);
+        // calculate the groupprojectids
         forEach.call(projectIds.split(","), function(g) {
           groupProjectIds.put(g, groupName)
         });
@@ -34,13 +37,12 @@ forEach.call(user.getGroups().toArray(), function(group) {
   return;
 });
 
-// add all the unique project ids roles the user has, that aren't in an already existing group
+// remove all the groupprojectids from the individual projectgroupprojectids so that all
+// that remains are project ids that are not already associated to an existing group
 projectGroupProjectIds.keySet().removeAll(groupProjectIds.keySet());
-for each (var e in projectGroupProjectIds.keySet()) groupsAndRoles.add("p"+e);
-
-// now add all the users groups
-var uniqueGroups = new HashSet(groupProjectIds.values());
-for each (var e in uniqueGroups) groupsAndRoles.add(e);
+for each (var e in projectGroupProjectIds.keySet()) {
+    groupsAndRoles.add("p"+e);
+}
 
 // add all roles the user is part of
 forEach.call(user.getRoleMappings().toArray(), function(role) {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

#3319 introduced a way to reduce the number of groups and project-default groups being added to user tokens in opensearch clients to reduce the impact of large cookie sizes preventing users from logging in to opensearch. Unfortunately, this also introduced a bug in which the groups the user was in were consolidated down too. This caused groups the user is in to not match up to their associated tenant in opensearch.

This PR fixes it so that groups are no longer consolidated down, only project-default groups are.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

