### PR TITLE
fix: add DropUnique to rollback ES migration

### DIFF
--- a/.github/workflows/test-db-migrations.yml
+++ b/.github/workflows/test-db-migrations.yml
@@ -1,0 +1,62 @@
+name: Test database migration and rollback
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'services/api/database/**'
+      - '.github/workflows/test-db-migrations.yml'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'services/api/database/**'
+      - '.github/workflows/test-db-migrations.yml'
+
+jobs:
+  makeup:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout PR
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          fetch-depth: "0"
+          ref: ${{ github.event.pull_request.head.sha }}
+      -
+        name: Checkout Branch or Tag
+        uses: actions/checkout@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          fetch-depth: "0"
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build necessary images
+        run: |
+          make build
+      -
+        name: Bring up a docker compose lagoon
+        run: |
+          make up
+      -
+        name: Show initial migration logs
+        run: |
+          docker compose -p lagoon logs api-init
+      -
+        name: Initiate rollback
+        run: |
+          docker compose -p lagoon exec api sh -c './node_modules/.bin/knex migrate:rollback --all --cwd /app/services/api/database'
+      -
+        name: Reperform initial migration
+        run: |
+          docker compose -p lagoon exec api sh -c './node_modules/.bin/knex migrate:latest --cwd /app/services/api/database'
+      -
+        name: Remove testing setup
+        run: |
+          make down

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,9 @@ services:
       - CONSOLE_LOGGING_LEVEL=trace
   api-init:
     image: ${IMAGE_REPO:-lagoon}/api
-    command: ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database
+    command: >
+      sh -c "./node_modules/.bin/knex migrate:list --cwd /app/services/api/database
+      && ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database"
     volumes:
       - ./services/api/database:/app/services/api/database
       - ./node-packages:/app/node-packages:delegated
@@ -195,10 +197,6 @@ services:
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123
-  local-registry:
-    image: ${IMAGE_REPO:-lagoon}/local-registry
-    ports:
-      - '5000:5000'
   drush-alias:
     image: uselagoon/drush-alias:latest
     ports:

--- a/services/api/database/migrations/20240114000000_environment_services.js
+++ b/services/api/database/migrations/20240114000000_environment_services.js
@@ -4,6 +4,7 @@
  */
 exports.up = async function(knex) {
     return knex.schema
+    .raw(`DELETE es1 FROM environment_service es1 INNER JOIN environment_service es2  WHERE  es1.id < es2.id AND es1.name = es2.name;`)
     .alterTable('environment_service', function (table) {
         table.string('type', 300);
         table.timestamp('updated').notNullable().defaultTo(knex.fn.now());

--- a/services/api/database/migrations/20240114000000_environment_services.js
+++ b/services/api/database/migrations/20240114000000_environment_services.js
@@ -27,6 +27,7 @@ exports.down = async function(knex) {
         table.dropColumn('type');
         table.dropColumn('updated');
         table.dropColumn('created');
+        table.dropUnique(['name', 'environment'], 'service_environment');
     })
     .dropTable('environment_service_container')
 };

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -731,6 +731,7 @@ export const deleteAllEnvironments: ResolverFn = async (
   return 'success';
 };
 
+// @deprecated in favor of addOrUpdateEnvironmentService and deleteEnvironmentService, will eventually be removed
 export const setEnvironmentServices: ResolverFn = async (
   root,
   { input: { environment: environmentId, services } },
@@ -745,7 +746,11 @@ export const setEnvironmentServices: ResolverFn = async (
 
   await query(sqlClientPool, Sql.deleteServices(environmentId));
 
-  for (const service of services) {
+  // remove any duplicates, since there is no other identifying information related to these duplicates don't matter.
+  // as this function is also being deprecated its usage over time will eventually drop
+  // this means removal of duplicates is an acceptable trade off while the transition takes place
+  var uniq = services.filter((value, index, array) => array.indexOf(value) === index);
+  for (const service of uniq) {
     await query(sqlClientPool, Sql.insertService(environmentId, service));
   }
 


### PR DESCRIPTION
In #3641 additional tables, fields and indexes were added to show environment<>service connections. In the rollback migration, an index was missed for removal. This PR resolves that. It doesn't need a seperate migration, as it hasn't been released yet, and would only be encountered on a rollback.

This PR also adds a github action test designed to try and catch any rollback/migration errors at the point of initial commit. It shouldn't fire without a migration present.

In the development of this PR, it was discovered that migrations could fail if there were multiple services in the same environment with the same "name". As this name is not descriptive (nor unique), the migration now adds a functionality to remove any duplicate service names. With the advent of the build deploy and remote controller changes, it will become impossible for an environment to have multiple identically named services (as it is a docker compose constraint).