### PR TITLE
fix: indentation in markdown lists in documentation

### DIFF
--- a/docs/administering-lagoon/using-harbor/harbor-settings/README.md
+++ b/docs/administering-lagoon/using-harbor/harbor-settings/README.md
@@ -11,23 +11,23 @@ Harbor is composed of multiple containers, which all require different settings 
 The following environment variables are required to be set in order for Harbor to properly start:
 
 * `HARBOR_REGISTRY_STORAGE_AMAZON_BUCKET`
-  * This needs to be set to the name of the AWS bucket which Harbor will save images to.
-  * Defaults to `harbor-images` when Lagoon is run locally or during CI testing.
+    * This needs to be set to the name of the AWS bucket which Harbor will save images to.
+    * Defaults to `harbor-images` when Lagoon is run locally or during CI testing.
 * `HARBOR_REGISTRY_STORAGE_AMAZON_REGION`
-  * This needs to be set to the AWS region in which Harbor's bucket is located.
-  * Defaults to `us-east-1` when Lagoon is run locally or during CI testing.
+    * This needs to be set to the AWS region in which Harbor's bucket is located.
+    * Defaults to `us-east-1` when Lagoon is run locally or during CI testing.
 * `REGISTRY_STORAGE_S3_ACCESSKEY`
-  * This needs to be set to the AWS access key Harbor should use to read and write to the AWS bucket.
-  * Defaults to an empty string when Lagoon is run locally or during CI testing, as MinIO does not require authentication.
+    * This needs to be set to the AWS access key Harbor should use to read and write to the AWS bucket.
+    * Defaults to an empty string when Lagoon is run locally or during CI testing, as MinIO does not require authentication.
 * `REGISTRY_STORAGE_S3_SECRETKEY`
-  * This needs to be set to the AWS secret key Harbor should use to read and write to the AWS bucket.
-  * Defaults to an empty string when Lagoon is run locally or during CI testing, as MinIO does not require authentication.
+    * This needs to be set to the AWS secret key Harbor should use to read and write to the AWS bucket.
+    * Defaults to an empty string when Lagoon is run locally or during CI testing, as MinIO does not require authentication.
 
 The following environment variables can be set if required:
 
 * `HARBOR_REGISTRY_STORAGE_AMAZON_ENDPOINT`
-  * If this variable is set, the Harbor registry will use its value as the address of the s3 entrypoint.
-  * Defaults to `https://s3.amazonaws.com` when this variable is not set.
+    * If this variable is set, the Harbor registry will use its value as the address of the s3 entrypoint.
+    * Defaults to `https://s3.amazonaws.com` when this variable is not set.
 
 ## Container Specific Settings
 

--- a/docs/installing-lagoon/install-harbor.md
+++ b/docs/installing-lagoon/install-harbor.md
@@ -4,7 +4,7 @@
     ```bash
     helm repo add harbor https://helm.goharbor.io
     ```
-2. Create the file `harbor-values.yml` inside of your config directory. The proxy-buffering annotations help with large image pushes.:
+1. Create the file `harbor-values.yml` inside of your config directory. The proxy-buffering annotations help with large image pushes.:
 
     ```yaml title="harbor-values.yml"
     expose:
@@ -44,10 +44,10 @@
       -f harbor-values.yml \
       harbor harbor/harbor
     ```
-2. Visit Harbor at the URL you set in `harbor.yml`.
-   1. Username: admin
-   2. Password:
-       ```bash
-       kubectl -n harbor get secret harbor-core -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode
-       ```
-3. You will need to add the above Harbor credentials to the Lagoon Remote `values.yml` in the next step, as well as `harbor-values.yml`.
+1. Visit Harbor at the URL you set in `harbor.yml`.
+    1. Username: admin
+    1. Password:
+        ```bash
+        kubectl -n harbor get secret harbor-core -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode
+        ```
+1. You will need to add the above Harbor credentials to the Lagoon Remote `values.yml` in the next step, as well as `harbor-values.yml`.

