### PR TITLE
refactor: use keycloak cache

### DIFF
--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -9,6 +9,7 @@ import { sqlClientPool } from '../clients/sqlClient';
 import { query } from '../util/db';
 import { Sql } from '../resources/user/sql';
 import { getConfigFromEnv } from '../util/config';
+import { getRedisKeycloakCache } from '../clients/redisClient';
 
 interface IUserAttributes {
   comment?: [string];
@@ -322,7 +323,19 @@ export const User = (clients: {
       id: userId,
       briefRepresentation: false
     });
-    const fullGroups = await keycloakAdminClient.groups.find({briefRepresentation: false});
+
+    let fullGroups = [];
+    try {
+      // check redis for the allgroups cache value
+      const data = await getRedisKeycloakCache("allgroups");
+      let buff = new Buffer(data, 'base64');
+      fullGroups = JSON.parse(buff.toString('utf-8'));
+    } catch (err) {
+      logger.warn(`Couldn't check redis keycloak cache: ${err.message}`);
+      // if it can't be recalled from redis, get the data from keycloak
+      const allGroups = await GroupModel.loadAllGroups();
+      fullGroups = await GroupModel.transformKeycloakGroups(allGroups);
+    }
 
     const regexp = /-(owner|maintainer|developer|reporter|guest)$/g;
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

The list all users groups function doesn't return all the attributes of the groups, so it was written to also consume all the groups and then iterate over them to get the attributes. This unfortunately had a cache bypass in there, this corrects it to consume from the cache instead of querying keycloak directly.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
