### PR TITLE
Fix error handling for duplicate projects during gitlab sync

### DIFF
--- a/services/api/src/gitlab-sync/projects.ts
+++ b/services/api/src/gitlab-sync/projects.ts
@@ -15,7 +15,7 @@ interface GitlabProject {
   },
 };
 
-const projectExistsRegex = /Duplicate entry '[^']+' for key 'name'/;
+const projectExistsRegex = /Project already exists/;
 const convertRoleNumberToString = R.cond([
   [R.equals(10), R.always('GUEST')],
   [R.equals(20), R.always('REPORTER')],


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

The error message for duplicate projects was changed in https://github.com/uselagoon/lagoon/pull/3418 and that broke the gitlab project sync script.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
