### PR TITLE
fix: purge the cached id of the group when group is deleted

### DIFF
--- a/services/api/src/clients/redisClient.ts
+++ b/services/api/src/clients/redisClient.ts
@@ -31,7 +31,7 @@ export const get = promisify(redisClient.get).bind(redisClient);
 const hgetall = promisify(redisClient.hgetall).bind(redisClient);
 const smembers = promisify(redisClient.smembers).bind(redisClient);
 const sadd = promisify(redisClient.sadd).bind(redisClient);
-const del = promisify(redisClient.del).bind(redisClient);
+export const del = promisify(redisClient.del).bind(redisClient);
 
 interface IUserResourceScope {
   resource: string;

--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -9,7 +9,7 @@ import { logger } from '../loggers/logger';
 // @ts-ignore
 import GroupRepresentation from 'keycloak-admin/lib/defs/groupRepresentation';
 import { User } from './user';
-import { saveRedisKeycloakCache, get, redisClient } from '../clients/redisClient';
+import { saveRedisKeycloakCache, get, del, redisClient } from '../clients/redisClient';
 import { Helpers as projectHelpers } from '../resources/project/helpers';
 import { sqlClientPool } from '../clients/sqlClient';
 import { log } from 'winston';
@@ -627,6 +627,11 @@ export const Group = (clients: {
 
   const deleteGroup = async (id: string): Promise<void> => {
     try {
+      const keycloakGroup = await keycloakAdminClient.groups.findOne({
+        id,
+        briefRepresentation: false,
+      });
+      del(`cache:keycloak:group-id:${keycloakGroup.name}`);
       await keycloakAdminClient.groups.del({ id });
     } catch (err) {
       if (err.response.status && err.response.status === 404) {

--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -631,7 +631,7 @@ export const Group = (clients: {
         id,
         briefRepresentation: false,
       });
-      del(`cache:keycloak:group-id:${keycloakGroup.name}`);
+      await del(`cache:keycloak:group-id:${keycloakGroup.name}`);
       await keycloakAdminClient.groups.del({ id });
     } catch (err) {
       if (err.response.status && err.response.status === 404) {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

When a group is deleted in Lagoon, there is a cached item that stores the group-id against the group-name. This allows us to recall information from keycloak quicker by using the ID, rather than a name based search and filtering method.

Unfortunately, if you delete a group, this cached ID remains, and subsequently re-creating the group before the cache expires, results in potential issues with trying to do things against the wrong group ID.

This fixes the issue by purging the cached ID when a group is deleted.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
