### PR TITLE
refactor: remove deleted projects from all groups

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -552,7 +552,6 @@ export const getAllProjectsInGroup: ResolverFn = async (
       return [];
     }
     const projectIdsArray = await getProjectsFromGroupAndSubgroups(group);
-
     return projectIdsArray.map(async id =>
       projectHelpers(sqlClientPool).getProjectByProjectInput({ id })
     );

--- a/services/api/src/resources/project/helpers.ts
+++ b/services/api/src/resources/project/helpers.ts
@@ -105,6 +105,8 @@ export const Helpers = (sqlClientPool: Pool) => {
     getAllProjects: async () => query(sqlClientPool, Sql.selectAllProjects()),
     getAllProjectsNotIn: async ids =>
       query(sqlClientPool, Sql.selectAllProjectNotIn(ids)),
+    getAllProjectsIn: async ids =>
+      query(sqlClientPool, Sql.selectAllProjectsIn(ids)),
     getAllProjectNames: async () =>
       R.map(
         R.prop('name'),

--- a/services/api/src/resources/project/sql.ts
+++ b/services/api/src/resources/project/sql.ts
@@ -16,6 +16,11 @@ export const Sql = {
       .whereNotIn('id', ids)
       .orderBy('id', 'asc')
       .toString(),
+  selectAllProjectsIn: (ids: number) =>
+    knex('project')
+      .select('id')
+      .whereIn('id', ids)
+      .toString(),
   selectProjectByName: (name: string) =>
     knex('project')
       .where('name', name)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This refactors the project deletion mutation to also remove the project from all of the groups it is in.

It also adds a helper to `getProjectsFromGroupAndSubgroups` that removes projectIds from being returned in the response that would otherwise result in `null` and an authorization error to the user.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #1562  
