### PR TITLE
fix: return groups user has access to in group payloads

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -551,7 +551,13 @@ export const getGroupsByOrganizationsProject: ResolverFn = async (
       }
     }
   }
-  const userProjectGroups = R.intersection(orgProjectGroups, userGroups);
+  let userProjectGroups = []
+  for (const ug of userGroups) {
+    const pg = orgProjectGroups.find(i => i.id === ug.id)
+    if (pg) {
+      userProjectGroups.push(pg)
+    }
+  }
 
   return userProjectGroups;
 };


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

As identified in https://github.com/uselagoon/lagoon-cli/pull/288#discussion_r1418476736 Users in groups with multiple roles (eg owner, developer etc) may not be able to view their project-group allocations via the cli, because the checks performed in Lagoon don't manage to marry the user groups and project groups successfully. This will manifest as the following:

```
$ lagoon list project-groups -p lagoon-demo
There are no groups for project 'lagoon-demo'
GROUP ID	GROUP NAME	ORGANIZATION 

instead of
$ lagoon list project-groups -p lagoon-demo
GROUP ID                            	GROUP NAME       	ORGANIZATION 
8fc64c2a-e810-4ff1-a47e-68a1501c4ae8	lagoon-demo-group	null	
```

When we changed the group payload to use brief representation, this meant more information was returned in the response than what is generated when a user requests their groups. This meant that the intersection that was previously performed would fail because the project group could contain all the subgroups for roles, and the user groups would only contain the group they are a member of within the main group, the intersection would fail as the two objects were now different.

This PR changes the comparison done to still match on the parent group even if the subgroups are not all returned in a user groups query.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

