### PR TITLE
fix: return error if project not found

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -208,7 +208,9 @@ export const getProjectByName: ResolverFn = async (
   const project = withK8s[0];
 
   if (!project) {
-    return null;
+    throw new Error(
+      `No project matching ${project.name} found`
+    );
   }
 
   try {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information and context so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

If you query the API for a project by name and the project does not exist, you get a strange error that makes it difficult to know what went wrong. This fixes it to return a project not found error instead

Previous error, what does it mean?
```
{
  "errors": [
    {
      "message": "Cannot read properties of undefined (reading 'id')",
      "locations": [
        {
          "line": 100,
          "column": 3
        }
      ],
      "path": [
        "projectByName"
      ]
    }
  ],
  "data": {
    "projectByName": null
  }
}
```

closes #3547 