### PR TITLE
Minor fix for updateNotification resolvers

### DIFF
--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -497,6 +497,11 @@ export const updateNotificationMicrosoftTeams: ResolverFn = async (
     sqlClientPool,
     Sql.selectNotificationMicrosoftTeamsByName(name)
   );
+
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+
   await checkNotificationUpdatePermissions(check, hasPermission)
 
   await query(sqlClientPool, Sql.updateNotificationMicrosoftTeams(input));
@@ -524,6 +529,11 @@ export const updateNotificationWebhook: ResolverFn = async (
     sqlClientPool,
     Sql.selectNotificationWebhookByName(name)
   );
+
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+
   await checkNotificationUpdatePermissions(check, hasPermission)
 
   await query(sqlClientPool, Sql.updateNotificationWebhook(input));
@@ -548,6 +558,11 @@ export const updateNotificationEmail: ResolverFn = async (
     sqlClientPool,
     Sql.selectNotificationEmailByName(name)
   );
+
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+
   await checkNotificationUpdatePermissions(check, hasPermission)
 
   await query(sqlClientPool, Sql.updateNotificationEmail(input));
@@ -572,6 +587,11 @@ export const updateNotificationRocketChat: ResolverFn = async (
     sqlClientPool,
     Sql.selectNotificationRocketChatByName(name)
   );
+
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+
   await checkNotificationUpdatePermissions(check, hasPermission)
 
   await query(sqlClientPool, Sql.updateNotificationRocketChat(input));
@@ -596,6 +616,11 @@ export const updateNotificationSlack: ResolverFn = async (
     sqlClientPool,
     Sql.selectNotificationSlackByName(name)
   );
+
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+
   await checkNotificationUpdatePermissions(check, hasPermission)
 
   await query(sqlClientPool, Sql.updateNotificationSlack(input));

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -484,6 +484,12 @@ const checkNotificationUpdatePermissions = async (check, hasPermission) => {
   }
 }
 
+const checkNotificationExists = (name, check) => {
+  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
+    throw new Error(`No notification found for ${name}`);
+  }
+}
+
 export const updateNotificationMicrosoftTeams: ResolverFn = async (
   root,
   { input },
@@ -498,9 +504,7 @@ export const updateNotificationMicrosoftTeams: ResolverFn = async (
     Sql.selectNotificationMicrosoftTeamsByName(name)
   );
 
-  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
-    throw new Error(`No notification found for ${name}`);
-  }
+  checkNotificationExists(name, check);
 
   await checkNotificationUpdatePermissions(check, hasPermission)
 
@@ -530,9 +534,7 @@ export const updateNotificationWebhook: ResolverFn = async (
     Sql.selectNotificationWebhookByName(name)
   );
 
-  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
-    throw new Error(`No notification found for ${name}`);
-  }
+  checkNotificationExists(name, check);
 
   await checkNotificationUpdatePermissions(check, hasPermission)
 
@@ -559,9 +561,7 @@ export const updateNotificationEmail: ResolverFn = async (
     Sql.selectNotificationEmailByName(name)
   );
 
-  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
-    throw new Error(`No notification found for ${name}`);
-  }
+  checkNotificationExists(name, check)
 
   await checkNotificationUpdatePermissions(check, hasPermission)
 
@@ -588,9 +588,7 @@ export const updateNotificationRocketChat: ResolverFn = async (
     Sql.selectNotificationRocketChatByName(name)
   );
 
-  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
-    throw new Error(`No notification found for ${name}`);
-  }
+  checkNotificationExists(name, check)
 
   await checkNotificationUpdatePermissions(check, hasPermission)
 
@@ -617,9 +615,7 @@ export const updateNotificationSlack: ResolverFn = async (
     Sql.selectNotificationSlackByName(name)
   );
 
-  if (R.find(R.propEq('name', `${name}`))(check) == undefined) {
-    throw new Error(`No notification found for ${name}`);
-  }
+  checkNotificationExists(name, check)
 
   await checkNotificationUpdatePermissions(check, hasPermission)
 


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Currently when running any of the `updateNotification` resolvers with a `name` that doesn't match any existing notifications the following is returned: `Cannot read properties of undefined (reading organization).`

This adds a check to ensure the notification exists, prior to passing it to `checkNotificationUpdatePermissions`.
