### PR TITLE
Clean up insights data on environment deletion

### DIFF
--- a/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
+++ b/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
@@ -3,12 +3,20 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-    return knex.schema.raw(`
-    DELETE ef
-    FROM environment_fact ef
-    LEFT JOIN environment e ON ef.environment = e.id
-    WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
-  `);
+    return Promise.all([
+      knex.schema.raw(`
+       DELETE ef
+       FROM environment_fact ef
+       LEFT JOIN environment e ON ef.environment = e.id
+       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
+      `),
+      knex.schema.raw(`
+       DELETE ep
+       FROM environment_problem ep
+       LEFT JOIN environment e ON ep.environment = e.id
+       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
+      `),
+]);
   };
 
   /**

--- a/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
+++ b/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
@@ -8,15 +8,15 @@ exports.up = function(knex) {
        DELETE ef
        FROM environment_fact ef
        LEFT JOIN environment e ON ef.environment = e.id
-       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
+       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00' OR e.project not in (select id from project)
       `),
       knex.schema.raw(`
        DELETE ep
        FROM environment_problem ep
        LEFT JOIN environment e ON ep.environment = e.id
-       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
+       WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00' OR e.project not in (select id from project)
       `),
-]);
+    ]);
   };
 
   /**

--- a/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
+++ b/services/api/database/migrations/20231222000000_delete_orphaned_insights.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+    return knex.schema.raw(`
+    DELETE ef
+    FROM environment_fact ef
+    LEFT JOIN environment e ON ef.environment = e.id
+    WHERE e.id IS NULL OR e.deleted != '0000-00-00 00:00:00'
+  `);
+  };
+
+  /**
+   * @param { import("knex").Knex } knex
+   * @returns { Promise<void> }
+   */
+  exports.down = function(knex) {
+    return knex.schema;
+  };

--- a/services/api/src/resources/environment/helpers.ts
+++ b/services/api/src/resources/environment/helpers.ts
@@ -3,6 +3,8 @@ import { Pool } from 'mariadb';
 import { asyncPipe } from '@lagoon/commons/dist/util/func';
 import { query } from '../../util/db';
 import { Sql } from './sql';
+import { Sql as problemSql } from '../problem/sql';
+import { Sql as factSql } from '../fact/sql';
 import { Helpers as projectHelpers } from '../project/helpers';
 // import { logger } from '../../loggers/logger';
 
@@ -48,6 +50,19 @@ export const Helpers = (sqlClientPool: Pool) => {
         sqlClientPool,
         Sql.deleteEnvironment(name, pid)
       );
+
+      // Here we clean up insights attached to the environment
+
+      await query(
+        sqlClientPool,
+        factSql.deleteFactsForEnvironment(eid)
+      );
+
+      await query(
+        sqlClientPool,
+        problemSql.deleteProblemsForEnvironment(eid)
+      );
+
     },
     getEnvironmentsDeploytarget: async (eid) => {
       const rows = await query(

--- a/services/api/src/resources/fact/sql.ts
+++ b/services/api/src/resources/fact/sql.ts
@@ -48,6 +48,13 @@ export const Sql = {
       })
       .del()
       .toString(),
+  deleteFactsForEnvironment: (environment) => // Used when removing environments.
+      knex('environment_fact')
+        .where({
+          environment
+        })
+        .del()
+        .toString(),
   deleteFactsFromSource: (environment, source) =>
     knex('environment_fact')
       .where({ environment, source })

--- a/services/api/src/resources/problem/sql.ts
+++ b/services/api/src/resources/problem/sql.ts
@@ -139,6 +139,13 @@ export const Sql = {
     }
     return q.del().toString();
   },
+  deleteProblemsForEnvironment: (environment) => { // This should be used primarily to remove problems when deleting an environment
+    let q = knex('environment_problem')
+      .where({
+        environment: environment
+      });
+    return q.del().toString();
+  },
   deleteProblemsFromSource: (environment, source, service) =>
     knex('environment_problem')
       .where({


### PR DESCRIPTION
Right now, when deleting an environment, there is nothing to clean up facts and problems that have been registered against that environment.

The really big problem here (beyond the fact that we're not cleaning up data) is with multiple PR/ephemeral environments, if they're running insights, there is potentially a _lot_ of insights information that is not even of any historical value.

This PR adds two things
1. Calls to queries that will clean up the appropriate facts and problems entries.
2. Adds a migration to remove any existing data that should be removed from the DB.

# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically
