### PR TITLE
fix: add the project directory to restore bucket path

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -1196,7 +1196,10 @@ export const createMiscTask = async function(taskData: any) {
           // Parse out the baasBucketName for any migrated projects
           // check if the project is configured for a shared baas bucket
           let [baasBucketName, shared] = await getBaasBucketName(result.environment.project, result.environment.openshift)
-
+          if (shared) {
+            // if it is a shared bucket, add the repo key to it too for restores
+            baasBucketName = `${baasBucketName}/baas-${makeSafe(taskData.data.project.name)}`
+          }
           // Handle custom backup configurations
           let lagoonBaasCustomBackupEndpoint = result.environment.project.envVariables.find(obj => {
             return obj.name === "LAGOON_BAAS_CUSTOM_BACKUP_ENDPOINT"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

When triggering a restore of a project configured with shared bucket, the project directory was missing. This adds it.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

