### PR TITLE
fix: filter out groups user isn't in when working out groups for user

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/01-populate-api-data-general.gql
@@ -846,4 +846,142 @@ mutation PopulateApi {
     id
   }
 
+  ## Create some general users with specific role against high-cotton for permissions validations in local testing easily
+  UserExampleGuest: addUser(
+    input: {
+      email: "guest@example.com"
+      comment: "guest user"
+    }
+  ) {
+    id
+  }
+
+  UserExampleReporter: addUser(
+    input: {
+      email: "reporter@example.com"
+      comment: "reporter user"
+    }
+  ) {
+    id
+  }
+
+  UserExampleDeveloper: addUser(
+    input: {
+      email: "developer@example.com"
+      comment: "developer user"
+    }
+  ) {
+    id
+  }
+
+  UserExampleMaintainer: addUser(
+    input: {
+      email: "maintainer@example.com"
+      comment: "maintainer user"
+    }
+  ) {
+    id
+  }
+
+  UserExampleOwner: addUser(
+    input: {
+      email: "owner@example.com"
+      comment: "owner user"
+    }
+  ) {
+    id
+  }
+
+  HighCottonGroup: addGroup(
+    input: {
+      name: "high-cotton"
+    }
+  ) {
+    id
+  }
+
+  HighCottonProjectToGroup: addGroupsToProject(
+    input: {
+      project: {
+        name: "high-cotton"
+      }
+      groups: [
+        {
+          name: "high-cotton"
+        }
+      ]
+    }
+  ) {
+    id
+  }
+
+  UserExampleGuestGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"guest@example.com"
+      }
+      group: {
+        name: "high-cotton"
+      }
+      role: GUEST
+    }
+  ) {
+    name
+  }
+
+  UserExampleReporterGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"reporter@example.com"
+      }
+      group: {
+        name: "high-cotton"
+      }
+      role: REPORTER
+    }
+  ) {
+    name
+  }
+
+  UserExampleDeveloperGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"developer@example.com"
+      }
+      group: {
+        name: "high-cotton"
+      }
+      role: DEVELOPER
+    }
+  ) {
+    name
+  }
+
+  UserExampleMaintainerGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"maintainer@example.com"
+      }
+      group: {
+        name: "high-cotton"
+      }
+      role: MAINTAINER
+    }
+  ) {
+    name
+  }
+
+  UserExampleOwnerGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"owner@example.com"
+      }
+      group: {
+        name: "high-cotton"
+      }
+      role: OWNER
+    }
+  ) {
+    name
+  }
 }

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -228,11 +228,17 @@ export const User = (clients: {
       for (const roleSubgroup of roleSubgroups) {
         for (const fullSubgroup of fullGroup.subGroups) {
           if (roleSubgroup.name.replace(regexp, "") == fullSubgroup.name) {
-            groups.push(fullSubgroup)
+            let group = fullSubgroup
+            let filtergroup = group.subGroups.filter((item) => item.name == roleSubgroup.name);
+            group.subGroups = filtergroup
+            groups.push(group)
           }
         }
         if (roleSubgroup.name.replace(regexp, "") == fullGroup.name) {
-          groups.push(fullGroup)
+          let group = fullGroup
+          let filtergroup = group.subGroups.filter((item) => item.name == roleSubgroup.name);
+          group.subGroups = filtergroup
+          groups.push(group)
         }
       }
     }


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

#3397 introduced some refactoring to the API to make permissions checks faster, but there is a bug when a group has multiple rolesubgroups and it adds all of these to the users groups that are returned. This could result in a user getting a role they may not have being added to their roles.

This fixes it by filtering out all the subgroups that the user isn't in from the groups returned from keycloak before populating the users groups with attributes.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

