### PR TITLE
feat: support defaultvalue and optional flag on adv task arguments

### DIFF
--- a/services/api/database/migrations/20230703000000_advanced_task_default_optional.js
+++ b/services/api/database/migrations/20230703000000_advanced_task_default_optional.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('advanced_task_definition_argument', (table) => {
+        table.text('default_value');
+        table.boolean('optional').notNullable().defaultTo(0);
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('advanced_task_definition_argument', (table) => {
+        table.dropColumn('default_value');
+        table.dropColumn('optional');
+    })
+};

--- a/services/api/src/resources/task/sql.ts
+++ b/services/api/src/resources/task/sql.ts
@@ -140,11 +140,15 @@ export const Sql = {
       name,
       type,
       displayName,
+      defaultValue,
+      optional,
       }: {
         id: number,
         advanced_task_definition: number,
         name: string,
         type: string,
+        defaultValue: string,
+        optional: boolean,
         displayName: string,
       }) =>
       knex('advanced_task_definition_argument')
@@ -153,6 +157,8 @@ export const Sql = {
           advanced_task_definition,
           name,
           type,
+          defaultValue,
+          optional,
           display_name: displayName
         })
       .toString(),

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -139,6 +139,8 @@ const typeDefs = gql`
     name: String
     displayName: String
     type: String
+    defaultValue: String
+    optional: Boolean
     range: [String]
     advancedTaskDefinition: AdvancedTaskDefinition
   }
@@ -1446,6 +1448,8 @@ const typeDefs = gql`
     name: String
     type: AdvancedTaskDefinitionArgumentTypes
     displayName: String
+    defaultValue: String
+    optional: Boolean
   }
 
   input AdvancedTaskDefinitionArgumentValueInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Support a default value and optional flag on advanced task arguments. 

The UI would need to understand both of these to populate the field with the default value, or allow an empty entry for optional arguments.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

partial #3477 (this PR does not do the range values component)
