### PR TITLE
allow make to override UPSTREAMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ endif
 
 # Builds a docker image. Expects as arguments: name of the image, location of Dockerfile, path of
 # Docker Build Context
-docker_build = PLATFORMS=$(PLATFORM_ARCH) IMAGE_REPO=$(CI_BUILD_TAG) TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl $(1) --builder $(CI_BUILD_TAG) --load
+docker_build = PLATFORMS=$(PLATFORM_ARCH) IMAGE_REPO=$(CI_BUILD_TAG) UPSTREAM_REPO=$(UPSTREAM_REPO) UPSTREAM_TAG=$(UPSTREAM_TAG) TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl $(1) --builder $(CI_BUILD_TAG) --load
 
 docker_buildx_create = 	docker buildx create --name $(CI_BUILD_TAG) || echo  -e '$(CI_BUILD_TAG) builder already present\n'
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,6 +11,14 @@ variable "LAGOON_VERSION" {
   default = "development"
 }
 
+variable "UPSTREAM_REPO" {
+  default = "uselagoon"
+}
+
+variable "UPSTREAM_TAG" {
+  default = "latest"
+}
+
 variable "PLATFORMS" {
   // use PLATFORMS=linux/amd64,linux/arm64 to override default single architecture on the cli
   default = "linux/amd64"
@@ -29,6 +37,8 @@ target "default"{
   }
   args = {
     LAGOON_VERSION = "${LAGOON_VERSION}"
+    UPSTREAM_REPO = "${UPSTREAM_REPO}"
+    UPSTREAM_TAG = "${UPSTREAM_TAG}"
   }
 }
 


### PR DESCRIPTION
With the newer builds intriduced in #3450 the ability to build from alternate upstreams was omitted. This PR allows you to choose a different set of sources to build from - e.g. testlagoon/X:main or a pr-branch.