### PR TITLE
refactor: deploytargetconfig permission for projects in organizations

### DIFF
--- a/services/api/src/resources/deploytargetconfig/resolvers.ts
+++ b/services/api/src/resources/deploytargetconfig/resolvers.ts
@@ -11,7 +11,6 @@ import { Sql as EnvironmentSql } from '../environment/sql'
 import { Helpers as projectHelpers } from '../project/helpers';
 import { Helpers as organizationHelpers } from '../organization/helpers';
 
-
 export const getDeployTargetConfigById = async (
   root,
   args,
@@ -26,9 +25,7 @@ export const getDeployTargetConfigById = async (
   // since deploytargetconfigs are associated to a project
   // re-use the existing `project:view` permissions check, since the same sorts of fields
   // are viewable by the same permissions at the project scope
-  await hasPermission('project', 'view', {
-    project: deployTargetConfig.project
-  });
+  await projectHelpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, deployTargetConfig.project)
 
   return deployTargetConfig;
 };
@@ -47,9 +44,7 @@ export const getDeployTargetConfigsByProjectId: ResolverFn = async (
   // since deploytargetconfigs are associated to a project
   // re-use the existing `project:view` permissions check, since the same sorts of fields
   // are viewable by the same permissions at the project scope
-  await hasPermission('project', 'view', {
-    project: pid
-  });
+  await projectHelpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, pid)
 
   const rows = await query(sqlClientPool, Sql.selectDeployTargetConfigsByProjectId(pid));
 
@@ -196,9 +191,7 @@ export const addDeployTargetConfig: ResolverFn = async (
   // since deploytargetconfigs are associated to a project
   // re-use the existing `project:update` permissions check, since the same sorts of fields
   // are updateable by the same permissions at the project scope
-  await hasPermission('project', 'update', {
-    project: project
-  });
+  await projectHelpers(sqlClientPool).checkOrgProjectUpdatePermission(hasPermission, project)
 
   // check the project has an organization id, if it does, check that the organization supports the requested deploytarget
   await checkProjectDeployTargetByOrg(project, deployTarget, sqlClientPool)
@@ -246,9 +239,7 @@ export const deleteDeployTargetConfig: ResolverFn = async (
   // re-use the existing `project:update` permissions check, since the same sorts of fields
   // are updateable by the same permissions at the project scope
   // deleting a deploytargetconfig from a project is classed as updating the project
-  await hasPermission('project', 'update', {
-    project: project
-  });
+  await projectHelpers(sqlClientPool).checkOrgProjectUpdatePermission(hasPermission, project)
 
   try {
     await query(sqlClientPool, 'DELETE FROM deploy_target_config WHERE id = :id', {
@@ -292,9 +283,7 @@ export const updateDeployTargetConfig: ResolverFn = async (
   // since deploytargetconfigs are associated to a project
   // re-use the existing `project:update` permissions check, since the same sorts of fields
   // are updateable by the same permissions at the project scope
-  await hasPermission('project', 'update', {
-    project: deployTargetConfig.project
-  });
+  await projectHelpers(sqlClientPool).checkOrgProjectUpdatePermission(hasPermission, deployTargetConfig.project)
 
   // check the project has an organization id, if it does, check that the organization supports the requested deploytarget
   await checkProjectDeployTargetByOrg(deployTargetConfig.project, deployTarget, sqlClientPool)

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -124,19 +124,7 @@ export const getProjectByEnvironmentId: ResolverFn = async (
 
   const project = withK8s[0];
 
-  try {
-    await hasPermission('project', 'view', {
-      project: project.id
-    });
-  } catch (err) {
-    // if the user hasn't got permission to view the project, but the project is in the organization
-    // allow the user to get the project
-    if (project.organization != null) {
-      await hasPermission('organization', 'viewProject', {
-        organization: project.organization
-      });
-    }
-  }
+  await Helpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, project.id)
 
   return project;
 };
@@ -152,19 +140,7 @@ export const getProjectById: ResolverFn = async (
 
   const project = withK8s[0];
 
-  try {
-    await hasPermission('project', 'view', {
-      project: project.id
-    });
-  } catch (err) {
-    // if the user hasn't got permission to view the project, but the project is in the organization
-    // allow the user to get the project
-    if (project.organization != null) {
-      await hasPermission('organization', 'viewProject', {
-        organization: project.organization
-      });
-    }
-  }
+  await Helpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, project.id)
 
   return project;
 };
@@ -180,19 +156,7 @@ export const getProjectByGitUrl: ResolverFn = async (
 
   const project = withK8s[0];
 
-  try {
-    await hasPermission('project', 'view', {
-      project: project.id
-    });
-  } catch (err) {
-    // if the user hasn't got permission to view the project, but the project is in the organization
-    // allow the user to get the project
-    if (project.organization != null) {
-      await hasPermission('organization', 'viewProject', {
-        organization: project.organization
-      });
-    }
-  }
+  await Helpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, project.id)
 
   return project;
 };
@@ -211,19 +175,7 @@ export const getProjectByName: ResolverFn = async (
     return null;
   }
 
-  try {
-    await hasPermission('project', 'view', {
-      project: project.id
-    });
-  } catch (err) {
-    // if the user hasn't got permission to view the project, but the project is in the organization
-    // allow the user to get the project
-    if (project.organization != null) {
-      await hasPermission('organization', 'viewProject', {
-        organization: project.organization
-      });
-    }
-  }
+  await Helpers(sqlClientPool).checkOrgProjectViewPermission(hasPermission, project.id)
 
   return project;
 };


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Changes the permission for projects that are in organizations to allow only organization owners the permission to add or modify deploytarget configs. This is because organizations have deploytargets assigned to them, and organization owners should be able to restrict where projects deploy their environments to from the targets assigned to the organization.

The behavior remains the same for projects not in an organization, where anyone with the permission to update a project can add or modify.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
