### PR TITLE
feat: retrieve the restored file size for backups

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -523,9 +523,6 @@ const resolvers = {
     restore: getRestoreByBackupId,
     environment: getEnvironmentByBackupId
   },
-  Restore: {
-    restoreLocation: getRestoreLocation,
-  },
   Workflow: {
     advancedTaskDefinition: resolveAdvancedTaskDefinitionsForWorkflow,
   },

--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -18,13 +18,8 @@ import { Helpers as projectHelpers } from '../project/helpers';
 import { getEnvVarsByProjectId } from '../env-variables/resolvers';
 import { logger } from '../../loggers/logger';
 
-export const getRestoreLocation: ResolverFn = async (
-  restore,
-  args,
-  context,
-) => {
-  const { restoreLocation, backupId } = restore;
-  const { sqlClientPool, hasPermission } = context;
+const getRestoreLocation = async (backupId, restoreLocation, sqlClientPool) => {
+  let restoreSize = 0;
   const rows = await query(sqlClientPool, Sql.selectBackupByBackupId(backupId));
   const project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(rows[0].environment);
   const projectEnvVars = await query(sqlClientPool, Sql.selectEnvVariablesByProjectsById(project.projectId));
@@ -100,39 +95,31 @@ export const getRestoreLocation: ResolverFn = async (
 
 
     // before generating the signed url, check the object exists
-    let exists = false
     const restoreLoc = await s3Client.headObject({
       Bucket: R.prop(2, s3Parts),
       Key: R.prop(3, s3Parts)
     });
     try {
-      await Promise.all([restoreLoc.promise()]).then(data => {
-        // the file exists
-      }).catch(err => {
-        if (err) throw err;
-      });
-      exists = true
-    } catch(err) {
-      exists = false
-    }
-    if (exists) {
-      return s3Client.getSignedUrl('getObject', {
+      const data = await Promise.resolve(restoreLoc.promise());
+      restoreSize = data.ContentLength
+      const restLoc = await s3Client.getSignedUrl('getObject', {
         Bucket: R.prop(2, s3Parts),
         Key: R.prop(3, s3Parts),
         Expires: 300 // 5 minutes
-      });
-    } else {
+      })
+      return [restLoc, restoreSize];
+    } catch(err) {
       await query(
         sqlClientPool,
         Sql.deleteRestore({
           backupId
         })
       );
-      return ""
+      return ["", restoreSize];
     }
   }
 
-  return restoreLocation;
+  return [restoreLocation, restoreSize];
 };
 
 export const getBackupsByEnvironmentId: ResolverFn = async (
@@ -410,8 +397,13 @@ export const getRestoreByBackupId: ResolverFn = async (
     sqlClientPool,
     Sql.selectRestoreByBackupId(backupId)
   );
-
-  return R.prop(0, rows);
+  const row = R.prop(0, rows)
+  if (row && row.restoreLocation != null) {
+    // if the restore has a location, determine the signed url and the reported size of the object in Bytes
+    const [restLoc, restSize] = await getRestoreLocation(backupId, row.restoreLocation, sqlClientPool);
+    return {...row, restoreLocation: restLoc, restoreSize: restSize};
+  }
+  return row;
 };
 
 export const backupSubscriber = createEnvironmentFilteredSubscriber([

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -966,6 +966,10 @@ const typeDefs = gql`
     backupId: String
     status: String
     restoreLocation: String
+    """
+    The size of the restored file in bytes
+    """
+    restoreSize: Int
     created: String
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a refactor to the restore query that adds the field `restoreSize: Int` that reports the `ContentLength` of the file, which is reported by the S3 client when the `HEAD` request to check the file exists is executed.

This would allow for the button in the UI to display the size of the file
![image](https://github.com/uselagoon/lagoon/assets/9973880/457d376c-a075-4f40-b052-8f0f18814336)


<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

partially #3152 (only for retrieved backups, not all)
