### PR TITLE
chore: add notice about planned harbor deprecations

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,6 +13,8 @@ All deprecations are listed below, with the most recent announcements at the top
 ### Lagoon v2.17.0
 release link: https://github.com/uselagoon/lagoon/releases/tag/v2.17.0
 * This release introduces a new active/standby task image that does not require the use of the [dioscuri controller](https://github.com/amazeeio/dioscuri). Dioscuri is deprecated and will eventually be removed from the `lagoon-remote` helm chart. If you use active/standby functionality in your clusters, you should upgrade to lagoon v2.17.0 and update your remote clusters to the version of the `lagoon-remote` helm chart the v2.17.0 release says to use (see release notes for v2.17.0)
+* Support for Harbor in the API will be removed in a future release. If you currently have your core installation with Harbor support, you should move to using the integration within lagoon-remote instead. See the documentation [here](https://docs.lagoon.sh/installing-lagoon/install-lagoon-remote) and read the section about Harbor.
+* Support for Harbor 2.1.x (chart version 1.5.x) and older in `lagoon-remote` will be removed in a future release. You should consider upgrading Harbor to a newer version (currently Lagoon supports up to v2.9.x (chart version 1.13.x)), following any recommended upgrade paths from Harbor.
 
 ### Lagoon v2.16.0
 release link: https://github.com/uselagoon/lagoon/releases/tag/v2.16.0


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just adding some notices about planned old Harbor version deprecation. The code in the API is already basically abandoned and likely doesn't work reliably for anyone using Harbor 2.2.x+. And retaining the code base in the remote-controller means retaining a forked client library, for which the newer library doesn't require a fork.

This would allow us to proceed with cleaning up old code in a future release, here are some existing PRs that could be merged then.
* https://github.com/uselagoon/lagoon/pull/3259
* https://github.com/uselagoon/lagoon/pull/3086
* https://github.com/uselagoon/remote-controller/pull/242
* any others that might be required to remove support from the API

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
