### PR TITLE
fix: check environment doesnt exist before checking env quotas

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/04-populate-api-data-organizations.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/04-populate-api-data-organizations.gql
@@ -7,7 +7,7 @@ mutation PopulateApi {
     friendlyName: "Test Organization"
     description: "An organization for testing"
     quotaProject: 5
-    quotaEnvironment: 15
+    quotaEnvironment: 4
     quotaGroup: 10
     quotaNotification: 10
   }) {

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -768,12 +768,15 @@ export const createDeployTask = async function(deployData: any) {
   const environments = await getEnvironmentsForProject(projectName);
 
   if (project.organization) {
-    // check the environment quota, this prevents environments being deployed by the api or webhooks
-    const curOrg = await getOrganizationById(project.organization);
-    if (curOrg.environments.length >= curOrg.quotaEnvironment) {
-      throw new OrganizationEnvironmentLimit(
-        `'${branchName}' would exceed the organization environment quota of ${curOrg.quotaEnvironment}`
-      );
+    // if this would be a new environment, check it against the environment quota
+    if (!environments.project.environments.map(e => e.name).find(i => i === branchName)) {
+      // check the environment quota, this prevents environments being deployed by the api or webhooks
+      const curOrg = await getOrganizationById(project.organization);
+      if (curOrg.environments.length >= curOrg.quotaEnvironment) {
+        throw new OrganizationEnvironmentLimit(
+          `'${branchName}' would exceed the organization environment quota of ${curOrg.quotaEnvironment}`
+        );
+      }
     }
   }
 

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -367,13 +367,16 @@ export const addOrUpdateEnvironment: ResolverFn = async (
   }
 
   if (projectOpenshift.organization) {
-    // check the environment quota, this prevents environments being added directly via the api
+    // if this would be a new environment, check it against the quota
     const curEnvs = await organizationHelpers(sqlClientPool).getEnvironmentsByOrganizationId(projectOpenshift.organization)
-    const curOrg = await organizationHelpers(sqlClientPool).getOrganizationById(projectOpenshift.organization)
-    if (curEnvs.length >= curOrg.quotaEnvironment && curOrg.quotaEnvironment != -1) {
-      throw new Error(
-        `Environment would exceed organization environment quota: ${curEnvs.length}/${curOrg.quotaEnvironment}`
-      );
+    if (!curEnvs.map(e => e.name).find(i => i === input.name)) {
+      // check the environment quota, this prevents environments being added directly via the api
+      const curOrg = await organizationHelpers(sqlClientPool).getOrganizationById(projectOpenshift.organization)
+      if (curEnvs.length >= curOrg.quotaEnvironment && curOrg.quotaEnvironment != -1) {
+        throw new Error(
+          `Environment would exceed organization environment quota: ${curEnvs.length}/${curOrg.quotaEnvironment}`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Fixes the environment quota check to make sure that an environment that already exists isn't evaluated to check if the quota is exceeded, and to allow it through as normal.

Also modifies the example organization deployed in local dev with a 4 env quota to validate

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

