### PR TITLE
fix: permissions changes for subscriptions after keyloak optimisations

### DIFF
--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -120,16 +120,50 @@ const apolloServer = new ApolloServer({
         esClient,
       };
 
-      let keycloakGroups = {}
+      // get all keycloak groups, do this early to reduce the number of times this is called otherwise
+      // but doing this early and once is pretty cheap
+      let keycloakGroups = []
+      try {
+        // check redis for the allgroups cache value
+        const data = await getRedisKeycloakCache("allgroups");
+        let buff = new Buffer(data, 'base64');
+        keycloakGroups = JSON.parse(buff.toString('utf-8'));
+      } catch (err) {
+        logger.warn(`Couldn't check redis keycloak cache: ${err.message}`);
+        // if it can't be recalled from redis, get the data from keycloak
+        const allGroups = await Group.Group(modelClients).loadAllGroups();
+        keycloakGroups = await Group.Group(modelClients).transformKeycloakGroups(allGroups);
+        const data = Buffer.from(JSON.stringify(keycloakGroups)).toString('base64')
+        try {
+          // then attempt to save it to redis
+          await saveRedisKeycloakCache("allgroups", data);
+        } catch (err) {
+          logger.warn(`Couldn't save redis keycloak cache: ${err.message}`);
+        }
+      }
+
+      let currentUser = {};
+      let serviceAccount = {};
+      // if this is a user request, get the users keycloak groups too, do this one to reduce the number of times it is called elsewhere
+      // legacy accounts don't do this
       let keycloakUsersGroups = []
+      let groupRoleProjectIds = []
+      const keycloakGrant = grant
+      if (keycloakGrant) {
+        keycloakUsersGroups = await User.User(modelClients).getAllGroupsForUser(keycloakGrant.access_token.content.sub);
+        serviceAccount = await keycloakGrantManager.obtainFromClientCredentials();
+        currentUser = await User.User(modelClients).loadUserById(keycloakGrant.access_token.content.sub);
+        // grab the users project ids and roles in the first request
+        groupRoleProjectIds = await User.User(modelClients).getAllProjectsIdsForUser(currentUser, keycloakUsersGroups);
+      }
 
       return {
         keycloakAdminClient,
         sqlClientPool,
         hasPermission: grant
-          ? keycloakHasPermission(grant, requestCache, modelClients)
+          ? keycloakHasPermission(grant, requestCache, modelClients, serviceAccount, currentUser, groupRoleProjectIds)
           : legacyHasPermission(legacyCredentials),
-        keycloakGrant: grant,
+        keycloakGrant,
         requestCache,
         models: {
           UserModel: User.User(modelClients),


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When #3397 was introduced, changes to the context were made, but the subscriptions was missed. This broke subscriptions permissions checks, so they resulted in a weird error that wasn't a permission denied error, but an undefined id error because the current user and all the new information was not passed through to the permission function.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

