### PR TITLE
feat: allUsers and userByEmail queries

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -209,6 +209,8 @@ const {
   updateUser,
   deleteUser,
   deleteAllUsers,
+  getAllUsers,
+  getUserByEmail,
 } = require('./resources/user/resolvers');
 
 const {
@@ -227,6 +229,7 @@ const {
   addGroupsToProject,
   removeGroupsFromProject,
   getMembersByGroupId,
+  getGroupRolesByUserId,
 } = require('./resources/group/resolvers');
 
 const {
@@ -442,6 +445,7 @@ const resolvers = {
   User: {
     sshKeys: getUserSshKeys,
     groups: getGroupsByUserId,
+    groupRoles: getGroupRolesByUserId,
   },
   Backup: {
     restore: getRestoreByBackupId,
@@ -485,6 +489,8 @@ const resolvers = {
     allGroups: getAllGroups,
     allProjectsInGroup: getAllProjectsInGroup,
     allProblemHarborScanMatchers: getProblemHarborScanMatches,
+    allUsers: getAllUsers,
+    userByEmail: getUserByEmail,
     projectsByMetadata: getProjectsByMetadata,
     projectsByFactSearch: getProjectsByFactSearch,
     workflowsForEnvironment: resolveWorkflowsForEnvironment,

--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -87,6 +87,36 @@ export const getGroupFromGroupsByName = async (id, groups) => {
   return {};
 }
 
+export const getGroupRolesByUserId: ResolverFn =async (
+  { id: uid },
+  _input,
+  { hasPermission, models, keycloakGrant, keycloakUsersGroups, adminScopes }
+) => {
+  // use the admin scope check instead of `hasPermission` for speed
+  if (adminScopes.groupViewAll) {
+    try {
+      const queryUserGroups = await models.UserModel.getAllGroupsForUser(uid);
+      let groups = []
+      for (const g in queryUserGroups) {
+        groups.push({id: queryUserGroups[g].id, name: queryUserGroups[g].name, role: queryUserGroups[g].subGroups[0].realmRoles[0]})
+      }
+
+      return groups;
+    } catch (err) {
+      if (!keycloakGrant) {
+        logger.debug('No grant available for getGroupsByUserId');
+        return [];
+      }
+    }
+  }
+  let groups = []
+  for (const g in keycloakUsersGroups) {
+    groups.push({id: keycloakUsersGroups[g].id, name: keycloakUsersGroups[g].name, role: keycloakUsersGroups[g].subGroups[0].realmRoles[0]})
+  }
+
+  return groups;
+}
+
 export const getMembersByGroupId: ResolverFn = async (
   { id },
   _input,

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -83,10 +83,7 @@ export const getUserByEmail: ResolverFn = async (
 ) => {
   await hasPermission('user', 'viewAll');
 
-  const user = await models.UserModel.loadUserByIdOrUsername({
-    id: R.prop('id', {}),
-    username: R.prop('email', {email: email}),
-  });
+  const user = await models.UserModel.loadUserByUsername(email);
 
   return user;
 };

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -44,6 +44,53 @@ export const getUserBySshKey: ResolverFn = async (
   return user;
 };
 
+// query to get all users, with some inputs to limit the search to specific email, id, or gitlabId
+export const getAllUsers: ResolverFn = async (
+  _root,
+  { id, email, gitlabId },
+  { sqlClientPool, models, hasPermission },
+) => {
+  await hasPermission('user', 'viewAll');
+
+  const users = await models.UserModel.loadAllUsers();
+  if (id) {
+    const filteredById = users.filter(function (item) {
+      return item.id === id;
+    });
+    return filteredById;
+  }
+  if (email) {
+    const filteredByEmail = users.filter(function (item) {
+      return item.email === email;
+    });
+    return filteredByEmail;
+  }
+  if (gitlabId) {
+    const filteredByGitlab = users.filter(function (item) {
+      return item.gitlabId === gitlabId;
+    });
+    return filteredByGitlab;
+  }
+
+  return users;
+};
+
+// query to get all users, with some inputs to limit the search to specific email, id, or gitlabId
+export const getUserByEmail: ResolverFn = async (
+  _root,
+  { email },
+  { sqlClientPool, models, hasPermission },
+) => {
+  await hasPermission('user', 'viewAll');
+
+  const user = await models.UserModel.loadUserByIdOrUsername({
+    id: R.prop('id', {}),
+    username: R.prop('email', {email: email}),
+  });
+
+  return user;
+};
+
 export const addUser: ResolverFn = async (
   _root,
   { input },

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -457,10 +457,19 @@ const typeDefs = gql`
     gitlabId: Int
     sshKeys: [SshKey]
     groups: [GroupInterface]
+    # This just returns the group name, id and the role the user has in that group.
+    # This is a neat way to visualize a users specific access without having to get all members of a group
+    groupRoles: [GroupRoleInterface]
   }
 
   type GroupMembership {
     user: User
+    role: GroupRole
+  }
+
+  type GroupRoleInterface {
+    id: String
+    name: String
     role: GroupRole
   }
 
@@ -1075,6 +1084,10 @@ const typeDefs = gql`
     """
     userBySshKey(sshKey: String!): User
     """
+    Returns User Object by a given email address
+    """
+    userByEmail(email: String!): User
+    """
     Returns Project Object by a given name
     """
     projectByName(name: String!): Project
@@ -1148,6 +1161,10 @@ const typeDefs = gql`
     """
     allProblems(source: [String], project: Int, environment: Int, envType: [EnvType], identifier: String, severity: [ProblemSeverityRating]): [Problem]
     problemSources: [String]
+    """
+    Returns all Users
+    """
+    allUsers(id: String, email: String, gitlabId: Int): [User]
     """
     Returns all Groups matching given filter (all if no filter defined)
     """

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -2063,6 +2063,33 @@ EOF
 EOF
 }
 
+function add_user_viewall {
+  CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=api --config $CONFIG_PATH | jq -r '.[0]["id"]')
+  view_all_users=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/permission?name=View+All+Users --config $CONFIG_PATH)
+
+  if [ "$view_all_users" != "[ ]" ]; then
+      echo "user:viewAll already configured"
+      return 0
+  fi
+
+  echo Configuring user:viewAll
+
+  GROUP_RESOURCE_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get -r lagoon clients/$CLIENT_ID/authz/resource-server/resource?name=user --config $CONFIG_PATH | jq -r '.[0]["_id"]')
+  /opt/jboss/keycloak/bin/kcadm.sh update clients/$CLIENT_ID/authz/resource-server/resource/$GROUP_RESOURCE_ID --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} -s 'scopes=[{"name":"add"},{"name":"getBySshKey"},{"name":"update"},{"name":"delete"},{"name":"deleteAll"},{"name":"viewAll"}]'
+
+  /opt/jboss/keycloak/bin/kcadm.sh create clients/$CLIENT_ID/authz/resource-server/permission/scope --config $CONFIG_PATH -r lagoon -f - <<EOF
+{
+  "name": "View All Users",
+  "type": "scope",
+  "logic": "POSITIVE",
+  "decisionStrategy": "UNANIMOUS",
+  "resources": ["user"],
+  "scopes": ["viewAll"],
+  "policies": ["[Lagoon] Users role for realm is Platform Owner"]
+}
+EOF
+}
+
 ##################
 # Initialization #
 ##################
@@ -2101,6 +2128,7 @@ function configure_keycloak {
     add_delete_env_var_permissions
     configure_lagoon_opensearch_sync_client
     update_env_var_view_permissions
+    add_user_viewall
 
     # always run last
     sync_client_secrets


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds two new admin only queries with a new `user:viewAll` permission scope:
* allUsers
* userByEmail

The `allUsers` has inputs that can be used to select from all users by a given `id`, `email`, and `gitlabId`

`userByEmail` is as the name implies, find a user by a given email address.

Part of this change is to also add a new resolver to the `User` type called `groupRoles`. This resolver will return all the groups the user is in, and the role the user has in that group. This makes it very easy to get a quick overview of a specific users role within the groups they're in.
```
{
  "data": {
    "userByEmail": {
      "email": "default-user@high-cotton",
      "id": "450ac6a8-1498-4a2b-8af2-e52d79a3b902",
      "groupRoles": [
        {
          "id": "a0fd34c5-0e86-4f48-b9a1-bf2dfd0d4428",
          "name": "project-high-cotton",
          "role": "MAINTAINER"
        }
      ]
    }
  }
}
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #1709 
