### PR TITLE
fix: validate project key if it is changed, update default-user

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -629,8 +629,7 @@ export const updateProject: ResolverFn = async (
 
   const oldProject = await Helpers(sqlClientPool).getProjectById(id);
 
-  // If the privateKey is changed, automatically remove the old one from the
-  // default user and link the new one.
+  // If the privateKey is changed, automatically add the new one to the default user
   if (patch.privateKey) {
     let keyPair: any = {};
     try {
@@ -646,11 +645,6 @@ export const updateProject: ResolverFn = async (
       const keyParts = keyPair.public.split(' ');
 
       try {
-        // since public keys can only be associated to a single user
-        // if a polysite tries for some reason uses the same key across all the polysites
-        // then only 1 of the default-users will be able to hold the public key
-        // ideally each project should have its own key and polysite repos should
-        // have the public key for each project added to it for pulls
         const { insertId } = await query(
           sqlClientPool,
           sshKeySql.insertSshKey({

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -634,12 +634,7 @@ export const updateProject: ResolverFn = async (
   if (patch.privateKey) {
     let keyPair: any = {};
     try {
-      const privateKey = R.cond([
-        [R.isNil, generatePrivateKey],
-        [R.isEmpty, generatePrivateKey],
-        [R.T, sshpk.parsePrivateKey]
-      ])(R.prop('privateKey', patch));
-
+      const privateKey = sshpk.parsePrivateKey(R.prop('privateKey', patch))
       const publicKey = privateKey.toPublic();
 
       keyPair = {

--- a/services/api/src/resources/sshKey/resolvers.ts
+++ b/services/api/src/resources/sshKey/resolvers.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { ResolverFn } from '../';
-import { query, isPatchEmpty, knex } from '../../util/db';
+import { query, isPatchEmpty } from '../../util/db';
 import { validateSshKey, getSshKeyFingerprint } from '.';
 import { Sql } from './sql';
 
@@ -189,8 +189,14 @@ export const deleteSshKey: ResolverFn = async (
     users: userIds
   });
 
-  let res = await query(sqlClientPool, knex('user_ssh_key').where('skid', skid).delete().toString());
-  res = await query(sqlClientPool, knex('ssh_key').where('id', skid).delete().toString());
+  let res = await query(
+    sqlClientPool,
+    Sql.deleteUserSshKeyByKeyId(skid)
+  );
+  res = await query(
+    sqlClientPool,
+    Sql.deleteSshKeyByKeyId(skid)
+  );
 
   userActivityLogger(`User deleted ssh key '${name}'`, {
     project: '',
@@ -222,8 +228,14 @@ export const deleteSshKeyById: ResolverFn = async (
     users: userIds
   });
 
-  let res = await query(sqlClientPool, knex('user_ssh_key').where('skid', id).delete().toString());
-  res = await query(sqlClientPool, knex('ssh_key').where('id', id).delete().toString());
+  let res = await query(
+    sqlClientPool,
+    Sql.deleteUserSshKeyByKeyId(id)
+  );
+  res = await query(
+    sqlClientPool,
+    Sql.deleteSshKeyByKeyId(id)
+  );
 
   // TODO: Check rows for success
 

--- a/services/api/src/resources/sshKey/sql.ts
+++ b/services/api/src/resources/sshKey/sql.ts
@@ -27,6 +27,20 @@ export const Sql = {
       .join('user_ssh_key as usk', 'sk.id', '=', 'usk.skid')
       .where('sk.key_fingerprint', '=', fingerprint)
       .toString(),
+  selectSshKeyByFingerprint: (fingerprint: string) =>
+    knex('ssh_key')
+      .where('key_fingerprint', '=', fingerprint)
+      .toString(),
+  deleteUserSshKeyByKeyId: (skid: number) =>
+    knex('user_ssh_key')
+      .where('skid', skid)
+      .delete()
+      .toString(),
+  deleteSshKeyByKeyId: (skid: number) =>
+    knex('ssh_key')
+      .where('id', skid)
+      .delete()
+      .toString(),
   insertSshKey: ({
     id,
     name,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When updating a projects private key, there is no validation on it to make sure that the key being changed is valid. This adds validation to the key being updated, and also updates the default-user with the new public key associated to it.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

