### PR TITLE
chore: update docs with tar copy instructions

### DIFF
--- a/docs/using-lagoon-advanced/ssh.md
+++ b/docs/using-lagoon-advanced/ssh.md
@@ -110,9 +110,23 @@ scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [local_
 rsync --rsh='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222' [local_path] [project_name]-[environment_name]@ssh.lagoon.amazeeio.cloud:[remote_path]
 ```
 
+### tar
+
+```bash
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [project_name]-[environment_name]@ssh.lagoon.amazee.io tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+```
+
 ### Specifying non-CLI pod/service
 
-In the rare case that you need to specify a non-CLI service this can be acheived with `rsync` using a `ssh` wrapper script to reorder the arguments in the manner required by Lagoon's SSH service:
+In the rare case that you need to specify a non-CLI service you can specify the `service=...` and/or `container=...` arguments in the copy command.
+
+Piping `tar` through the `ssh` connection is the simplest method, and can be used to copy a file or directory using the usual `tar` flags:
+
+```bash
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [project_name]-[environment_name]@ssh.lagoon.amazee.io service=solr tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+```
+
+You can also use `rsync` with a wrapper script to reorder the arguments to `ssh` in the manner required by Lagoon's SSH service:
 
 ```bash
 #!/usr/bin/env sh


### PR DESCRIPTION
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

This PR adds documentation on copying data to/from Lagoon environments using `tar` over SSH.

This is useful if the target container doesn't have `rsync` or `scp` installed.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
