### PR TITLE
Use updated internal-services-test URL syntax and add persistent storage test

### DIFF
--- a/tests/files/services/docker-compose.yml
+++ b/tests/files/services/docker-compose.yml
@@ -8,22 +8,22 @@ services:
     ports:
       - '3306'
 
-  mariadb-10-6:
-    image: uselagoon/mariadb-10.6
+  mariadb-10-11:
+    image: uselagoon/mariadb-10.11
     labels:
       lagoon.type: mariadb
     ports:
       - '3306'
 
   mongo-4:
-    image: uselagoon/mongo:latest
+    image: uselagoon/mongo-4
     labels:
       lagoon.type: mongo
     ports:
       - '27017'
 
   opensearch-2:
-    image: uselagoon/opensearch-2:latest
+    image: uselagoon/opensearch-2
     environment:
     - cluster.name=opensearch-cluster
     - node.name=opensearch
@@ -39,7 +39,8 @@ services:
         soft: 65536
         hard: 65536
     labels:
-      lagoon.type: none # gets set to opensearch in a second deployment
+      lagoon.type: opensearch
+      # lagoon.type: none # gets set to opensearch in a second deployment
     ports:
       - '9200'
 
@@ -50,15 +51,15 @@ services:
     ports:
       - '5432'
 
-  postgres-14:
-    image: uselagoon/postgres-14
+  postgres-15:
+    image: uselagoon/postgres-15
     labels:
       lagoon.type: postgres
     ports:
       - '5432'
 
-  redis-6:
-    image: uselagoon/redis-6
+  redis-7:
+    image: uselagoon/redis-7
     labels:
       lagoon.type: redis
     ports:

--- a/tests/files/services/docker-compose.yml
+++ b/tests/files/services/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: uselagoon/mariadb-10.5
     labels:
       lagoon.type: mariadb-single
+      lagoon.persistent.size: 100Mi
     ports:
       - '3306'
 
@@ -40,7 +41,7 @@ services:
         hard: 65536
     labels:
       lagoon.type: opensearch
-      # lagoon.type: none # gets set to opensearch in a second deployment
+      lagoon.persistent.size: 100Mi
     ports:
       - '9200'
 
@@ -48,6 +49,7 @@ services:
     image: uselagoon/postgres-13
     labels:
       lagoon.type: postgres-single
+      lagoon.persistent.size: 100Mi
     ports:
       - '5432'
 
@@ -69,6 +71,7 @@ services:
     image: uselagoon/solr-8
     labels:
       lagoon.type: solr
+      lagoon.persistent.size: 100Mi
     ports:
      - "8983"
     command:
@@ -78,6 +81,11 @@ services:
   internal-services-test:
     image: uselagoon/internal-services-test:main
     labels:
-      lagoon.type: basic
+      lagoon.type: basic-persistent
+      lagoon.persistent: /app/files
+      lagoon.persistent.size: 10Mi
+      lagoon.persistent.class: bulk
     ports:
       - "3000"
+    environment:
+      - STORAGE_LOCATION=/app/files

--- a/tests/tests/services/services.yaml
+++ b/tests/tests/services/services.yaml
@@ -92,32 +92,20 @@
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 
-# - name: "{{ testname }} - api add envVariable on {{ project }}"
-#   hosts: localhost
-#   serial: 1
-#   vars:
-#     envName: "LAGOON_SERVICE_TYPES"
-#     envValue: "opensearch-2:opensearch"
-#     envScope: "BUILD"
-#     project: "{{ project }}"
-#   tasks:
-#   - ansible.builtin.include_tasks: ../../tasks/api/add-project-variable.yaml
-
-# - name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
-#   hosts: localhost
-#   serial: 1
-#   vars:
-#     branch: "{{ branch }}"
-#     project: "{{ project }}"
-#     namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
-#   tasks:
-#   - ansible.builtin.include_tasks: ../../tasks/api/deploy-no-sha.yaml
-
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, opensearch-2 service"
   hosts: localhost
   serial: 1
   vars:
     url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/opensearch?service=opensearch-2"
+    expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
+  tasks:
+  - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
+
+- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, persistent storage"
+  hosts: localhost
+  serial: 1
+  vars:
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/storage?path=/app/files"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml

--- a/tests/tests/services/services.yaml
+++ b/tests/tests/services/services.yaml
@@ -38,11 +38,11 @@
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, mariadb 10.6 service"
+- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, mariadb 10.11 service"
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb?service=mariadb-10.6"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb?service=mariadb-10.11"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -56,11 +56,11 @@
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, postgres-14 service"
+- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, postgres-15 service"
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres?service=postgres-14"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres?service=postgres-15"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -83,35 +83,35 @@
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, redis-6 service"
+- name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, redis-7 service"
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/redis?service=redis-6"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/redis?service=redis-7"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 
-- name: "{{ testname }} - api add envVariable on {{ project }}"
-  hosts: localhost
-  serial: 1
-  vars:
-    envName: "LAGOON_SERVICE_TYPES"
-    envValue: "opensearch-2:opensearch"
-    envScope: "BUILD"
-    project: "{{ project }}"
-  tasks:
-  - ansible.builtin.include_tasks: ../../tasks/api/add-project-variable.yaml
+# - name: "{{ testname }} - api add envVariable on {{ project }}"
+#   hosts: localhost
+#   serial: 1
+#   vars:
+#     envName: "LAGOON_SERVICE_TYPES"
+#     envValue: "opensearch-2:opensearch"
+#     envScope: "BUILD"
+#     project: "{{ project }}"
+#   tasks:
+#   - ansible.builtin.include_tasks: ../../tasks/api/add-project-variable.yaml
 
-- name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
-  hosts: localhost
-  serial: 1
-  vars:
-    branch: "{{ branch }}"
-    project: "{{ project }}"
-    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
-  tasks:
-  - ansible.builtin.include_tasks: ../../tasks/api/deploy-no-sha.yaml
+# - name: "{{ testname }} - api deployEnvironmentBranch on {{ project }}, which should deploy the first commit"
+#   hosts: localhost
+#   serial: 1
+#   vars:
+#     branch: "{{ branch }}"
+#     project: "{{ project }}"
+#     namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+#   tasks:
+#   - ansible.builtin.include_tasks: ../../tasks/api/deploy-no-sha.yaml
 
 - name: "{{ testname }} - check if {{ project }} is deployed with searching for the hash, opensearch-2 service"
   hosts: localhost

--- a/tests/tests/services/services.yaml
+++ b/tests/tests/services/services.yaml
@@ -33,7 +33,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb-10.5"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb?service=mariadb-10.5"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -42,7 +42,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb-10.6"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mariadb?service=mariadb-10.6"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -51,7 +51,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres-13"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres?service=postgres-13"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -60,7 +60,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres-14"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/postgres?service=postgres-14"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -69,7 +69,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mongo-4"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/mongo?service=mongo-4"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -78,7 +78,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/solr-8"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/solr?service=solr-8"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -87,7 +87,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/redis-6"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/redis?service=redis-6"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
@@ -117,7 +117,7 @@
   hosts: localhost
   serial: 1
   vars:
-    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/opensearch-2"
+    url: "http://internal-services-test.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ route_suffix }}/opensearch?service=opensearch-2"
     expected_content: "LAGOON_GIT_SAFE_BRANCH={{ branch }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml


### PR DESCRIPTION
The URL format in the internal-services-test has changed, this PR updates it in the relevant tests, as well as updating a couple of the test images.

It also removes the double-handling of the openshift image in #3458 now we have reduced it in size.