### PR TITLE
Document why Lagoon disables automatic updates for Drupal

### DIFF
--- a/docs/drupal/automatic-updates.md
+++ b/docs/drupal/automatic-updates.md
@@ -1,0 +1,33 @@
+# Automatic Updates
+
+Lagoon deploys applications in a way that is not compatible with some methods of
+updating Drupal core and contrib. Lagoon expects to build immutable images and
+run immutable containers. When the code of the application is changed at
+runtime, it can cause any of the following problems:
+
+1. Containers are managed automatically by Kubernetes and may be moved,
+   restarted, or scaled at any time. When this happens, the original built
+   container image will be ran and any changes that happened at runtime are
+   lost.
+2. Tasks and cronjobs may run with the orignal built container image and won't
+   have access to any updated code.
+3. Updating requires write permissions to the filesystem, but it is possible to
+   configure an environment that forces a read-only filesystem.
+4. Best practices is to deploy small containers that each do one thing. For a
+   typical Drupal project this means there is a `cli`, `php`, and `nginx`
+   container which each contain a copy of the code. Updating only one of these
+   containers will cause issues with code mismatches.
+
+The following update methods been disabled by Lagoon.
+
+### Drupal Automatic Updates
+
+The [Automatic Updates](https://www.drupal.org/project/automatic_updates)
+contrib module is disabled by and it will also be disabled when it moves
+into Drupal core.
+
+### Drush
+
+Using `drush pm-install` or `drush pm-update` is disabled by default as part of
+the [amazeeio/drupal-integrations](https://github.com/amazeeio/drupal-integrations)
+package.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Subfolders: drupal/subfolders.md
     - Integrate Drupal & Fastly: drupal/integrate-drupal-and-fastly.md
     - PHPUnit and PhpStorm: drupal/phpunit-and-phpstorm.md
+    - Automatic Updates: drupal/automatic-updates.md
   - WordPress:
     - Overview: applications/wordpress.md
   - Node.js-based:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Adds a page to the docs that we can use to disabled automatic updates for Drush and Drupal automatic updates.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Part of #3504 
