### PR TITLE
refactor: allow environments to be deleted if the deploytarget is disabled

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -502,7 +502,7 @@ export const cancelDeployment: ResolverFn = async (
   });
 
   // check if the deploytarget for this environment is disabled
-  const deploytarget = await query(sqlClientPool, Sql.selectDeployTarget(environment.openshift));
+  const deploytarget = await environmentHelpers(sqlClientPool).getEnvironmentsDeploytarget(environment.openshift);
   if (deploytarget[0].disabled) {
     // if it is, proceed to mark the build as cancelled
     var date = new Date();

--- a/services/api/src/resources/deployment/sql.ts
+++ b/services/api/src/resources/deployment/sql.ts
@@ -63,10 +63,6 @@ export const Sql = {
       .where('id', id)
       .update(patch)
       .toString(),
-  selectDeployTarget: (id: number) =>
-    knex('openshift')
-      .where('id', '=', id)
-      .toString(),
   selectPermsForDeployment: (id: number) =>
     knex('deployment')
       .select({ pid: 'environment.project' })

--- a/services/api/src/resources/environment/helpers.ts
+++ b/services/api/src/resources/environment/helpers.ts
@@ -49,6 +49,13 @@ export const Helpers = (sqlClientPool: Pool) => {
         Sql.deleteEnvironment(name, pid)
       );
     },
+    getEnvironmentsDeploytarget: async (eid) => {
+      const rows = await query(
+        sqlClientPool,
+        Sql.selectDeployTarget(eid)
+      );
+      return aliasOpenshiftToK8s(rows);
+    },
     getEnvironmentsByProjectId: async (projectId) => {
       const rows = await query(
         sqlClientPool,

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -642,6 +642,14 @@ export const deleteEnvironment: ResolverFn = async (
     }
   });
 
+  // if the deploytarget of this environment is marked as disabled or doesn't exist, just delete the environment
+  // the removetask will never work if the deploytarget is disabled and the environment will remain undeleted in the api
+  const deploytarget = await Helpers(sqlClientPool).getEnvironmentsDeploytarget(environment.openshift);
+  if (deploytarget.length == 0 || deploytarget[0].disabled) {
+    await Helpers(sqlClientPool).deleteEnvironment(name, environment.id, projectId);
+    return 'success';
+  }
+
   await createRemoveTask(data);
   sendToLagoonLogs(
     'info',

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -48,6 +48,10 @@ export const Sql = {
         name,
       })
       .toString(),
+  selectDeployTarget: (id: number) =>
+    knex('openshift')
+      .where('id', '=', id)
+      .toString(),
   selectServicesByEnvironmentId: (id: number) =>
     knex('environment_service')
       .where('environment', '=', id)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When attempting to delete an environment on a cluster that no longer exists, or has been marked as disabled, Lagoon still tries to send a deletion request which goes unanswered.

Lagoon will now check if the target that the environment is deployed against is disabled, or doesn't exist anymore, and will perform the deletion as requested without sending the deletion request to the target cluster.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3324 
