### PR TITLE
Add migration to mark orphaned environments deleted

### DIFF
--- a/services/api/database/migrations/20240108000000_fix_env_orphans.js
+++ b/services/api/database/migrations/20240108000000_fix_env_orphans.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    return knex('environment')
+    .update('deleted', knex.raw('NOW()'))
+    .whereNotIn('project', function() {
+      this.select('id').from('project');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+};

--- a/services/api/database/migrations/20240108000000_fix_env_orphans.js
+++ b/services/api/database/migrations/20240108000000_fix_env_orphans.js
@@ -6,6 +6,7 @@ exports.up = async function(knex) {
     return knex('environment')
     .leftJoin('project', 'environment.project', 'project.id')
     .whereNull('project.id')
+    .andWhere('environment.deleted','0000-00-00 00:00:00')
     .update('deleted', knex.raw('NOW()'));
 };
 

--- a/services/api/database/migrations/20240108000000_fix_env_orphans.js
+++ b/services/api/database/migrations/20240108000000_fix_env_orphans.js
@@ -4,10 +4,9 @@
  */
 exports.up = async function(knex) {
     return knex('environment')
-    .update('deleted', knex.raw('NOW()'))
-    .whereNotIn('project', function() {
-      this.select('id').from('project');
-    });
+    .leftJoin('project', 'environment.project', 'project.id')
+    .whereNull('project.id')
+    .update('deleted', knex.raw('NOW()'));
 };
 
 /**


### PR DESCRIPTION
As discussed in #3630 there are cases in previous versions of Lagoon where projects have been deleted and have had their environments orphaned without the (the envs) having their `deleted` field set to a non-zero/default value.

This PR introduces a migration to set the `deleted` field to the current date/time to mark an environment as having been deleted.

Note: there is no "down" specified for this migration - I wasn't sure what we wanted to do here. It's obviously not best to just simply reset all orphaned items `deleted` field to 0, since that's not the state of the DB pre migration (or, isn't guaranteed to be).

One option, I suppose, would be to set the date/time to something very specific - like "0000-00-01 11:11:11" -- assuming that this value wouldn't arise "naturally" -- and then have the down migration target environments with that date/time?
Thoughts?

# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically
