### PR TITLE
Update docs for getting k8s token used for ssh-core

### DIFF
--- a/docs/installing-lagoon/install-lagoon-remote.md
+++ b/docs/installing-lagoon/install-lagoon-remote.md
@@ -70,6 +70,8 @@ Now we will install Lagoon Remote into the Lagoon namespace. The [RabbitMQ](../d
         user: root
   ```
 
+1. Enable [ssh-core service account](https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/values.yaml#L116-L125)
+
 1. Install Lagoon Remote:
 
     ```bash title="Install Lagoon remote"

--- a/docs/installing-lagoon/querying-graphql.md
+++ b/docs/installing-lagoon/querying-graphql.md
@@ -48,18 +48,10 @@
 
     1. `name`: get from `lagoon-remote-values.yml`
     2. `consoleUrl`: API Endpoint of Kubernetes cluster. Get from `values.yml`
-    3. `token`: create a token for the `lagoon-build-deploy` service account
+    3. `token`: get a token for the `ssh-core` service account
 
-      ```bash title="Create token"
-        kubectl -n lagoon create token lagoon-build-deploy --duration 3h
-      ```
-
-!!! Warning "Prior to Kubernetes 1.21:"
-      Use the `lagoon-build-deploy` token installed by `lagoon-remote`:
-
-      ```bash title="Use deploy token"
-        kubectl -n lagoon describe secret \
-          $(kubectl -n lagoon get secret | grep lagoon-build-deploy | awk '{print $1}') | grep token: | awk '{print $2}'
+      ```bash title="Get token"
+      kubectl -n lagoon get secret/lagoon-remote-ssh-core-token -o json | jq -r '.data.token | @base64d'
       ```
 
 !!! Info


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Docs update to use the new `ssh-core` service account introduced in lagoon-remote chart 0.82.0.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
