### PR TITLE
Fixes inter-resolver call from addFactsByName

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -1135,7 +1135,7 @@ export const switchActiveStandby: ResolverFn = async (
     const environmentsForProject = await query(
       sqlClientPool,
       environmentSql.selectEnvironmentsByProjectID(
-        project.id
+        project.id, true
       )
     );
     for (const envForProject of environmentsForProject) {

--- a/services/api/src/resources/environment/helpers.ts
+++ b/services/api/src/resources/environment/helpers.ts
@@ -49,6 +49,13 @@ export const Helpers = (sqlClientPool: Pool) => {
         Sql.deleteEnvironment(name, pid)
       );
     },
+    getEnvironmentsByProjectId: async (projectId) => {
+      const rows = await query(
+        sqlClientPool,
+        Sql.selectEnvironmentsByProjectID(projectId)
+      );
+      return aliasOpenshiftToK8s(rows);
+    },
     getEnvironmentsByEnvironmentInput: async environmentInput => {
       const notEmpty = R.complement(R.anyPass([R.isNil, R.isEmpty]));
       const hasId = R.both(R.has('id'), R.propSatisfies(notEmpty, 'id'));

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -22,12 +22,18 @@ export const Sql = {
       .andWhere('project', '=', projectId)
       .andWhere('deleted', '0000-00-00 00:00:00')
       .toString(),
-  selectEnvironmentsByProjectID: (projectId: number) =>
-    knex('environment')
+  selectEnvironmentsByProjectID: (projectId: number, includeDeleted: boolean = false) => {
+    let select = knex('environment')
       .select('id', 'name')
       .where('project', '=', projectId)
-      .orderBy('id', 'desc')
-      .toString(),
+      .orderBy('id', 'desc');
+
+      if(!includeDeleted) {
+        select = select.andWhere('deleted', '0000-00-00 00:00:00');
+      }
+
+      return select.toString()
+  },
   truncateEnvironment: () =>
     knex('environment')
       .truncate()


### PR DESCRIPTION
Adding the `adminScopes` details in the downstream resolver `getEnvironmentsByProjectId` seems to have broken the `addFactsByName` resolver.

This PR resolves that, as well as cleans up some of the logic
* no intra-resolver calls
* no internal api calls
* Adds a `getEnvironmentsByProjectId` function to the environment helper

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

