### PR TITLE
fix: return error when no matching event to prevent empty email notifications

### DIFF
--- a/services/logs2notifications/internal/handler/email_events.go
+++ b/services/logs2notifications/internal/handler/email_events.go
@@ -60,7 +60,7 @@ func (h *Messaging) processEmailTemplates(notification *Notification) (string, s
 	if err != nil {
 		eventSplit := strings.Split(notification.Event, ":")
 		if eventSplit[0] != "problem" {
-			return "", "", "", "", "", nil
+			return "", "", "", "", "", fmt.Errorf("no matching event")
 		}
 		if eventSplit[1] == "insert" {
 			tpl = "problemNotification"
@@ -127,7 +127,7 @@ func (h *Messaging) processEmailTemplates(notification *Notification) (string, s
 	case "problemNotification":
 		eventSplit := strings.Split(notification.Event, ":")
 		if eventSplit[0] != "problem" && eventSplit[1] == "insert" {
-			return "", "", "", "", "", nil
+			return "", "", "", "", "", fmt.Errorf("no matching event")
 		}
 		mainHTMLTpl = `[{{.ProjectName}}] New problem found for <code>{{.EnvironmentName}}</code>
 		<ul><li>* Service: {{.ServiceName}}</li>{{ if ne .Severity "" }}
@@ -142,7 +142,7 @@ func (h *Messaging) processEmailTemplates(notification *Notification) (string, s
 			notification.Meta.EnvironmentName,
 		)
 	default:
-		return "", "", "", "", "", nil
+		return "", "", "", "", "", fmt.Errorf("no matching event")
 	}
 
 	var body bytes.Buffer


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a fix for the email notification handler to prevent empty email notifications from being sent when no matching event type is found.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
