### PR TITLE
Build multiarchitecture Lagoon images & Update to Keycloak 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,19 +32,19 @@ pipeline {
         sh script: "docker image prune -af", label: "Pruning images"
       }
     }
-    stage ('refresh upstream images') {
-      when {
-        not {
-          buildingTag()
-        }
-      }
-      steps {
-        sh script: "make -O -j$NPROC docker_pull", label: "Ensuring fresh upstream images"
-      }
-    }
+    // stage ('refresh upstream images') {
+    //   when {
+    //     not {
+    //       buildingTag()
+    //     }
+    //   }
+    //   steps {
+    //     sh script: "make -O -j$NPROC docker_pull", label: "Ensuring fresh upstream images"
+    //   }
+    // }
     stage ('build images') {
       steps {
-        sh script: "make -O -j$NPROC build", label: "Building images"
+        sh script: "make -O build", label: "Building images"
       }
     }
     stage ('show trivy scan results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
       }
       steps {
         sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-        sh script: "make -O -j$NPROC publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
+        sh script: "make -O publish-testlagoon-images BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
       }
     }
     stage ('setup test cluster') {
@@ -157,7 +157,7 @@ pipeline {
       }
       steps {
         sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-        sh script: "make -O -j$NPROC publish-testlagoon-baseimages publish-testlagoon-serviceimages publish-testlagoon-taskimages BRANCH_NAME=latest", label: "Publishing built images with :latest tag"
+        sh script: "make -O publish-testlagoon-images BRANCH_NAME=latest", label: "Publishing built images with :latest tag"
       }
     }
     stage ('deploy to test environment') {
@@ -186,7 +186,7 @@ pipeline {
       }
       steps {
         sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-        sh script: "make -O -j$NPROC publish-uselagoon-baseimages publish-uselagoon-serviceimages publish-uselagoon-taskimages", label: "Publishing built images to uselagoon"
+        sh script: "make -O publish-uselagoon-images", label: "Publishing built images to uselagoon"
       }
     }
     stage ('scan built images') {

--- a/Makefile
+++ b/Makefile
@@ -283,16 +283,15 @@ broker-up: build/broker-single
 .PHONY: publish-testlagoon-images
 publish-testlagoon-images:
 	PLATFORMS=linux/amd64 REPO=docker.io/testlagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
-	PLATFORMS=linux/amd64 REPO=ghcr.io/uselagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
 
 # tag and push all images
 
 .PHONY: publish-uselagoon-images
 publish-uselagoon-images:
 	PLATFORMS=linux/amd64,linux/arm64 REPO=docker.io/uselagoon TAG=$(LAGOON_VERSION) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
-	PLATFORMS=linux/amd64,linux/arm64 REPO=ghcr.io/uselagoon TAG=$(LAGOON_VERSION) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
 	PLATFORMS=linux/amd64,linux/arm64 REPO=docker.io/uselagoon TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
-	PLATFORMS=linux/amd64,linux/arm64 REPO=ghcr.io/uselagoon TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
+
+.PHONY: clean
 clean:
 	rm -rf build/*
 	docker buildx rm $(CI_BUILD_TAG)

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ broker-up: build/broker-single
 
 .PHONY: publish-testlagoon-images
 publish-testlagoon-images:
-	PLATFORMS=linux/amd64 REPO=docker.io/testlagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
+	PLATFORMS=linux/amd64,linux/arm64 REPO=docker.io/testlagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
 
 # tag and push all images
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,314 @@
+# docker-bake.dev.hcl
+variable "REPO" {
+  default = "ghcr.io/tobybellwood"
+}
+
+variable "TAG" {
+  default = "bake"
+}
+
+variable "LAGOON_VERSION" {
+  default = "development"
+}
+
+variable "PLATFORMS" {
+  // use PLATFORMS=linux/amd64,linux/arm64 to override default single architecture on the cli
+  default = "linux/amd64"
+}
+
+target "default"{
+  platforms = ["${PLATFORMS}"]
+  dockerfile = "Dockerfile"
+  labels = {
+    "org.opencontainers.image.source": "https://github.com/uselagoon/lagoon",
+    "org.opencontainers.image.url": "https://github.com/uselagoon/lagoon",
+    "org.opencontainers.image.description": "The system services needed to run a lagoon-core in production and locally",
+    "org.opencontainers.image.licenses": "Apache 2.0",
+    "org.opencontainers.image.version": "${LAGOON_VERSION}",
+    "repository": "https://github.com/uselagoon/lagoon"
+  }
+  args = {
+    LAGOON_VERSION = "${LAGOON_VERSION}"
+  }
+}
+
+group "default" {
+  targets = [
+    "actions-handler",
+    "api-db",
+    "api-redis",
+    "api",
+    "auth-server",
+    "backup-handler",
+    "broker-single",
+    "broker",
+    "keycloak-db",
+    "keycloak",
+    "local-api-data-watcher-pusher",
+    "local-dbaas-provider",
+    "local-git",
+    "local-mongodb-dbaas-provider",
+    "local-registry",
+    "logs2notifications",
+    "ssh",
+    "task-activestandby",
+    "tests",
+    "webhook-handler",
+    "webhooks2tasks",
+    "workflows"
+  ]
+}
+
+group "local-dev" {
+  targets = [
+    "local-api-data-watcher-pusher",
+    "local-dbaas-provider",
+    "local-git",
+    "local-mongodb-dbaas-provider",
+    "local-registry",
+  ]
+}
+
+group "prod-images" {
+  targets = [
+    "actions-handler",
+    "api-db",
+    "api-redis",
+    "api",
+    "auth-server",
+    "backup-handler",
+    "broker-single",
+    "broker",
+    "keycloak-db",
+    "keycloak",
+    "logs2notifications",
+    "ssh",
+    "task-activestandby",
+    "tests",
+    "webhook-handler",
+    "webhooks2tasks",
+    "workflows"
+  ]
+}
+
+target "yarn-workspace-builder" {
+  inherits = ["default"]
+  context = "."
+  dockerfile = "yarn-workspace-builder/Dockerfile"
+}
+
+target "api" {
+  inherits = ["default"]
+  context = "services/api"
+  contexts = {
+    "lagoon/yarn-workspace-builder": "target:yarn-workspace-builder"
+  }
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/api - the API service for Lagoon"
+  }
+  tags = ["${REPO}/api:${TAG}"]
+}
+
+target "api-db" {
+  inherits = ["default"]
+  context = "services/api-db"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/api-db - the MariaDB database service for Lagoon API"
+  }
+  tags = ["${REPO}/api-db:${TAG}"]
+}
+
+target "api-redis" {
+  inherits = ["default"]
+  context = "services/api-redis"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/api-redis - the Redis service for Lagoon API"
+  }
+  tags = ["${REPO}/api-redis:${TAG}"]
+}
+
+target "actions-handler" {
+  inherits = ["default"]
+  context = "services/actions-handler"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/actions-handler - the actions-handler service for Lagoon"
+  }
+  tags = ["${REPO}/actions-handler:${TAG}"]
+}
+
+target "auth-server" {
+  inherits = ["default"]
+  context = "services/auth-server"
+  contexts = {
+    "lagoon/yarn-workspace-builder": "target:yarn-workspace-builder"
+  }
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/auth-server - the auth-server service for Lagoon"
+  }
+  tags = ["${REPO}/auth-server:${TAG}"]
+}
+
+target "backup-handler" {
+  inherits = ["default"]
+  context = "services/backup-handler"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/backup-handler - the backup-handler service for Lagoon"
+  }
+  tags = ["${REPO}/backup-handler:${TAG}"]
+}
+
+target "broker-single" {
+  inherits = ["default"]
+  context = "services/broker-single"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/broker-single - the RabbitMQ broker standalone service for Lagoon"
+  }
+  tags = ["${REPO}/broker-single:${TAG}"]
+}
+
+target "broker" {
+  inherits = ["default"]
+  context = "services/broker"
+  contexts = {
+    "lagoon/broker-single": "target:broker-single"
+  }
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/broker - the RabbitMQ broker service for Lagoon"
+  }
+  tags = ["${REPO}/broker:${TAG}"]
+}
+
+target "keycloak" {
+  inherits = ["default"]
+  context = "services/keycloak"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/keycloak - the Keycloak service for Lagoon"
+  }
+  tags = ["${REPO}/keycloak:${TAG}"]
+}
+
+target "keycloak-db" {
+  inherits = ["default"]
+  context = "services/keycloak-db"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/keycloak-db - the MariaDB database service for Lagoon Keycloak"
+  }
+  tags = ["${REPO}/keycloak-db:${TAG}"]
+}
+
+target "logs2notifications" {
+  inherits = ["default"]
+  context = "services/logs2notifications"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/logs2notifications - the logs2notifications service for Lagoon"
+  }
+  tags = ["${REPO}/logs2notifications:${TAG}"]
+}
+
+target "ssh" {
+  inherits = ["default"]
+  context = "."
+  dockerfile = "services/ssh/Dockerfile"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/ssh - the ssh service for Lagoon"
+  }
+  tags = ["${REPO}/ssh:${TAG}"]
+  // Note not currently arm64 compatible, libnss is waaaay too old
+  platforms = ["linux/amd64"]
+}
+
+target "tests" {
+  inherits = ["default"]
+  context = "tests"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/tests - the tests image for Lagoon"
+  }
+  tags = ["${REPO}/tests:${TAG}"]
+}
+
+target "webhook-handler" {
+  inherits = ["default"]
+  context = "services/webhook-handler"
+  contexts = {
+    "lagoon/yarn-workspace-builder": "target:yarn-workspace-builder"
+  }
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/webhook-handler - the webhook-handler service for Lagoon"
+  }
+  tags = ["${REPO}/webhook-handler:${TAG}"]
+}
+
+target "webhooks2tasks" {
+  inherits = ["default"]
+  context = "services/webhooks2tasks"
+  contexts = {
+    "lagoon/yarn-workspace-builder": "target:yarn-workspace-builder"
+  }
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/webhooks2tasks - the webhooks2tasks service for Lagoon"
+  }
+  tags = ["${REPO}/webhooks2tasks:${TAG}"]
+}
+
+target "workflows" {
+  inherits = ["default"]
+  context = "services/workflows"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/workflows - the workflows service for Lagoon"
+  }
+  tags = ["${REPO}/workflows:${TAG}"]
+}
+
+target "task-activestandby" {
+  inherits = ["default"]
+  context = "taskimages/activestandby"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/task-activestandby - the active/standby task image for Lagoon"
+  }
+  tags = ["${REPO}/task-activestandby:${TAG}"]
+}
+
+target "local-api-data-watcher-pusher" {
+  inherits = ["default"]
+  context = "local-dev/api-data-watcher-pusher"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/local-api-data-watcher-pusher - the local-dev data pusher image for Lagoon"
+  }
+  tags = ["${REPO}/local-api-data-watcher-pusher:${TAG}"]
+}
+
+target "local-dbaas-provider" {
+  inherits = ["default"]
+  context = "local-dev/dbaas-provider"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/local-dbaas-provider - the local-dev MariaDB DBaaS image for Lagoon"
+  }
+  tags = ["${REPO}/local-dbaas-provider:${TAG}"]
+}
+
+target "local-git" {
+  inherits = ["default"]
+  context = "local-dev/git"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/local-git - the local-dev Git repository image for Lagoon"
+  }
+  tags = ["${REPO}/local-git:${TAG}"]
+}
+
+target "local-mongodb-dbaas-provider" {
+  inherits = ["default"]
+  context = "local-dev/mongodb-dbaas-provider"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/local-mongodb-dbaas-provider - the local-dev MongoDB DBaaS image for Lagoon"
+  }
+  tags = ["${REPO}/local-mongodb-dbaas-provider:${TAG}"]
+}
+
+target "local-registry" {
+  inherits = ["default"]
+  context = "local-dev/registry"
+  labels = {
+    "org.opencontainers.image.title": "lagoon-core/local-registry - the local-dev Docker registry image for Lagoon"
+  }
+  tags = ["${REPO}/local-registry:${TAG}"]
+}

--- a/services/actions-handler/Dockerfile
+++ b/services/actions-handler/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 
 # compile
-RUN CGO_ENABLED=0  GOOS=linux GOARCH=amd64 go build -a -o actions-handler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o actions-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/backup-handler/Dockerfile
+++ b/services/backup-handler/Dockerfile
@@ -8,7 +8,7 @@ COPY . /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 
 # compile
-RUN CGO_ENABLED=0  GOOS=linux GOARCH=amd64 go build -a -o backup-handler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o backup-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -8,7 +8,7 @@ COPY javascript /tmp/lagoon-scripts
 
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
-FROM jboss/keycloak:16.1.1
+FROM quay.io/keycloak/keycloak:17.0.1-legacy
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
@@ -37,9 +37,8 @@ RUN chgrp -R 0 $JBOSS_HOME &&\
 # Reproduce behavior of Alpine: Run Bash as sh
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
-RUN chmod +x /sbin/tini
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini
 
 ENV TMPDIR=/tmp \
     TMP=/tmp \

--- a/services/logs2notifications/Dockerfile
+++ b/services/logs2notifications/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 
 # compile
-RUN CGO_ENABLED=0  GOOS=linux GOARCH=amd64 go build -a -o logs2notifications .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o logs2notifications .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/workflows/Dockerfile
+++ b/services/workflows/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/uselagoon/lagoon/services/workflows/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/workflows/
 
 # compile
-RUN CGO_ENABLED=0  GOOS=linux GOARCH=amd64 go build -a -o workflows .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o workflows .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/taskimages/activestandby/Dockerfile
+++ b/taskimages/activestandby/Dockerfile
@@ -5,7 +5,7 @@ COPY . /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 WORKDIR /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o taskrunner .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o taskrunner .
 
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This PR introduces a new build method to better support multiarch builds. It makes a couple of changes needed to support ARM in the images, and migrates the build to a bakefile.

Local building should stay the same - i.e `make build` - but be parallel by default.

This has required an upgrade to Keycloak - that I think is relatively minor (we still use the legacy Wildfly distribution):
https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-17-0-0
https://www.keycloak.org/docs/latest/upgrading/#migrating-to-17-0-0