### PR TITLE
fix: actually collect the storagecalc field from project to send to remote

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -1102,6 +1102,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
         standbyRoutes
         standbyAlias
         productionBuildPriority
+        storageCalc
         developmentBuildPriority
         envVariables {
           name


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When remote storage calculator was introduced, the API was updated to send storageCalc field, but the API resolver to collect this information was not updated to include this field. This PR fixes that.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

