### PR TITLE
fix: support unlimited env quota in commons

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -772,9 +772,9 @@ export const createDeployTask = async function(deployData: any) {
     if (!environments.project.environments.map(e => e.name).find(i => i === branchName)) {
       // check the environment quota, this prevents environments being deployed by the api or webhooks
       const curOrg = await getOrganizationById(project.organization);
-      if (curOrg.environments.length >= curOrg.quotaEnvironment) {
+      if (curOrg.environments.length >= curOrg.quotaEnvironment && curOrg.quotaEnvironment != -1) {
         throw new OrganizationEnvironmentLimit(
-          `'${branchName}' would exceed the organization environment quota of ${curOrg.quotaEnvironment}`
+          `'${branchName}' would exceed organization environment quota: ${curOrg.environments.length}/${curOrg.quotaEnvironment}`
         );
       }
     }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a minor fix to support the unlimited (-1) support for environment quotas in organizations in the node-packages that was missed initially

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

