### PR TITLE
feat: support changing more settings in keycloak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ STERN_VERSION = v2.6.1
 CHART_TESTING_VERSION = v3.9.0
 K3D_IMAGE = docker.io/rancher/k3s:v1.26.6-k3s1
 TESTS = [nginx,api,features-kubernetes,bulk-deployment,features-kubernetes-2,features-variables,active-standby-kubernetes,tasks,drush,python,gitlab,github,bitbucket,services,workflows]
-CHARTS_TREEISH = keycloak-realm-settings
+CHARTS_TREEISH = organizations
 TASK_IMAGES = task-activestandby
 
 # Symlink the installed kubectl client if the correct version is already

--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ api-development: build/api build/api-db build/local-api-data-watcher-pusher buil
 
 .PHONY: ui-logs-development
 ui-logs-development: build/actions-handler build/api build/api-db build/local-api-data-watcher-pusher build/keycloak build/keycloak-db build/broker-single build/api-redis build/logs2notifications build/local-minio
-	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility up -d api api-db actions-handler local-api-data-watcher-pusher ui keycloak keycloak-db broker api-redis logs2notifications local-minio local-minio-upload
+	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility up -d api api-db actions-handler local-api-data-watcher-pusher ui keycloak keycloak-db broker api-redis logs2notifications local-minio local-minio-upload mailhog
 
 ## CI targets
 

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ STERN_VERSION = v2.6.1
 CHART_TESTING_VERSION = v3.9.0
 K3D_IMAGE = docker.io/rancher/k3s:v1.26.6-k3s1
 TESTS = [nginx,api,features-kubernetes,bulk-deployment,features-kubernetes-2,features-variables,active-standby-kubernetes,tasks,drush,python,gitlab,github,bitbucket,services,workflows]
-CHARTS_TREEISH = main
+CHARTS_TREEISH = keycloak-realm-settings
 TASK_IMAGES = task-activestandby
 
 # Symlink the installed kubectl client if the correct version is already

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
   mailhog:
     image: mailhog/mailhog
     ports:
-      - 8025
+      - '32025:8025'
   webhooks2tasks:
     image: ${IMAGE_REPO:-lagoon}/webhooks2tasks
     command: yarn run dev
@@ -128,9 +128,12 @@ services:
       - keycloak-db
     ports:
       - '8088:8080'
+    environment:
+      - KEYCLOAK_ADMIN_EMAIL=admin@example.com
     volumes:
       - "./services/keycloak/profile.properties:/opt/jboss/keycloak/standalone/configuration/profile.properties"
       - "./services/keycloak/startup-scripts:/opt/jboss/startup-scripts"
+      - "./local-dev/keycloak:/lagoon/keycloak"
   keycloak-db:
     image: ${IMAGE_REPO:-lagoon}/keycloak-db
     ports:

--- a/local-dev/keycloak/keycloak-realm-settings.json
+++ b/local-dev/keycloak/keycloak-realm-settings.json
@@ -1,0 +1,5 @@
+{
+	"rememberMe": true,
+	"resetPasswordAllowed": true,
+	"verifyEmail": false
+}

--- a/local-dev/keycloak/keycloak-realm-settings.json
+++ b/local-dev/keycloak/keycloak-realm-settings.json
@@ -1,5 +1,6 @@
 {
 	"rememberMe": true,
 	"resetPasswordAllowed": true,
-	"verifyEmail": false
+	"verifyEmail": false,
+	"editUsernameAllowed": false
 }

--- a/local-dev/keycloak/keycloak-smtp-settings.json
+++ b/local-dev/keycloak/keycloak-smtp-settings.json
@@ -1,0 +1,16 @@
+{
+	"smtpServer": {
+		"envelopeFrom": "lagoon@example.com",
+		"from": "lagoon@example.com",
+		"fromDisplayName": "Lagoon",
+		"host": "mailhog",
+		"port": "1025",
+		"replyTo": "lagoon@example.com",
+		"replyToDisplayName": "Lagoon No-Reply",
+		"ssl": "false",
+		"starttls": "false",
+		"auth": "false",
+		"user": "not-used-if-auth=false",
+		"password": "not-used-if-auth=false"
+	}
+}

