### PR TITLE
refactor: when creating a group, user should be added as owner

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -230,7 +230,7 @@ export const getGroupByName: ResolverFn = async (
 export const addGroup: ResolverFn = async (
   _root,
   { input },
-  { models, sqlClientPool, hasPermission, userActivityLogger }
+  { models, sqlClientPool, keycloakGrant, adminScopes, hasPermission, userActivityLogger }
 ) => {
   await hasPermission('group', 'add');
 
@@ -257,6 +257,21 @@ export const addGroup: ResolverFn = async (
     parentGroupId
   });
   await models.GroupModel.addProjectToGroup(null, group);
+
+  // if the user is not an admin, then add the user as an owner to the group
+  if (!adminScopes.projectViewAll && keycloakGrant) {
+    const user = await models.UserModel.loadUserById(
+      keycloakGrant.access_token.content.sub
+    );
+
+    try {
+      await models.GroupModel.addUserToGroup(user, group, 'owner');
+    } catch (err) {
+      logger.error(
+        `Could not link requesting user to group ${group.name}: ${err.message}`
+      );
+    }
+  }
 
   // We don't have any projects yet. So just an empty string
   OpendistroSecurityOperations(sqlClientPool, models.GroupModel).syncGroup(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Users can create groups, but they aren't added as an owner to the group afterwards so they can't do anything with this group.

This changes the behaviour and will add the user to the group when it is created (if they are not an admin)

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #2916 
