### PR TITLE
chore: remove kind and apiversion from restore

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -979,8 +979,6 @@ export const createRemoveTask = async function(removeData: any) {
 // creates the restore job configuration for use in the misc task
 const restoreConfig = (name, backupId, backupS3Config, restoreS3Config) => {
   let config = {
-    apiVersion: 'backup.appuio.ch/v1alpha1',
-    kind: 'Restore',
     metadata: {
       name
     },


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

To aid in Lagoon supporting a newer version of k8up, we need to strip references to the older CRDs.

This PR removes the `Kind` and `apiVersion` references from the restore, since k8up v1 and v2 restore specs are identical, and the `remote-controller` has supported checking the cluster for specific versions of k8up since `v0.8.0`, this will make it so that the remote-controller will now determine which version of the restore to create based on which version of k8up is detected in the remote clusters.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3253 
