### PR TITLE
feat: helper query to get a deployment by name

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -43,6 +43,7 @@ const {
 const {
   getDeploymentsByEnvironmentId,
   getDeploymentByRemoteId,
+  getDeploymentByName,
   getDeploymentsByBulkId,
   getDeploymentsByFilter,
   addDeployment,
@@ -478,6 +479,7 @@ const resolvers = {
     environmentsByFactSearch: getEnvironmentsByFactSearch,
     userCanSshToEnvironment,
     deploymentByRemoteId: getDeploymentByRemoteId,
+    deploymentByName: getDeploymentByName,
     deploymentsByBulkId: getDeploymentsByBulkId,
     deploymentsByFilter: getDeploymentsByFilter,
     taskByTaskName: getTaskByTaskName,

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -284,6 +284,11 @@ export const getDeploymentByName: ResolverFn = async (
   const projectId = await projectHelpers(sqlClientPool).getProjectIdByName(
     projectName
   );
+
+  await hasPermission('deployment', 'view', {
+    project: projectId
+  });
+
   const environmentRows = await environmentHelpers(sqlClientPool).getEnvironmentByNameAndProject(
     environmentName, projectId
   );
@@ -299,10 +304,6 @@ export const getDeploymentByName: ResolverFn = async (
   if (!deployment) {
     throw new Error('No deployment found');
   }
-
-  await hasPermission('deployment', 'view', {
-    project: projectId
-  });
 
   return deployment;
 };

--- a/services/api/src/resources/environment/helpers.ts
+++ b/services/api/src/resources/environment/helpers.ts
@@ -63,6 +63,20 @@ export const Helpers = (sqlClientPool: Pool) => {
       );
       return aliasOpenshiftToK8s(rows);
     },
+    getEnvironmentByNameAndProject: async (environmentName, projectId) => {
+      const rows = await query(
+        sqlClientPool,
+        Sql.selectEnvironmentByNameAndProject(
+          environmentName,
+          projectId
+        )
+      );
+      if (!R.prop(0, rows)) {
+        throw new Error('Unauthorized');
+      }
+
+      return rows;
+    },
     getEnvironmentsByEnvironmentInput: async environmentInput => {
       const notEmpty = R.complement(R.anyPass([R.isNil, R.isEmpty]));
       const hasId = R.both(R.has('id'), R.propSatisfies(notEmpty, 'id'));

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1090,6 +1090,21 @@ const typeDefs = gql`
     name: String
   }
 
+  input DeploymentByNameInput {
+    """
+    The environment name
+    """
+    environment: String
+    """
+    The project name
+    """
+    project: String
+    """
+    The deployment name (eg, lagoon-build-abc)
+    """
+    name: String
+  }
+
   type Query {
     """
     Returns the current user
@@ -1155,6 +1170,7 @@ const typeDefs = gql`
       kubernetesNamespaceName: String
     ): Environment
     deploymentByRemoteId(id: String): Deployment
+    deploymentByName(input: DeploymentByNameInput): Deployment
     deploymentsByBulkId(bulkId: String): [Deployment]
     deploymentsByFilter(openshifts: [Int], deploymentStatus: [DeploymentStatusType]): [Deployment]
     taskByTaskName(taskName: String): Task


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This is a helper query to easily get a deployment by its name, making it easier to get a deployment status rather than having to use the remoteId. Will make retrieving deployments in the CLI easier, and other systems that know the name of the deployment before the remoteId.

# Usage
```
query deploymentByName {
  deploymentByName(input: {
    name: "build-1"
    environment: "Master"
    project:"high-cotton"
  }){
    name
    status
    remoteId
  }
}
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

