### PR TITLE
fix: reset exists check at the end of the loop

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -372,8 +372,8 @@ export const getUsersByOrganizationId: ResolverFn = async (
           }
         }
         members.push(groupMembers[member].user)
-        exists = false
       }
+      exists = false
     }
   }
   return members.map(row => ({ ...row, organization: args.organization }));


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

There was a condition where the user already exists check resulted in the `true` statement being retained, preventing new users that aren't already counted from being counted.

This fixes it by resetting the exists check at the end of the user loop check

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

