### PR TITLE
refactor: reduce user queries to keycloak

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -437,12 +437,14 @@ export const Group = (clients: {
     let membership = [];
     for (const roleSubgroup of roleSubgroups) {
       const keycloakUsers = await keycloakAdminClient.groups.listMembers({
-        id: roleSubgroup.id
+        id: roleSubgroup.id,
+        briefRepresentation: false,
       });
 
       let members = [];
       for (const keycloakUser of keycloakUsers) {
-        const fullUser = await UserModel.loadUserById(keycloakUser.id);
+        const users = await UserModel.transformKeycloakUsers([keycloakUser]);
+        const fullUser = users[0]
         const member = {
           user: fullUser,
           role: roleSubgroup.realmRoles[0],

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -54,6 +54,7 @@ interface UserModel {
   updateUser: (userInput: UserEdit) => Promise<User>;
   deleteUser: (id: string) => Promise<void>;
   resetUserPassword: (id: string) => Promise<void>;
+  transformKeycloakUsers: (keycloakUsers: UserRepresentation[]) => Promise<User[]>;
 }
 
 interface AttributeFilterFn {
@@ -681,6 +682,7 @@ export const User = (clients: {
     addUser,
     updateUser,
     deleteUser,
-    resetUserPassword
+    resetUserPassword,
+    transformKeycloakUsers
   };
 };


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This removes a step to query keycloak for user information when the information required is already in the payload from the `listMembers` query.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

