### PR TITLE
introduce DEPRECATIONS.md to track deprecations

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,20 @@
+
+
+# Lagoon Project Deprecation Announcements
+
+## Overview
+This file is a constantly updated central tracker for deprecations across the suite of Lagoon products. As Lagoon continues to evolve, we occasionally need to replace, rename or retire existing processes, tools or configuration. Where this may impact a user's processes or procedures, we intend to outline a timeframe to allow any necessary changes to be made.
+
+Deprecations will be tracked by the release they are announced in, and then updated when the actual deprecation occurs. All deprecations should provide a rough timeline (in months or releases). Releases will normally only be listed here if they include planned deprecations.
+
+## Deprecation History
+All deprecations are listed below, with the most recent announcements at the top.
+
+### Lagoon v2.17.0
+release link: https://github.com/uselagoon/lagoon/releases/tag/v2.17.0
+* (insert any planned deprecations here)
+
+### Lagoon v2.16.0
+release link: https://github.com/uselagoon/lagoon/releases/tag/v2.16.0
+
+There were no planned deprecations announced in this release.


### PR DESCRIPTION
This PR introduces a central file, DEPRECATIONS.md to track deprecations across Lagoon products.

I've opted to put it in the repository root, but we can discuss whether it should live in the docs?

Inspiration:
* https://platform.openai.com/docs/deprecations
* https://developers.google.com/maps/deprecations
* https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations
* https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md
* https://github.com/wix-incubator/wix-rest-docs/blob/master/guides/Deprecations.md