### PR TITLE
Stringify outgoing JSON for problems

### DIFF
--- a/services/api/src/resources/problem/resolvers.ts
+++ b/services/api/src/resources/problem/resolvers.ts
@@ -207,7 +207,10 @@ export const addProblem: ResolverFn = async (
     }
   });
 
-  return R.prop(0, rows);
+  let ret = R.prop(0, rows);
+  ret.data = JSON.stringify(data);
+
+  return ret;
 };
 
 export const deleteProblem: ResolverFn = async (

--- a/services/api/src/resources/problem/resolvers.ts
+++ b/services/api/src/resources/problem/resolvers.ts
@@ -110,7 +110,7 @@ export const getProblemsByEnvironmentId: ResolverFn = async (
     });
   }
 
-  const rows = await query(
+  let rows = await query(
     sqlClientPool,
     Sql.selectProblemsByEnvironmentId({
       environmentId,
@@ -118,6 +118,16 @@ export const getProblemsByEnvironmentId: ResolverFn = async (
       source
     })
   );
+
+  //With some changes in Mariadb, we now have to stringify outgoing json
+  interface hasData {
+    data: string
+  }
+
+  rows = R.map((e:hasData) => {
+    e.data = JSON.stringify(e.data);
+    return e
+  }, rows);
 
   return R.sort(R.descend(R.prop('created')), rows);
 };
@@ -191,7 +201,7 @@ export const addProblem: ResolverFn = async (
         version: version || '',
         fixed_version: fixedVersion,
         links: links,
-        data,
+        data: JSON.stringify(data),
         created,
       }
     }


### PR DESCRIPTION
The way JSON is handled in the api-db changed a few releases ago, requiring strigification/unmarshalling (depending on the GraphQL types) of JSON.

This does the same for "problems" whose datatype, in the API, is "JSON" (a constraint that should potentially be dropped) - and the type at the GraphQL level. This stringifies "data" where required.

