### PR TITLE
Enabled dark/light mode toggle for Lagoon Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,8 +145,19 @@ nav:
 theme:
   name: 'material'
   palette:
-    primary: 'blue'
-    accent: 'light blue'
+    # Palette toggle for light mode
+    - primary: 'blue'
+      accent: 'light blue'
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: 'blue'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+
   favicon: images/lagoon-icon.png
   logo: images/lagoon-icon-bw.png
   icon:


### PR DESCRIPTION
MkDocs has in-built colour palette toggle functionality - enabing a light/dark mode. 
Enabled this for the Lagoon Docs with mkdocs default colour scheme for dark mode - though functionality is available to define a custom colour scheme via external css if required.