### PR TITLE
refactor: add empty attributes to new groups

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -564,13 +564,16 @@ export const Group = (clients: {
     groupInput: any
   ): Promise<void> => {
     const group = await loadGroupById(groupInput.id);
-    const groupProjectIds = getProjectIdsFromGroup(group)
-    const newGroupProjects = R.pipe(
-      R.append(projectId),
-      R.uniq,
-      R.join(',')
-      // @ts-ignore
-    )(groupProjectIds);
+    let newGroupProjects = ""
+    if (projectId) {
+      const groupProjectIds = getProjectIdsFromGroup(group)
+      newGroupProjects = R.pipe(
+        R.append(projectId),
+        R.uniq,
+        R.join(',')
+        // @ts-ignore
+      )(groupProjectIds);
+    }
 
     try {
       await keycloakAdminClient.groups.update(

--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -210,6 +210,7 @@ export const addGroup: ResolverFn = async (
     name: input.name,
     parentGroupId
   });
+  await models.GroupModel.addProjectToGroup(null, group);
 
   // We don't have any projects yet. So just an empty string
   OpendistroSecurityOperations(sqlClientPool, models.GroupModel).syncGroup(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When new groups are created, there are no `lagoon-projects` attributes created on the group. Now when groups are created, these attributes will be added, just with empty values.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

