### PR TITLE
chore: allow changing the lagoon realm frontend url

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,6 +131,7 @@ services:
     ports:
       - '8088:8080'
     environment:
+      - KEYCLOAK_FRONTEND_URL=http://localhost:8088/auth
       - KEYCLOAK_ADMIN_EMAIL=admin@example.com
     volumes:
       - "./services/keycloak/profile.properties:/opt/jboss/keycloak/standalone/configuration/profile.properties"

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -102,6 +102,21 @@ function configure_admin_email {
 
 }
 
+function configure_keycloak_frontend_url {
+  # this configures the realm frontend url
+  if [ "$KEYCLOAK_FRONTEND_URL" != "" ]; then
+    echo Configuring frontend url to ${KEYCLOAK_FRONTEND_URL}
+    /opt/jboss/keycloak/bin/kcadm.sh update realms/lagoon --config $CONFIG_PATH -f - <<EOF
+{
+  "attributes": {
+    "frontendUrl": "${KEYCLOAK_FRONTEND_URL}"
+  }
+}
+EOF
+  fi
+
+}
+
 function configure_smtp_settings {
   # this checks if the file containing the json data for email configuration exists
   if [ "$KEYCLOAK_ADMIN_EMAIL" == "" ] && [ -f "/lagoon/keycloak/keycloak-smtp-settings.json" ]; then
@@ -2466,6 +2481,7 @@ function configure_keycloak {
     # Sets the order of migrations, add new ones at the end.
     configure_lagoon_realm
     configure_admin_email
+    configure_keycloak_frontend_url
     configure_smtp_settings
     configure_realm_settings
     configure_opendistro_security_client


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Allows for setting the frontendUrl in the `lagoon` realm via an envvar. This allows password reset emails to provide the correct URL for resets.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

