### PR TITLE
feat: support shared bucket for backups

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -1119,6 +1119,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
           monitoringConfig
           buildImage
           disabled
+          sharedBaasBucketName
         }
         autoIdle
         branches
@@ -1139,6 +1140,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
         storageCalc
         developmentBuildPriority
         buildImage
+        sharedBaasBucket
         envVariables {
           name
           value
@@ -1190,8 +1192,10 @@ export const getOpenShiftInfoForEnvironment = (environment: number): Promise<any
           monitoringConfig
           buildImage
           disabled
+          sharedBaasBucketName
         }
         project {
+          sharedBaasBucket
           buildImage
           envVariables {
             name

--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -5,11 +5,38 @@ import { createJWTWithoutUserId } from './jwt';
 import { logger } from './logs/local-logger';
 import { envHasConfig, getConfigFromEnv } from './util/config';
 
-interface Project {
+export interface Project {
   slack: any;
   name: string;
-  openshift: any;
+  openshift: DeployTarget;
   deploymentsDisabled: number;
+  sharedBaasBucket?: boolean;
+  routerPattern?: string;
+  envVariables?: any;
+  gitUrl?: string;
+  subfolder?: string;
+  activesystemsdeploy?: string;
+  activesystemsremove?: string;
+  branches?: string;
+  productionenvironment?: string;
+  autoidle?: number;
+  storagecalc?: number;
+  pullrequests?: string;
+  openshiftprojectpattern?: string;
+  productionRoutes?: string;
+  standbyRoutes?: string;
+  productionEnvironment?: string;
+  standbyProductionEnvironment?: string;
+}
+
+export interface DeployTarget {
+  name: string;
+  sharedBaasBucketName?: string;
+  routerPattern?: string;
+  disabled?: boolean;
+  id?: number
+  buildImage?: string
+  monitoringConfig?: any
 }
 
 interface GroupPatch {
@@ -602,12 +629,6 @@ export async function getProjectsByGitUrl(gitUrl: string): Promise<Project[]> {
         name
         productionEnvironment
         deploymentsDisabled
-        openshift {
-          consoleUrl
-          token
-          projectUser
-          routerPattern
-        }
       }
     }
   `);
@@ -928,7 +949,7 @@ export async function getEnvironmentByIdWithVariables(
         openshiftProjectName
         openshiftProjectPattern
         openshift {
-          routerPattern
+          ...${deployTargetMinimalFragment}
         }
         envVariables {
           name
@@ -1110,16 +1131,7 @@ export const getOpenShiftInfoForProject = (project: string): Promise<any> =>
       project:projectByName(name: "${project}"){
         id
         openshift  {
-          id
-          name
-          consoleUrl
-          token
-          projectUser
-          routerPattern
-          monitoringConfig
-          buildImage
-          disabled
-          sharedBaasBucketName
+          ...${deployTargetMinimalFragment}
         }
         autoIdle
         branches
@@ -1161,15 +1173,7 @@ export const getDeployTargetConfigsForProject = (project: number): Promise<any> 
         weight
         deployTargetProjectPattern
         deployTarget{
-          id
-          name
-          consoleUrl
-          token
-          projectUser
-          routerPattern
-          monitoringConfig
-          buildImage
-          disabled
+          ...${deployTargetMinimalFragment}
         }
       }
     }
@@ -1183,16 +1187,7 @@ export const getOpenShiftInfoForEnvironment = (environment: number): Promise<any
         name
         openshiftProjectPattern
         openshift  {
-          id
-          name
-          consoleUrl
-          token
-          projectUser
-          routerPattern
-          monitoringConfig
-          buildImage
-          disabled
-          sharedBaasBucketName
+          ...${deployTargetMinimalFragment}
         }
         project {
           sharedBaasBucket
@@ -1244,8 +1239,7 @@ export const getEnvironmentsForProject = (
         autoIdle
         openshiftProjectPattern
         openshift{
-          id
-          name
+          ...${deployTargetMinimalFragment}
         }
       }
     }
@@ -1284,6 +1278,18 @@ fragment on Deployment {
   environment {
     name
   }
+}
+`);
+
+const deployTargetMinimalFragment = graphqlapi.createFragment(`
+fragment on Openshift {
+  id
+  name
+  routerPattern
+  buildImage
+  disabled
+  sharedBaasBucketName
+  monitoringConfig
 }
 `);
 

--- a/services/api/database/migrations/20230706000000_shared_baas_bucket.js
+++ b/services/api/database/migrations/20230706000000_shared_baas_bucket.js
@@ -22,4 +22,7 @@ exports.down = async function(knex) {
     .alterTable('project', (table) => {
         table.dropColumn('shared_baas_bucket');
     })
+    .alterTable('openshift', (table) => {
+        table.dropColumn('shared_baas_bucket_name');
+    })
 };

--- a/services/api/database/migrations/20230706000000_shared_baas_bucket.js
+++ b/services/api/database/migrations/20230706000000_shared_baas_bucket.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('openshift', (table) => {
+        table.string('shared_baas_bucket_name', 300);
+    })
+    .alterTable('project', (table) => {
+        table.boolean('shared_baas_bucket').notNullable().defaultTo(1); // defaults all new projects to use the shared baas bucket
+    })
+    .raw(`UPDATE project SET shared_baas_bucket=0;`) // update existing projects already deployed to retain their project specific buckets
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+    .alterTable('project', (table) => {
+        table.dropColumn('shared_baas_bucket');
+    })
+};

--- a/services/api/src/resources/openshift/sql.ts
+++ b/services/api/src/resources/openshift/sql.ts
@@ -13,7 +13,8 @@ export const Sql = {
     friendlyName,
     cloudProvider,
     cloudRegion,
-    buildImage
+    buildImage,
+    sharedBaasBucketName
   }: {
     id?: number;
     name: string;
@@ -27,6 +28,7 @@ export const Sql = {
     cloudProvider?: string;
     cloudRegion?: string;
     buildImage?: string;
+    sharedBaasBucketName?: string;
   }) =>
     knex('openshift')
       .insert({
@@ -41,7 +43,8 @@ export const Sql = {
         friendlyName,
         cloudProvider,
         cloudRegion,
-        buildImage
+        buildImage,
+        sharedBaasBucketName
       })
       .toString(),
   updateOpenshift: ({

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -785,7 +785,8 @@ export const updateProject: ResolverFn = async (
         openshift,
         openshiftProjectPattern,
         developmentEnvironmentsLimit,
-        buildImage
+        buildImage,
+        sharedBaasBucket
       }
     })
   );
@@ -887,7 +888,8 @@ export const updateProject: ResolverFn = async (
         deploymentsDisabled,
         pullrequests,
         developmentEnvironmentsLimit,
-        buildImage
+        buildImage,
+        sharedBaasBucket
       }
     }
   });

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -328,6 +328,15 @@ export const addProject = async (
     }
   }
 
