### PR TITLE
fix: use new stream endpoints for token mapper

### DIFF
--- a/services/keycloak/javascript/mappers/groups-and-roles.js
+++ b/services/keycloak/javascript/mappers/groups-and-roles.js
@@ -8,7 +8,7 @@ var projectGroupProjectIds = new HashMap();
 
 var forEach = Array.prototype.forEach;
 // add all groups the user is part of
-forEach.call(user.getGroups().toArray(), function(group) {
+forEach.call(user.getGroupsStream().toArray(), function(group) {
   // remove the group role suffixes
   // lets check if the group has a parent if this is a child
   var groupName = group.getName().replace(/-(owner|maintainer|developer|reporter|guest)$/,"");
@@ -45,7 +45,7 @@ for each (var e in projectGroupProjectIds.keySet()) {
 }
 
 // add all roles the user is part of
-forEach.call(user.getRoleMappings().toArray(), function(role) {
+forEach.call(user.getRoleMappingsStream().toArray(), function(role) {
   var roleName = role.getName();
   groupsAndRoles.add(roleName);
 });


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Keycloak changed some endpoints to stream, this updates the mapper to use these new endpoints

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