--- a/docs/using-lagoon-the-basics/configure-webhooks.md
+++ b/docs/using-lagoon-the-basics/configure-webhooks.md
@@ -13,50 +13,50 @@ Your Lagoon administrator will also give you the route to the `webhook-handler`.
 
 1. Proceed to Settings -&gt; Webhooks -&gt; `Add webhook` in your GitHub repository.
 
-   ![Adding webhook in GitHub.](./webhooks-2020-01-23-12-40-16.png)
+    ![Adding webhook in GitHub.](./webhooks-2020-01-23-12-40-16.png)
 
-2. The `Payload URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
-3. Set `Content type` to `application/json`.
+1. The `Payload URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
+1. Set `Content type` to `application/json`.
 
-   ![Add the Payload URL and set the Content type.](./gh_webhook_1.png)
+    ![Add the Payload URL and set the Content type.](./gh_webhook_1.png)
 
-4. Choose "`Let me select individual events`."
-5. Choose which events will trigger your webhook. We suggest that you send `Push` and `Pull request` events, and then filter further in the Lagoon configuration of your project.
+1. Choose "`Let me select individual events`."
+1. Choose which events will trigger your webhook. We suggest that you send `Push` and `Pull request` events, and then filter further in the Lagoon configuration of your project.
 
-   ![Select the webhook event triggers in GitHub.](./gh_webhook_2.png)
+    ![Select the webhook event triggers in GitHub.](./gh_webhook_2.png)
 
-6. Make sure the webhook is set to `Active`.
-7. Click `Add webhook` to save your configuration.
+1. Make sure the webhook is set to `Active`.
+1. Click `Add webhook` to save your configuration.
 
 ## GitLab
 
 1. Navigate to Settings -&gt; Integrations in your GitLab repository.
 
-   ![Go to Settings &amp;gt; Integrations in your GitLab repository.](./gitlab-settings.png)
+    ![Go to Settings &amp;gt; Integrations in your GitLab repository.](./gitlab-settings.png)
 
-2. The `URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
-3. Select the `Trigger` events which will send a notification to Lagoon. We suggest that you send `Push events` and `Merge request events`, and then filter further in the Lagoon configuration of your project.
+1. The `URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
+1. Select the `Trigger` events which will send a notification to Lagoon. We suggest that you send `Push events` and `Merge request events`, and then filter further in the Lagoon configuration of your project.
 
-   ![Selecting Trigger events in GitLab.](./gitlab_webhook.png)
+    ![Selecting Trigger events in GitLab.](./gitlab_webhook.png)
 
-4. Click `Add webhook`to save your configuration.
+1. Click `Add webhook`to save your configuration.
 
 ## Bitbucket
 
 1. Navigate to Settings -&gt; Webhooks -&gt; Add new webhook in your repository.
-2. `Title` is for your reference.
-3. `URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
-4. `Choose from a full list of triggers` and select the following:
-   * Repository
-     * Push
-   * Pull Request
+1. `Title` is for your reference.
+1. `URL` is the route to the `webhook-handler` of your Lagoon instance, provided by your Lagoon administrator.
+1. `Choose from a full list of triggers` and select the following:
+    * Repository
+        * Push
+    * Pull Request
+        * Created
+        * Updated
+        * Approved
+        * Approval removed
+        * Merged
+        * Declined
 
-     * Created
-     * Updated
-     * Approved
-     * Approval removed
-     * Merged
-     * Declined
+    ![Select the Bitbucket Triggers for your webhook. ](./bb_webhook_1.png)
 
-     ![Select the Bitbucket Triggers for your webhook. ](./bb_webhook_1.png)
-5. Click `Save` to save the webhook configurations for Bitbucket.
+1. Click `Save` to save the webhook configurations for Bitbucket.


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Various places that lists were indented 2 or 3 spaces instead of 4 as per the markdown spec.

# Closing issues

n/a
