### PR TITLE
refactor: improve the query for deploymentsbyfilter for platform users

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -193,21 +193,19 @@ export const getDeploymentsByFilter: ResolverFn = async (
   }
 
   let queryBuilder = knex.select("deployment.*").from('deployment').
-      join('environment', 'deployment.environment', '=', 'environment.id').
-      join('project', 'environment.project', '=', 'project.id').
-      where('environment.deleted', '=', '0000-00-00 00:00:00');
+      join('environment', 'deployment.environment', '=', 'environment.id');
+
+  if (userProjectIds) {
+      queryBuilder = queryBuilder.whereIn('environment.project', userProjectIds);
+  }
 
   if(openshifts) {
     queryBuilder = queryBuilder.whereIn('environment.openshift', openshifts);
   }
 
-
   queryBuilder = queryBuilder.whereIn('deployment.status', deploymentStatus);
 
-
-  if (userProjectIds) {
-    queryBuilder = queryBuilder.whereIn('project.id', userProjectIds);
-  }
+  queryBuilder = queryBuilder.where('environment.deleted', '=', '0000-00-00 00:00:00');
 
   const queryBuilderString = queryBuilder.toString();
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This changes the query for `deploymentsByFilter` to only add the project join when projects are requested. This improves the response on the query considerably by not doing the project join for no reason.

```
> select deployment.* from deployment join environment on deployment.environment = environment.id join project on environment.project = project.id where environment.deleted = '0000-00-00 00:00:00' and deployment.status in ("NEW", "PENDING", "RUNNING", "QUEUED");
<SNIP>
8 rows in set (25.832 sec)
```
versus this when not including the project join for no reason
```
> select deployment.* from deployment join environment on deployment.environment = environment.id where environment.deleted = '0000-00-00 00:00:00' and deployment.status in ("NEW", "PENDING", "RUNNING", "QUEUED");
<snip>
8 rows in set (2.333 sec)
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
