### PR TITLE
refactor: flag to support adding orgowner as owner of project or group on creation

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -379,8 +379,16 @@ export const addGroup: ResolverFn = async (
   });
   await models.GroupModel.addProjectToGroup(null, group);
 
-  // if the user is not an admin, or an organization add, then add the user as an owner to the group
-  if (!adminScopes.projectViewAll && !input.organization && keycloakGrant) {
+  // if the user is not an admin, then add the user as an owner to the group
+  let userAlreadyHasAccess = false;
+  if (adminScopes.projectViewAll) {
+    userAlreadyHasAccess = true
+  }
+  // if the group is created without the addOrgOwner boolean set to true, then do not add the user to the group as its owner
+  if (!input.addOrgOwner) {
+    userAlreadyHasAccess = true
+  }
+  if (!userAlreadyHasAccess && keycloakGrant) {
     const user = await models.UserModel.loadUserById(
       keycloakGrant.access_token.content.sub
     );

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -293,7 +293,10 @@ export const addProject = async (
     await hasPermission('organization', 'addProject', {
       organization: input.organization
     });
-    userAlreadyHasAccess = true
+    // if the project is created without the organizationProjectOwner boolean set to true, then do not add the user to the project as its owner
+    if (!input.organizationProjectOwner) {
+      userAlreadyHasAccess = true
+    }
     // check the project quota before adding the project
     const organization = await organizationHelpers(sqlClientPool).getOrganizationById(input.organization);
     const projects = await organizationHelpers(sqlClientPool).getProjectsByOrganizationId(input.organization);

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -293,8 +293,8 @@ export const addProject = async (
     await hasPermission('organization', 'addProject', {
       organization: input.organization
     });
-    // if the project is created without the organizationProjectOwner boolean set to true, then do not add the user to the project as its owner
-    if (!input.organizationProjectOwner) {
+    // if the project is created without the addOrgOwner boolean set to true, then do not add the user to the project as its owner
+    if (!input.addOrgOwner) {
       userAlreadyHasAccess = true
     }
     // check the project quota before adding the project

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1491,6 +1491,7 @@ const typeDefs = gql`
     developmentBuildPriority: Int
     deploymentsDisabled: Int
     organization: Int
+    organizationProjectOwner: Boolean
     buildImage: String
     sharedBaasBucket: Boolean
   }

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1491,7 +1491,7 @@ const typeDefs = gql`
     developmentBuildPriority: Int
     deploymentsDisabled: Int
     organization: Int
-    organizationProjectOwner: Boolean
+    addOrgOwner: Boolean
     buildImage: String
     sharedBaasBucket: Boolean
   }
@@ -2176,6 +2176,7 @@ const typeDefs = gql`
     name: String!
     parentGroup: GroupInput
     organization: Int
+    addOrgOwner: Boolean
   }
 
   input UpdateGroupPatchInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds a boolean `organizationProjectOwner` to addProject that if set to true will add the organization owner to the newly created project

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