--- a/local-dev/keycloak/keycloak-smtp-settings.json
+++ b/local-dev/keycloak/keycloak-smtp-settings.json
@@ -2,11 +2,11 @@
 	"smtpServer": {
 		"envelopeFrom": "lagoon@example.com",
 		"from": "lagoon@example.com",
-		"fromDisplayName": "Lagoon",
+		"fromDisplayName": "Local Lagoon",
 		"host": "mailhog",
 		"port": "1025",
 		"replyTo": "lagoon@example.com",
-		"replyToDisplayName": "Lagoon No-Reply",
+		"replyToDisplayName": "Local Lagoon No-Reply",
 		"ssl": "false",
 		"starttls": "false",
 		"auth": "false",

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -71,6 +71,7 @@ function configure_lagoon_realm {
     CLIENT_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get  -r lagoon clients?clientId=lagoon-ui --config $CONFIG_PATH | jq -r '.[0]["id"]')
     echo '{"protocol":"openid-connect","config":{"id.token.claim":"true","access.token.claim":"true","userinfo.token.claim":"true","user.attribute":"lagoon-uid","claim.name":"lagoon.user_id","jsonType.label":"int","multivalued":""},"name":"Lagoon User ID","protocolMapper":"oidc-usermodel-attribute-mapper"}' | /opt/jboss/keycloak/bin/kcadm.sh create -r ${KEYCLOAK_REALM:-master} clients/$CLIENT_ID/protocol-mappers/models --config $CONFIG_PATH -f -
 
+    # don't use KEYCLOAK_REALM_SETTINGS, use the 'configure_realm_settings' way to pass values from a file (inject by configmap/volume mount)
     if [ "$KEYCLOAK_REALM_SETTINGS" ]; then
         echo Applying extra Realm settings
         echo $KEYCLOAK_REALM_SETTINGS | /opt/jboss/keycloak/bin/kcadm.sh update realms/${KEYCLOAK_REALM:-master} --config $CONFIG_PATH -f -
@@ -88,6 +89,39 @@ function configure_lagoon_realm {
         /opt/jboss/keycloak/bin/kcadm.sh add-roles --config $CONFIG_PATH -r ${KEYCLOAK_REALM:-master} --uid ${user_id} --rolename admin
         echo "Gave user '$KEYCLOAK_LAGOON_ADMIN_USERNAME' the role 'admin'"
     fi
+}
+
+function configure_admin_email {
+  # Configure the admin user with an email address so that email configuration can be enabled in the lagoon realm
+  # this will always update the email address of the admin user if it is defined
+  if [ "$KEYCLOAK_ADMIN_EMAIL" != "" ]; then
+    echo Configuring admin user email to ${KEYCLOAK_ADMIN_EMAIL}
+    ADMIN_USER_ID=$(/opt/jboss/keycloak/bin/kcadm.sh get users -r master --config $CONFIG_PATH -q username=admin | jq -r '.[0]|.id')
+    /opt/jboss/keycloak/bin/kcadm.sh update users/${ADMIN_USER_ID} --config $CONFIG_PATH -s "email=${KEYCLOAK_ADMIN_EMAIL}"
+  fi
+
+}
+
+function configure_smtp_settings {
+  # this checks if the file containing the json data for email configuration exists
+  if [ "$KEYCLOAK_ADMIN_EMAIL" == "" ] && [ -f "/lagoon/keycloak/keycloak-smtp-settings.json" ]; then
+    echo "Admin email must be set to configure lagoon realm email server settings"
+    return 0
+  fi
+  if [ -f "/lagoon/keycloak/keycloak-smtp-settings.json" ]; then
+    echo Configuring lagoon realm email server settings
+    /opt/jboss/keycloak/bin/kcadm.sh update realms/lagoon --config $CONFIG_PATH -f /lagoon/keycloak/keycloak-smtp-settings.json
+  fi
+
+}
+
+function configure_realm_settings {
+  # this checks if the file containing the json data for realm settings exists
+  if [ -f "/lagoon/keycloak/keycloak-realm-settings.json" ]; then
+    echo Configuring lagoon realm settings
+    /opt/jboss/keycloak/bin/kcadm.sh update realms/lagoon --config $CONFIG_PATH -f /lagoon/keycloak/keycloak-realm-settings.json
+  fi
+
 }
 
 function configure_opendistro_security_client {
@@ -2431,6 +2465,9 @@ function configure_keycloak {
 
     # Sets the order of migrations, add new ones at the end.
     configure_lagoon_realm
+    configure_admin_email
+    configure_smtp_settings
+    configure_realm_settings
     configure_opendistro_security_client
     configure_api_client
     add_group_viewall


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds the ability to configure additional realm settings easily using json files, and also set the admin user email address which seems to be required for configuring email.

There does exist an existing way to apply realm settings using an envvar, but it is cumbersome. This new way allows helm to create a configmap to then volumemount to the required location and be consumed.

I've separated out the smtp configuration to its own step so that the email configuration can be provided separately to other realm settings easily, but they still use the same endpoint in the end.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