+  let sharedBaasBucket = null;
+  if (input.sharedBaasBucket === false || input.sharedBaasBucket === true) {
+    if (adminScopes.projectViewAll) {
+      sharedBaasBucket = input.sharedBaasBucket
+    } else {
+      throw new Error('Setting shared baas bucket is only available to administrators.');
+    }
+  }
+
   const osRows = await query(sqlClientPool, OS.Sql.selectOpenshift(openshift));
   if(osRows.length == 0) {
     throw Error(`Openshift ID: "${openshift}" does not exist"`);
@@ -594,7 +603,8 @@ export const updateProject: ResolverFn = async (
         deploymentsDisabled,
         pullrequests,
         developmentEnvironmentsLimit,
-        buildImage
+        buildImage,
+        sharedBaasBucket
       }
     }
   },
@@ -608,6 +618,12 @@ export const updateProject: ResolverFn = async (
   if (deploymentsDisabled) {
     if (!adminScopes.projectViewAll) {
       throw new Error('Disabling deployments is only available to administrators.');
+    }
+  }
+
+  if (sharedBaasBucket === false || sharedBaasBucket === true) {
+    if (adminScopes.projectViewAll) {
+      throw new Error('Setting shared baas bucket is only available to administrators.');
     }
   }
 

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -329,7 +329,7 @@ export const addProject = async (
   }
 
   let sharedBaasBucket = null;
-  if (input.sharedBaasBucket === false || input.sharedBaasBucket === true) {
+  if(typeof input.sharedBaasBucket == "boolean") {
     if (adminScopes.projectViewAll) {
       sharedBaasBucket = input.sharedBaasBucket
     } else {
@@ -621,7 +621,7 @@ export const updateProject: ResolverFn = async (
     }
   }
 
-  if (sharedBaasBucket === false || sharedBaasBucket === true) {
+  if(typeof sharedBaasBucket == "boolean") {
     if (adminScopes.projectViewAll) {
       throw new Error('Setting shared baas bucket is only available to administrators.');
     }

--- a/services/api/src/resources/project/sql.ts
+++ b/services/api/src/resources/project/sql.ts
@@ -125,7 +125,8 @@ export const Sql = {
       developmentBuildPriority = 6,
       deploymentsDisabled = 0,
       developmentEnvironmentsLimit = 5,
-      buildImage
+      buildImage,
+      sharedBaasBucket
     } = input;
 
     return knex('project').insert({
@@ -159,7 +160,8 @@ export const Sql = {
     openshift,
     openshiftProjectPattern,
     developmentEnvironmentsLimit,
-    buildImage
+    buildImage,
+    sharedBaasBucket
   }).toString();
  }
 };

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1700,6 +1700,7 @@ const typeDefs = gql`
     developmentBuildPriority: Int
     deploymentsDisabled: Int
     buildImage: String
+    sharedBaasBucket: Boolean
   }
 
   input UpdateProjectInput {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -508,6 +508,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 
@@ -526,6 +527,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 
@@ -789,6 +791,7 @@ const typeDefs = gql`
     Build image this project will use if set
     """
     buildImage: String
+    sharedBaasBucket: Boolean
   }
 
   """
@@ -1313,6 +1316,7 @@ const typeDefs = gql`
     developmentBuildPriority: Int
     deploymentsDisabled: Int
     buildImage: String
+    sharedBaasBucket: Boolean
   }
 
   input AddEnvironmentInput {
@@ -1542,6 +1546,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 
@@ -1562,6 +1567,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 
@@ -1717,6 +1723,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 
@@ -1741,6 +1748,7 @@ const typeDefs = gql`
     cloudProvider: String
     cloudRegion: String
     buildImage: String
+    sharedBaasBucketName: String
     disabled: Boolean
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

As described in #3444 there is a limit on how many buckets there can be in S3.

This changes the behaviour of `new` projects to use a bucket derived from the deploytarget name, or from a defined `sharedBaasBucketName` field on the deploytarget.

There is currently a `LAGOON_BAAS_BUCKET_NAME` override variable that can also be defined in a project, so this still overrides the shared bucket even if the project is `new`. To revert to the shared bucket in this case is to simply delete the `LAGOON_BAAS_BUCKET_NAME` variable.

The change will now create the k8up path like so.
```
${sharedBaasBucketName}/baas-${projectName}
```

To convert an existing project to use the shared bucket, you will need to check for the existence of the override variable and remove it, and then update the project in the Lagoon API to set the projects `sharedBaasBucket=true` (platform-owner role required). This has the negative effect that it basically makes all the existing backups unusable. So transferring the data somehow will need to be done if you wish to retain those backups. A deployment will also need to be performed after setting the `sharedBaasBucket` value.

This requires https://github.com/uselagoon/build-deploy-tool/pull/219 to work

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3444 
