### PR TITLE
feat: pass environment variables for project/environment to tasks too

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -914,6 +914,40 @@ export async function getEnvironmentById(
   return result;
 }
 
+export async function getEnvironmentByIdWithVariables(
+  id: number
+): Promise<any> {
+  const result = await graphqlapi.query(`
+    {
+      environmentById(id: ${id}) {
+        id
+        name
+        autoIdle
+        deployType
+        environmentType
+        openshiftProjectName
+        openshiftProjectPattern
+        openshift {
+          routerPattern
+        }
+        envVariables {
+          name
+          value
+          scope
+        }
+      }
+    }
+  `);
+
+  if (!result || !result.environmentById) {
+    throw new EnvironmentNotFound(
+      `Cannot find environment for id ${id}\n${result.environmentById}`
+    );
+  }
+
+  return result;
+}
+
 export async function getDeploymentByName(
   openshiftProjectName: string,
   deploymentName: string,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Currently builds get the list of environment variables from the API. Tasks rely on them being up to date in the `lagoon-env` configmap.

This can be problematic sometimes if you're running a task that uses environment variables, you need to run a deployment first to update the variables, then run the task.

The motivation behind this PR is to allow tasks to consume variables the way they currently do (via the lagoon-env configmap) or the same way that builds do using the `LAGOON_ENVIRONMENT|PROJECT_VARIABLES` variable and parsing the resulting JSON. This means that I can add a variable to the API that only my task uses and then run my task and consume it from the injected variables values instead of having to wait for a deployment.

Advanced Lagoon administration tasks could then also potentially perform some of the functions that builds currently do (update variables, routes, etc, etc) without requiring a full deployment to take place.

This also requires that the remote-controller and the LagoonTask CRD are updated to inject these into task pods.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

