### PR TITLE
feat: introduce /.well-known endpoint for service discovery information

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -22,7 +22,15 @@ app.use(json());
 app.use(
   morgan('combined', {
     skip: (req, res) => {
-      return req.originalUrl.startsWith('/status');
+      if (req.originalUrl.startsWith('/status')) {
+        return req.originalUrl.startsWith('/status')
+      }
+      if (req.originalUrl.startsWith('/favicon.ico')) {
+        return req.originalUrl.startsWith('/favicon.ico')
+      }
+      if (req.originalUrl.startsWith('/.well-known')) {
+        return req.originalUrl.startsWith('/.well-known')
+      }
     },
     stream: {
       write: message => logger.info(message.trim())

--- a/services/api/src/authMiddleware.ts
+++ b/services/api/src/authMiddleware.ts
@@ -44,6 +44,10 @@ const authenticateJWT = async (
   if (req.url === '/status') {
     return next();
   }
+  // Allow access to status without auth.
+  if (req.url === '/.well-known/appspecific/sh.lagoon.discovery.json') {
+    return next();
+  }
 
   // @ts-ignore
   const token = getBearerTokenFromHeader(req.get('Authorization'));

--- a/services/api/src/routes/index.ts
+++ b/services/api/src/routes/index.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import statusRoute from './status';
 import keysRoute from './keys';
+import wellKnown from './well-known';
 
 export function createRouter() {
   const router = express.Router();
@@ -12,6 +13,9 @@ export function createRouter() {
 
   // Fetch the current api status.
   router.get('/status', ...statusRoute);
+
+  // Fetch the well-known.
+  router.get('/.well-known/appspecific/sh.lagoon.discovery.json', ...wellKnown);
 
   // Return keys of all customers
   router.post('/keys', ...keysRoute);

--- a/services/api/src/routes/well-known.ts
+++ b/services/api/src/routes/well-known.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { envHasConfig, getConfigFromEnv } from '../util/config';
+
+const wellKnown = (req: Request, res: Response) => {
+  let discoverData = {
+    lagoon_version: getConfigFromEnv('LAGOON_VERSION',''),
+    authorization_endpoint: getConfigFromEnv('KEYCLOAK_URL', ''),
+    ssh_token_exchange: {
+      token_endpoint_host: getConfigFromEnv('SSH_TOKEN_ENDPOINT', ''),
+      token_endpoint_port: parseInt(getConfigFromEnv('SSH_TOKEN_ENDPOINT_PORT', '22'), 10)
+    },
+    webhook_endpoint: getConfigFromEnv('WEBHOOK_URL', ''),
+    ui_url: getConfigFromEnv('UI_URL',''),
+  }
+  res.json(discoverData);
+};
+
+export default [wellKnown];

--- a/tests/checks/check-api-request.yaml
+++ b/tests/checks/check-api-request.yaml
@@ -6,6 +6,6 @@
     headers:
       Authorization: "Bearer {{ bearer_token }}"
   register: result
-  until: result.content is match(expected_content)
+  until: result.content is search(expected_content)
   retries: 1
   delay: 0

--- a/tests/tests/features/api-token.yaml
+++ b/tests/tests/features/api-token.yaml
@@ -10,6 +10,6 @@
   vars:
     url: "{{ lookup('env','API_PROTOCOL') }}://{{ lookup('env','API_HOST') }}:{{ lookup('env','API_PORT') }}/"
     bearer_token: "{{ token }}"
-    expected_content: '{"status":"success","data":{}}'
+    expected_content: 'success'
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-api-request.yaml


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a simple way to expose some discovery data via a `/.well-known/appspecific/sh.lagoon.discovery.json` endpoint.

This could expose other information too, and for tools like `lagoon-cli` and `lagoon-sync`, users only need to know the API hostname (and maybe port if not standard http/s) when configuring their tools, rather than needing to know all the other endpoint information.

This contains some basic information like so, as long as the variables are provided to populate it correctly. Some are already provided by the chart, others will need to be created in the chart
```
{
    "lagoon_version": "v2.17.0",
    "authorization_endpoint": "https://keycloak.example.com",
    "ssh_token_exchange": {
        "token_endpoint_host": "token.example.com",
        "token_endpoint_port": 22
    },
    "webhook_endpoint": "https://webhook.example.com",
    "ui_url": "https://ui.example.com"
}
```

This requires updates to the charts to inject `SSH_TOKEN_ENDPOINT` and `SSH_TOKEN_ENDPOINT_PORT` variables that require a user to define, the `port` may be able to be consumed via the chart though, so only the hostname would need to be provided.

Conditions for the endpoint DNS record would be if this is a fresh install of the token or ssh service, the cluster loadbalancer/service IP or name for the token endpoint may not be known immediately, so could be set to the DNS record that will eventually be populated once the loadbalancer/service IP is know after deployment.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

