### PR TITLE
fix: permission changes for some organization changes

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -385,7 +385,9 @@ export const getUserByEmailAndOrganizationId: ResolverFn = async (
   { email, organization},
   { sqlClientPool, models, hasPermission },
 ) => {
-  await hasPermission('organization', 'viewUser', organization);
+  await hasPermission('organization', 'viewUser', {
+    organization: organization
+  });
 
   try {
     const user = await models.UserModel.loadUserByUsername(email);

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -233,9 +233,15 @@ export const addUserToOrganization: ResolverFn = async (
     owner: false,
   }
   if (owner) {
+    await hasPermission('organization', 'addOwner', {
+      organization: organization
+    });
     updateUser.owner = true
+  } else {
+    await hasPermission('organization', 'addViewer', {
+      organization: organization
+    });
   }
-  await hasPermission('organization', 'addViewer')
   await models.UserModel.updateUser(updateUser);
 
   userActivityLogger(`User added a user to organization '${organizationData.name}'`, {
@@ -272,7 +278,9 @@ export const removeUserFromOrganization: ResolverFn = async (
     username: R.prop('email', userInput),
   });
 
-  await hasPermission('organization', 'addOwner');
+  await hasPermission('organization', 'addOwner', {
+    organization: organization
+  });
 
   await models.UserModel.updateUser({
     id: user.id,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Small fix to the way the viewUser permission is checked in organizations, and the permission around addOwner and addViewer

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

