### PR TITLE
fix: use Float for restore size

### DIFF
--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -975,7 +975,7 @@ const typeDefs = gql`
     """
     The size of the restored file in bytes
     """
-    restoreSize: Int
+    restoreSize: Float
     created: String
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Changes the return type from `Int` to `Float`, based on discussion in #3629 

Other services in the API that store information related to storage size use Float, and these values would very likely see sizes into the GB if not TB of sizes that a restore would also see.
https://github.com/uselagoon/lagoon/blob/v2.17.0/services/api/src/typeDefs.js#L941
https://github.com/uselagoon/lagoon/blob/v2.17.0/services/api/src/typeDefs.js#L947

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3629 
