### PR TITLE
feat: support querying for disabled deploytargets

### DIFF
--- a/services/api/src/resources/openshift/resolvers.ts
+++ b/services/api/src/resources/openshift/resolvers.ts
@@ -85,12 +85,15 @@ export const deleteOpenshift: ResolverFn = async (
 
 export const getAllOpenshifts: ResolverFn = async (
   root,
-  args,
+  { disabled },
   { sqlClientPool, hasPermission }
 ) => {
   await hasPermission('openshift', 'viewAll');
 
-  return query(sqlClientPool, 'SELECT * FROM openshift');
+  if (disabled != null) {
+    return query(sqlClientPool, knex('openshift').where('disabled', disabled).toString());
+  }
+  return query(sqlClientPool, knex('openshift').toString());
 };
 
 export const getOpenshiftByProjectId: ResolverFn = async (

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1190,11 +1190,11 @@ const typeDefs = gql`
     """
     Returns all OpenShift Objects
     """
-    allOpenshifts: [Openshift]
+    allOpenshifts(disabled: Boolean): [Openshift]
     """
     Returns all Kubernetes Objects
     """
-    allKubernetes: [Kubernetes]
+    allKubernetes(disabled: Boolean): [Kubernetes]
     """
     Returns all Environments matching given filter (all if no filter defined)
     """


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just adds some optional search parameters to the `allOpenshift|Kubernetes` query to allow searching for `disabled` deploytargets specifically supports `true|false` and is optional so doesn't impact existing functionality

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

