### PR TITLE
update python k8s to 27.2 in tests and set timeouts for helm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,7 +508,7 @@ k3d/test: k3d/cluster helm/repos $(addprefix local-dev/,$(K3D_TOOLS)) build
 			--volume "$$(realpath ../kubeconfig.k3d.$(CI_BUILD_TAG)):/root/.kube/config" \
 			--workdir /workdir \
 			"quay.io/helmpack/chart-testing:$(CHART_TESTING_VERSION)" \
-			ct install
+			ct install --helm-extra-args "--timeout 60m"
 
 LOCAL_DEV_SERVICES = api auth-server actions-handler logs2notifications webhook-handler webhooks2tasks
 
@@ -635,7 +635,7 @@ k3d/retest:
 			--volume "$$(realpath ../kubeconfig.k3d.$(CI_BUILD_TAG)):/root/.kube/config" \
 			--workdir /workdir \
 			"quay.io/helmpack/chart-testing:$(CHART_TESTING_VERSION)" \
-			ct install
+			ct install --helm-extra-args "--timeout 60m"
 
 .PHONY: k3d/clean
 k3d/clean: local-dev/k3d

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.15.4
-jmespath==1.0.1
-kubernetes==25.3.0
-PyJWT==2.6.0
+ansible-core >= 2.15.4
+kubernetes >= 27.2.0
+jmespath == 1.0.1
+PyJWT == 2.6.0


### PR DESCRIPTION
This was initially intended to fix an issue that it turns out was caused by (my own) upstream change in https://github.com/uselagoon/lagoon-charts/pull/622.

Keeping the looser version pins here to reduce maintenance overhead.