### PR TITLE
Adds service to deleteFactsFromSource

### DIFF
--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -382,18 +382,22 @@ export const deleteFact: ResolverFn = async (
 
 export const deleteFactsFromSource: ResolverFn = async (
   root,
-  { input: { environment: environmentId, source } },
+  { input: { environment: environmentId, source, service } },
   { sqlClientPool, hasPermission, userActivityLogger }
 ) => {
   const environment = await environmentHelpers(
     sqlClientPool
   ).getEnvironmentById(environmentId);
 
+  if(environment == null) {
+    throw new Error(`Unable to find environment with id: ${environmentId}`);
+  }
+
   await hasPermission('fact', 'delete', {
     project: environment.project
   });
 
-  await query(sqlClientPool, Sql.deleteFactsFromSource(environmentId, source));
+  await query(sqlClientPool, Sql.deleteFactsFromSource(environmentId, source, service));
 
   userActivityLogger(`User deleted facts`, {
     project: '',
@@ -401,7 +405,8 @@ export const deleteFactsFromSource: ResolverFn = async (
     payload: {
       data: {
         environment: environmentId,
-        source
+        source,
+        service
       }
     }
   });

--- a/services/api/src/resources/fact/sql.ts
+++ b/services/api/src/resources/fact/sql.ts
@@ -48,11 +48,18 @@ export const Sql = {
       })
       .del()
       .toString(),
-  deleteFactsFromSource: (environment, source) =>
-    knex('environment_fact')
-      .where({ environment, source })
-      .del()
-      .toString(),
+  deleteFactsFromSource: (environment, source, service) => {
+    let query =  knex('environment_fact')
+      .where({ environment, source });
+
+      if(service != null) {
+        query = query.andWhere("service", "=", service)
+      }
+
+    query = query.del();
+
+    return query.toString();
+  },
   selectFactReferenceByDatabaseId: (id: number) =>
     knex('environment_fact_reference')
       .where({ id })

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -378,6 +378,7 @@ const typeDefs = gql`
   input DeleteFactsFromSourceInput {
     environment: Int!
     source: String!
+    service: String
   }
 
   type FactReference {


### PR DESCRIPTION
This PR introduces the same functionality as an earlier PR https://github.com/uselagoon/lagoon/pull/2611

The rationale for its existence mirrors that of the earlier PR, but _mutatis mutandis_ wrt facts.

Essentially, it allows us to better target facts for clearing, since multiple facts could potentially exist with the same name, same source, but on different services. 

Think, for instance, a `php-version` collected by some process that runs on both the `php-nginx` service and a `cli` service, we want to be able to clear the facts from one of the services, without having it be cleared from both.


<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog
