### PR TITLE
feat: add buildimage boolean to allprojects and allkubernetes query

### DIFF
--- a/services/api/src/resources/openshift/resolvers.ts
+++ b/services/api/src/resources/openshift/resolvers.ts
@@ -111,15 +111,21 @@ export const deleteOpenshift: ResolverFn = async (
 
 export const getAllOpenshifts: ResolverFn = async (
   root,
-  { disabled },
+  { disabled, buildImage },
   { sqlClientPool, hasPermission }
 ) => {
   await hasPermission('openshift', 'viewAll');
 
-  if (disabled != null) {
-    return query(sqlClientPool, knex('openshift').where('disabled', disabled).toString());
+  let queryBuilder = knex('openshift');
+  if (buildImage) {
+    queryBuilder = queryBuilder.and.whereNot('build_image', '');
   }
-  return query(sqlClientPool, knex('openshift').toString());
+
+  if (disabled != null) {
+    queryBuilder = queryBuilder.where('disabled', disabled);
+  }
+
+  return query(sqlClientPool, queryBuilder.toString());
 };
 
 export const getOpenshiftByProjectId: ResolverFn = async (

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -67,7 +67,7 @@ export const getProjectDeployKey: ResolverFn = async (
 
 export const getAllProjects: ResolverFn = async (
   root,
-  { order, createdAfter, gitUrl },
+  { order, createdAfter, gitUrl, buildImage },
   { sqlClientPool, hasPermission, models, keycloakGrant, keycloakUsersGroups }
 ) => {
   let userProjectIds: number[];
@@ -97,6 +97,10 @@ export const getAllProjects: ResolverFn = async (
 
   if (gitUrl) {
     queryBuilder = queryBuilder.andWhere('git_url', gitUrl);
+  }
+
+  if (buildImage) {
+    queryBuilder = queryBuilder.and.whereNot('build_image', '');
   }
 
   if (userProjectIds) {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1339,11 +1339,11 @@ const typeDefs = gql`
     """
     Returns all OpenShift Objects
     """
-    allOpenshifts(disabled: Boolean): [Openshift]
+    allOpenshifts(disabled: Boolean, buildImage: Boolean): [Openshift]
     """
     Returns all Kubernetes Objects
     """
-    allKubernetes(disabled: Boolean): [Kubernetes]
+    allKubernetes(disabled: Boolean, buildImage: Boolean): [Kubernetes]
     """
     Returns all Environments matching given filter (all if no filter defined)
     """

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1331,7 +1331,7 @@ const typeDefs = gql`
     """
     Returns all Project Objects matching given filters (all if no filter defined)
     """
-    allProjects(createdAfter: String, gitUrl: String, order: ProjectOrderType): [Project]
+    allProjects(createdAfter: String, gitUrl: String, order: ProjectOrderType, buildImage: Boolean): [Project]
     """
     Returns all Project Objects matching metadata filters
     """


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Adds the ability to filter projects and deploytargets that have a build image override easily. This allows an administrator to easily check if there are any projects or clusters with image overrides outside of the core defined build image.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

