### PR TITLE
chore: use safer drush cr status check for version

### DIFF
--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -595,11 +595,11 @@ export const taskDrushCacheClear: ResolverFn = async (
   });
 
   const command =
-    'drupal_version=$(drush status drupal-version --format=list) && \
+    'drupal_version=$(drush status | grep -i "drupal version" | awk \'{print $NF}\') && \
   if [ ${drupal_version%.*} == "7" ]; then \
     if drush cc all; then echo "drush cc all complete"; else exit $?; fi; \
   elif [ ${drupal_version%.*.*} -ge "8" ] ; then \
-    if drush cr; then echo "drush cr complete"; else exit $?; fi; \
+    if drush cr -y; then echo "drush cache:rebuild complete"; else exit $?; fi; \
   else \
     echo "could not clear cache for found Drupal Version ${drupal_version}"; \
     exit 1; \


### PR DESCRIPTION
This PR modifies the drupal version check done for a cache-clear to work with all versions of Drush 8-12

closes #3617 