### PR TITLE
fix: logic on admin task visibility for advanced tasks

### DIFF
--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -598,9 +598,9 @@ export const invokeRegisteredTask = async (
           service: task.service || 'cli',
           image: task.image, //the return data here is basically what gets dropped into the DB.
           payload: payload,
-          deployTokenInjection: task.deployTokenInjection == true,
-          projectKeyInjection: task.projectKeyInjection == true,
-          adminOnlyView: task.adminOnlyView == false,
+          deployTokenInjection: task.deployTokenInjection,
+          projectKeyInjection: task.projectKeyInjection,
+          adminOnlyView: task.adminOnlyView,
           remoteId: undefined,
           execute: true
         });


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

#3393 introduced admin task visibility, but there was a logic error that meant advanced imaged based tasks will default to hidden to normal users even if the adminonlyview flag was not set.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

