### PR TITLE
docs: add note about tls-acme false and remove out of date information

### DIFF
--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -250,6 +250,11 @@ that's important!):
 
 ### SSL Configuration `tls-acme`
 
+!!! Warning
+    If you switch from `tls-acme: true` to `tls-acme: false` this will remove any previously
+    generated certificates for this route. This could result in unexpected behaviour if you're
+    using an external CDN and do any certificate pinning.
+
 * `tls-acme`: Configures automatic TLS certificate generation via Let's Encrypt.
   Default is `true`, set to `false` to disable automatic certificates.
 * `insecure`: Configures HTTP connections. Default is `Allow`.
@@ -266,10 +271,7 @@ that's important!):
 !!! Info
     If you plan to switch from a SSL certificate signed by a Certificate
     Authority (CA) to a Let's Encrypt certificate, it's best to get in touch
-    with your Lagoon administrator to oversee the transition. There are [known
-    issues](https://github.com/tnozicka/openshift-acme/issues/68) during the
-    transition. The workaround would be manually removing the CA certificate and
-    then triggering the Let's Encrypt process.
+    with your Lagoon administrator to oversee the transition.
 
 ### Monitoring a specific path
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just tidying up the documentation around tls-acme by removing an out of date reference to an openshift issue, and including a warning about changing from `tls-acme: true` to `tls-acme: false` and that this will remove any previously generated certificates.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
