### PR TITLE
Point Ansible tests temporarily at the old-galaxy server

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -5,3 +5,7 @@ host_key_checking = False
 deprecation_warnings = False
 interpreter_python = auto_silent
 callback_whitelist = profile_tasks
+
+[galaxy]
+server = https://old-galaxy.ansible.com/
+;server = https://galaxy.ansible.com/


### PR DESCRIPTION
In our old version of ansible, access to the replaced galaxy server is temporarily restricted - this points back at the legacy infra whilst we upgrade ansible.

to do:
- [ ] Submit PR with updated Ansible version (in progress)