### PR TITLE
feat: add new resolver to retrieve the projects public key only

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -191,6 +191,7 @@ const {
   updateProjectMetadata,
   removeProjectMetadataByKey,
   getPrivateKey,
+  getProjectDeployKey,
 } = require('./resources/project/resolvers');
 
 const {
@@ -360,6 +361,7 @@ const resolvers = {
     envVariables: getEnvVarsByProjectId,
     groups: getGroupsByProjectId,
     privateKey: getPrivateKey,
+    publicKey: getProjectDeployKey,
   },
   GroupInterface: {
     __resolveType(group) {

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -38,6 +38,21 @@ export const getPrivateKey: ResolverFn = async (
   }
 };
 
+export const getProjectDeployKey: ResolverFn = async (
+  project,
+  _args,
+  { hasPermission }
+) => {
+  try {
+    const privateKey = sshpk.parsePrivateKey(R.prop('privateKey', project))
+
+    const keyParts = privateKey.toPublic().toString().split(' ');
+    return keyParts[0] + " " + keyParts[1]
+  } catch (err) {
+    return null;
+  }
+};
+
 export const getAllProjects: ResolverFn = async (
   root,
   { order, createdAfter, gitUrl },

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -611,6 +611,10 @@ const typeDefs = gql`
     """
     privateKey: String
     """
+    SSH Public Key for Project, can be added to git repositories to allow Lagoon read access.
+    """
+    publicKey: String
+    """
     Set if the .lagoon.yml should be found in a subfolder
     Usefull if you have multiple Lagoon projects per Git Repository
     """


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

To retrieve a projects public key currently means getting the private key and then parsing it to extract the public key. This is silly.

This resolver handles this now.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
