### PR TITLE
fix: use the right value for project name when getting variables for advanced tasks

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -1357,7 +1357,7 @@ export const createMiscTask = async function(taskData: any) {
         case 'deploytarget:task:advanced':
           // inject variables into advanced tasks the same way it is in builds and standard tasks
           const [_, envVars, projectVars] = await getTaskProjectEnvironmentVariables(
-            project.name,
+            taskData.data.project.name,
             taskData.data.environment.id
           )
           miscTaskData.project.variables = {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just fixes an issue with using the wrong input value for retrieving data for the projects variables

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

