### PR TITLE
add CLEAR_API_DATA env to allow API data clearing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,7 @@ k3d/retest:
 			LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY=enabled \
 			USE_CALICO_CNI=false \
 			LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD=enabled \
+			CLEAR_API_DATA=true \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ PUBLISH_PLATFORM_ARCH := linux/amd64,linux/arm64
 # Skip image scanning by default to make building images substantially faster
 SCAN_IMAGES := false
 
+# Clear all data from the API on a retest run, usually to clear up after a failure. Set false to preserve
+CLEAR_API_DATA ?= true
+
 # Init the file that is used to hold the image tag cross-reference table
 $(shell >build.txt)
 $(shell >scan.txt)
@@ -629,7 +632,7 @@ k3d/retest:
 			LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY=enabled \
 			USE_CALICO_CNI=false \
 			LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD=enabled \
-			CLEAR_API_DATA=true \
+			CLEAR_API_DATA=$(CLEAR_API_DATA) \
 		&& docker run --rm --network host --name ct-$(CI_BUILD_TAG) \
 			--volume "$$(pwd)/test-suite-run.ct.yaml:/etc/ct/ct.yaml" \
 			--volume "$$(pwd):/workdir" \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -209,6 +209,8 @@ services:
     depends_on:
       - api
     image: ${IMAGE_REPO:-lagoon}/local-api-data-watcher-pusher
+    environment:
+      - CLEAR_API_DATA=false
     volumes:
       - ./local-dev/api-data-watcher-pusher:/home
   local-dbaas-provider:

--- a/local-dev/api-data-watcher-pusher/data-init-push.sh
+++ b/local-dev/api-data-watcher-pusher/data-init-push.sh
@@ -56,7 +56,10 @@ send_task_data() {
 wait_for_services
 
 # Optionally clear *some* API data prior to reloading - not really necessary any more
-# send_graphql_query $clear_gql_file_path
+if expr "$CLEAR_API_DATA" : '[Tt][Rr][Uu][Ee]' > /dev/null; then
+  echo "Clearing Lagoon data first"
+  send_graphql_query $clear_gql_file_path
+fi
 
 # Create the lagoon-demo project and associated users, groups, deployments, tasks etc
 send_graphql_query $populate_demo_lagoon_gql_file_path


### PR DESCRIPTION
This PR adds an optional CLEAR_API_DATA into the data watcher pusher that triggers the delete_all_* mutations.

In normal usage this isn't required, but can come in handy when rerunning tests (make k3d/retest) after failures.

Longer term goal is to make the ansible tests more fault tolerant, but let's eat the elephant one bite at a time...