### PR TITLE
fix: delete linked ssh keys correctly

### DIFF
--- a/services/api/src/resources/user/sql.ts
+++ b/services/api/src/resources/user/sql.ts
@@ -15,14 +15,17 @@ export const Sql = {
       .select('user_ssh_key.usid')
       .toString(),
   deleteFromSshKeys: (id: string) =>
-    knex('ssh_key as sk')
-      .join('user_ssh_key as usk', 'sk.id', '=', 'usk.skid')
-      .where('usk.usid', '=', id)
+    knex('ssh_key')
+      .whereIn('id', function() {
+        this.select('skid')
+            .from('user_ssh_key')
+            .where('usid', id);
+      })
       .delete()
       .toString(),
   deleteFromUserSshKeys: (id: string) =>
-    knex('user_ssh_key ')
-      .where('usid', '=', id)
+    knex('user_ssh_key')
+      .where('usid', id)
       .delete()
       .toString(),
   selectUserIdBySshFingerprint: ({


### PR DESCRIPTION
In #3462 the routine used to delete a users ssh keys could error
```
Error: graphql: Cannot read properties of undefined (reading 'status')
```

This PR fixes the Knex logic to enable these deletes.

Tested by adding a key to a user, deleting user, and readding key to different user

```
tobybellwood@pop-os:~/sites/lagoon$ lagoon get user-sshkeys -E user@example.com
Info: No SSH keys for user 'user@example.com'
tobybellwood@pop-os:~/sites/lagoon$ lagoon add user-sshkey -E user@example.com  --keyvalue "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINA0ITV2gbDc6noYeWaqfxTYpaEKq7HzU3+F71XGhSL/ my-computer@example"
Result: success
id: 594
tobybellwood@pop-os:~/sites/lagoon$ lagoon get user-sshkeys -E user@example.com
EMAIL                   NAME                    TYPE            VALUE 
user@example.com  my-computer@example     ssh-ed25519     AAAAC3NzaC1lZDI1NTE5AAAAINA0ITV2gbDc6noYeWaqfxTYpaEKq7HzU3+F71XGhSL/
tobybellwood@pop-os:~/sites/lagoon$ lagoon add user-sshkey -E other.user@example.com  --keyvalue "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINA0ITV2gbDc6noYeWaqfxTYpaEKq7HzU3+F71XGhSL/ my-computer@example"
Error: graphql: (conn=81218, no: 1062, SQLState: 23000) Duplicate entry 'SHA256:FfrcVNHge/3iuS4pT5cMOWzb1SxOM5tFetDPIS+4neo' for key 'key_fingerprint'
tobybellwood@pop-os:~/sites/lagoon$ lagoon delete user -E user@example.com
✔ Yes
Result: success
tobybellwood@pop-os:~/sites/lagoon$ lagoon get user-sshkeys -E user@example.com
Info: No SSH keys for user 'user@example.com'
tobybellwood@pop-os:~/sites/lagoon$ lagoon add user-sshkey -E other.user@example.com  --keyvalue "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINA0ITV2gbDc6noYeWaqfxTYpaEKq7HzU3+F71XGhSL/ my-computer@example"
Result: success
id: 596
tobybellwood@pop-os:~/sites/lagoon$ lagoon get user-sshkeys -E other.user@example.com
EMAIL                   NAME                    TYPE            VALUE 
other.user@example.com my-computer@example     ssh-ed25519     AAAAC3NzaC1lZDI1NTE5AAAAINA0ITV2gbDc6noYeWaqfxTYpaEKq7HzU3+F71XGhSL/
```
