### PR TITLE
Change: check expiration of legacy tokens, reject if necessary

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -113,24 +113,7 @@ let transportOptions: {
   timeout: 60000
 };
 
-if (!envHasConfig('JWTSECRET') || !envHasConfig('JWTAUDIENCE')) {
-  logger.error(
-    'Unable to create api token due to missing `JWTSECRET`/`JWTAUDIENCE` environment variables'
-  );
-} else {
-  const apiAdminToken = createJWTWithoutUserId({
-    payload: {
-      role: 'admin',
-      iss: 'lagoon-commons',
-      aud: getConfigFromEnv('JWTAUDIENCE')
-    },
-    jwtSecret: getConfigFromEnv('JWTSECRET')
-  });
-
-  transportOptions.headers.Authorization = `Bearer ${apiAdminToken}`;
-}
-
-const transport = new Transport(`${getConfigFromEnv('API_HOST', 'http://api:3000')}/graphql`, transportOptions);
+const transport = new Transport(`${getConfigFromEnv('API_HOST', 'http://api:3000')}/graphql`, {transportOptions});
 
 export const graphqlapi = new Lokka({ transport });
 

--- a/node-packages/commons/src/lokka-transport-http-retry.ts
+++ b/node-packages/commons/src/lokka-transport-http-retry.ts
@@ -1,13 +1,41 @@
 import { Transport as LokkaTransportHttp } from '@lagoon/lokka-transport-http';
 import fetchUrl from 'node-fetch';
+import { createJWTWithoutUserId } from './jwt';
+import { logger } from './logs/local-logger';
+import { envHasConfig, getConfigFromEnv } from './util/config';
+
+// generate a fresh token for each operation
+const generateToken = () => {
+  if (!envHasConfig('JWTSECRET') || !envHasConfig('JWTAUDIENCE')) {
+    logger.error(
+      'Unable to create api token due to missing `JWTSECRET`/`JWTAUDIENCE` environment variables'
+    );
+  } else {
+    const apiAdminToken = createJWTWithoutUserId({
+      payload: {
+        role: 'admin',
+        iss: 'lagoon-internal',
+        aud: getConfigFromEnv('JWTAUDIENCE'),
+        // set a 60s expiry on the token
+        exp: Math.floor(Date.now() / 1000) + 60
+      },
+      jwtSecret: getConfigFromEnv('JWTSECRET')
+    });
+
+    return `Bearer ${apiAdminToken}`;
+  }
+  return ""
+}
 
 class NetworkError extends Error {}
 class ApiError extends Error {}
 
 // Retries the fetch if operational/network errors occur
 const retryFetch = (endpoint, options, retriesLeft = 5, interval = 1000) =>
-  new Promise((resolve, reject) =>
-    fetchUrl(endpoint, options)
+  new Promise((resolve, reject) => {
+    // get a fresh token for every request
+    options.headers.Authorization = generateToken()
+    return fetchUrl(endpoint, options)
       .then(response => {
         if (response.status !== 200 && response.status !== 400) {
           throw new NetworkError(`Invalid status code: ${response.status}`);
@@ -38,6 +66,7 @@ const retryFetch = (endpoint, options, retriesLeft = 5, interval = 1000) =>
           retryFetch(endpoint, options, retriesLeft - 1).then(resolve, reject);
         }, interval);
       })
+    }
   );
 
 export class Transport extends LokkaTransportHttp {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

As we look to phase out the usage of legacy tokens, we need to be able to reject long lived or non-expiring legacy tokens initially.
This introduces two new environment variables that can be set in the API.

* `LEGACY_EXPIRY_MAX` (default 3600s) - This is the maximum expiry that can be allowed to interact with the API
* `LEGACY_EXPIRY_REJECT` (default false) - This is what controls if a legacy token is rejected based on the checks

If a legacy token has the `exp` field, the remaining duration of the token is calculated against the `iss` timestamp. If this duration is greater than the `LEGACY_EXPIRY_MAX`, then depending on the `LEGACY_EXPIRY_REJECT` setting, it will log, or log and reject the request.

If there is no `exp` field on the token, then depending on the `LEGACY_EXPIRY_REJECT` setting, it will log, or log and reject the request.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
