### PR TITLE
Split image pushing to dockerhub up to avoid contention

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,9 +33,16 @@ pipeline {
         sh script: "docker image prune -af", label: "Pruning images"
       }
     }
-    stage ('build images') {
+    stage ('build and push images') {
+      environment {
+        PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+      }
       steps {
         sh script: "make -O build", label: "Building images"
+        retry(3) {
+          sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+          sh script: "make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/amd64 BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built amd64 images to testlagoon/*"
+        }
       }
     }
     stage ('show trivy scan results') {
@@ -62,20 +69,6 @@ pipeline {
             sh script: "cat test-suite-0.txt", label: "View ${NODE_NAME}:${WORKSPACE}/test-suite-0.txt"
           }
         }
-        stage ('push images to testlagoon/*') {
-          when {
-            not {
-              environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
-            }
-          }
-          environment {
-            PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
-          }
-          steps {
-            sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-            sh script: "make -O publish-testlagoon-images BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
-          }
-        }
       }
     }
     stage ('run first test suite') {
@@ -92,6 +85,22 @@ pipeline {
               sh script: "./local-dev/stern --kubeconfig ./kubeconfig.k3d.${CI_BUILD_TAG} --all-namespaces '^[a-z]' --since 1s -t > test-suite-1.txt || true", label: "Collecting test-suite-1 logs"
             }
             sh script: "cat test-suite-1.txt", label: "View ${NODE_NAME}:${WORKSPACE}/test-suite-1.txt"
+          }
+        }
+        stage ('push all images to testlagoon/*') {
+          when {
+            not {
+              environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
+            }
+          }
+          environment {
+            PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+          }
+          steps {
+            retry(3) {
+              sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+              sh script: "make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/arm64,linux/amd64 BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
+            }
           }
         }
       }


### PR DESCRIPTION
It appears that a number of the push failures (and slowness) in Jenkins have been caused by resource contention.

This PR moves the initial amd64 image push immediately after the build phase - this will allow images to be quickly used when required. It then moves the multiarch image push to the second test phase - when no docker actions are occurring on the host.

All image push routines also have a retry set for them to hopefully cope better with failures.

