### PR TITLE
add local-dev-yarn command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,21 @@ down:
 kill:
 	docker ps --format "{{.Names}}" | grep lagoon | xargs -t -r -n1 docker rm -f -v
 
+.PHONY: local-dev-yarn
+local-dev-yarn:
+	$(MAKE) local-dev-yarn-stop
+	docker run --name local-dev-yarn -d -v ${PWD}:/app uselagoon/node-20-builder
+	docker exec local-dev-yarn bash -c "yarn install --frozen-lockfile"
+	docker exec local-dev-yarn bash -c "cd /app/node-packages/commons && yarn build"
+	echo -e "use 'yarn workspace api add package@version' to update a package in workspace api"
+	docker exec -it local-dev-yarn bash
+	$(MAKE) local-dev-yarn-stop
+
+.PHONY: local-dev-yarn-stop
+local-dev-yarn-stop:
+	docker stop local-dev-yarn || true
+	docker rm local-dev-yarn || true
+
 .PHONY: ui-development
 ui-development: build-ui-logs-development
 	IMAGE_REPO=$(CI_BUILD_TAG) docker-compose -p $(CI_BUILD_TAG) --compatibility up -d api api-db local-api-data-watcher-pusher ui keycloak keycloak-db broker api-redis


### PR DESCRIPTION
This PR adds two makefile commands to facilitate easier yarn updating

`make local-dev-yarn` will mount the entire lagoon directory into a node-builder container, preinstall and build the yarn packages, and drop you into a shell to yarn away. When you `exit` the container, it clears itself up, leaving the updates to the package.json/yarn.lock in your repo.

`make local-dev-yarn-stop` is a convenience function that clears the named container away if a process exits badly (or at the beginning/end of a local-dev-yarn cycle.

This removes the need to set up node/yarn on your local machine, and avoids the need to remember how it all sets up.