### PR TITLE
fix: only update deployment fields if they are provided by remote-controller

### DIFF
--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -100,9 +100,11 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue mq.MQ, message
 	// prepare the deployment patch for later step
 	statusType := schema.StatusTypes(strings.ToUpper(buildStatus))
 	updateDeploymentPatch := schema.UpdateDeploymentPatchInput{
-		RemoteID:  &message.Meta.RemoteID,
 		Status:    &statusType,
 		BuildStep: &message.Meta.BuildStep,
+	}
+	if message.Meta.RemoteID != "" {
+		updateDeploymentPatch.RemoteID = &message.Meta.RemoteID
 	}
 	if message.Meta.StartTime != "" {
 		updateDeploymentPatch.Started = &message.Meta.StartTime

--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -100,8 +100,10 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue mq.MQ, message
 	// prepare the deployment patch for later step
 	statusType := schema.StatusTypes(strings.ToUpper(buildStatus))
 	updateDeploymentPatch := schema.UpdateDeploymentPatchInput{
-		Status:    &statusType,
-		BuildStep: &message.Meta.BuildStep,
+		Status: &statusType,
+	}
+	if message.Meta.BuildStep != "" {
+		updateDeploymentPatch.BuildStep = &message.Meta.BuildStep
 	}
 	if message.Meta.RemoteID != "" {
 		updateDeploymentPatch.RemoteID = &message.Meta.RemoteID


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Minor fix that will only update the remoteid of a deployment if it is provided. In most cases the remote-controller will send this. But if an old build is cancelled, it can't determine the remoteid (because the pod or the build resource may have been deleted from the cluster a long time ago) so it doesn't provide the remoteid

This remoteid is used by the logs retrieval, and when a long time removed build is cancelled via the ui/api, it removes the remoteid which makes the logs inaccessible.

There is no reason to continually update the remoteid of a deployment once it has been set by the build.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

