### PR TITLE
disable opensearch tests temporarily

### DIFF
--- a/tests/files/services/docker-compose.yml
+++ b/tests/files/services/docker-compose.yml
@@ -22,26 +22,26 @@ services:
     ports:
       - '27017'
 
-  opensearch-2:
-    image: uselagoon/opensearch-2:latest
-    environment:
-    - cluster.name=opensearch-cluster
-    - node.name=opensearch
-    - discovery.seed_hosts=opensearch
-    - cluster.initial_cluster_manager_nodes=opensearch
-    - bootstrap.memory_lock=true
-    - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    labels:
-      lagoon.type: opensearch
-    ports:
-      - '9200'
+  # opensearch-2:
+  #   image: uselagoon/opensearch-2:latest
+  #   environment:
+  #   - cluster.name=opensearch-cluster
+  #   - node.name=opensearch
+  #   - discovery.seed_hosts=opensearch
+  #   - cluster.initial_cluster_manager_nodes=opensearch
+  #   - bootstrap.memory_lock=true
+  #   - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #     nofile:
+  #       soft: 65536
+  #       hard: 65536
+  #   labels:
+  #     lagoon.type: opensearch
+  #   ports:
+  #     - '9200'
 
   postgres-13:
     image: uselagoon/postgres-13

--- a/tests/tests/services/services.yaml
+++ b/tests/tests/services/services.yaml
@@ -81,14 +81,14 @@
   tasks:
   - include: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, opensearch-2 service"
-  hosts: localhost
-  serial: 1
-  vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/opensearch-2"
-    expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
-  tasks:
-  - include: ../../checks/check-url-content.yaml
+# - name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, opensearch-2 service"
+#   hosts: localhost
+#   serial: 1
+#   vars:
+#     url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/opensearch-2"
+#     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
+#   tasks:
+#   - include: ../../checks/check-url-content.yaml
 
 - name: "{{ testname }} - api deleteEnvironment on {{ project }}, which should remove all resources"
   hosts: localhost


### PR DESCRIPTION
The Opensearch tests appear to be stalling builds and causing test runs to fail unnecessarily. This is potentially due to the image size. Trialling removing the test to see if reliability improves.