### PR TITLE
feat: group polysite deployments under bulk label

### DIFF
--- a/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketPullRequestUpdated.ts
@@ -69,6 +69,8 @@ export async function bitbucketPullRequestUpdated(webhook: WebhookRequestData, p
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/bitbucketPush.ts
+++ b/services/webhooks2tasks/src/handlers/bitbucketPush.ts
@@ -56,6 +56,8 @@ export async function bitbucketPush(webhook: WebhookRequestData, project: Projec
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     let logMessage = `\`<${body.push.changes[0].new.links.html.href}>\``

--- a/services/webhooks2tasks/src/handlers/giteaPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPullRequestOpened.ts
@@ -70,6 +70,8 @@ export async function giteaPullRequestOpened(webhook: WebhookRequestData, projec
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/giteaPullRequestSynchronize.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPullRequestSynchronize.ts
@@ -88,6 +88,8 @@ export async function giteaPullRequestSynchronize(webhook: WebhookRequestData, p
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/giteaPush.ts
+++ b/services/webhooks2tasks/src/handlers/giteaPush.ts
@@ -57,6 +57,8 @@ export async function giteaPush(webhook: WebhookRequestData, project: Project) {
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     let logMessage = `\`<${body.repository.html_url}/tree/${meta.branch}|${meta.branch}>\``

--- a/services/webhooks2tasks/src/handlers/githubPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestOpened.ts
@@ -70,6 +70,8 @@ export async function githubPullRequestOpened(webhook: WebhookRequestData, proje
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.ts
+++ b/services/webhooks2tasks/src/handlers/githubPullRequestSynchronize.ts
@@ -88,6 +88,8 @@ export async function githubPullRequestSynchronize(webhook: WebhookRequestData, 
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/githubPush.ts
+++ b/services/webhooks2tasks/src/handlers/githubPush.ts
@@ -56,6 +56,8 @@ export async function githubPush(webhook: WebhookRequestData, project: Project) 
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     let logMessage = `\`<${body.repository.html_url}/tree/${meta.branch}|${meta.branch}>\``

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestOpened.ts
@@ -70,6 +70,8 @@ export async function gitlabPullRequestOpened(webhook: WebhookRequestData, proje
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPullRequestUpdated.ts
@@ -70,6 +70,8 @@ export async function gitlabPullRequestUpdated(webhook: WebhookRequestData, proj
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     try {

--- a/services/webhooks2tasks/src/handlers/gitlabPush.ts
+++ b/services/webhooks2tasks/src/handlers/gitlabPush.ts
@@ -57,6 +57,8 @@ export async function gitlabPush(webhook: WebhookRequestData, project: Project) 
       buildName: buildName,
       sourceUser: sourceUser,
       sourceType: "WEBHOOK",
+      bulkId: webhook.bulkId,
+      bulkName: webhook.bulkName,
     }
 
     let logMessage = `\`<${body.project.http_url}/tree/${meta.branch}|${meta.branch}>\``

--- a/services/webhooks2tasks/src/types.ts
+++ b/services/webhooks2tasks/src/types.ts
@@ -17,22 +17,23 @@ export interface removeData {
 }
 
 export interface deployData {
-  baseBranchName?: string;
-  baseSha?: string;
-  branchName: string;
-  buildName?: string;
-  buildPriority?: string;
-  buildVariables?: any;
-  bulkId?: string;
-  headBranchName?: string;
-  headSha?: string;
-  projectName: string;
-  pullrequestNumber?: number;
-  pullrequestTitle?: string;
-  pullrequestUrl?: string;
-  repoName?: string;
-  repoUrl?: string;
-  sha?: string;
+  baseBranchName?: string,
+  baseSha?: string,
+  branchName: string,
+  buildName?: string,
+  buildPriority?: string,
+  buildVariables?: any,
+  bulkId?: string,
+  bulkName?: string,
+  headBranchName?: string,
+  headSha?: string,
+  projectName: string,
+  pullrequestNumber?: number,
+  pullrequestTitle?: string,
+  pullrequestUrl?: string,
+  repoName?: string,
+  repoUrl?: string,
+  sha?: string,
   sourceType?: string,
   sourceUser?: string,
   type?: string;
@@ -40,13 +41,15 @@ export interface deployData {
 
 export interface WebhookRequestData {
   body?: any;
+  bulkId?: string,
+  bulkName?: string,
   event: string;
   giturl: string;
   sender?: any;
   user?: any;
   uuid?: string;
   webhooktype: string;
-}
+};
 
 export type Project = Pick<
   LagoonProject,

--- a/services/webhooks2tasks/src/webhooks/projects.ts
+++ b/services/webhooks2tasks/src/webhooks/projects.ts
@@ -22,6 +22,7 @@ import { gitlabBranchDeleted } from '../handlers/gitlabBranchDeleted';
 import { gitlabPullRequestClosed } from '../handlers/gitlabPullRequestClosed';
 import { gitlabPullRequestOpened } from '../handlers/gitlabPullRequestOpened';
 import { gitlabPullRequestUpdated } from '../handlers/gitlabPullRequestUpdated';
+import crypto from 'crypto';
 
 import {
   WebhookRequestData,
@@ -138,6 +139,15 @@ export async function processProjects(
       channelWrapperWebhooks.ack(rabbitMsg);
     }
     return;
+  }
+
+  // if there are more than 1 projects returned, it is probably a polysite deployment
+  if (projects.length > 1) {
+    // label them as a bulk or grouped deployment
+    // assign a random uuid
+    webhook.bulkId = crypto.randomUUID()
+    // and then add the name as polysite indicating what type of event started it
+    webhook.bulkName = `Polysite - ${webhooktype}:${event} - ${new Date().toISOString()}`
   }
 
   projects.forEach(async project => {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Simple addition to group polysite (projects with the same giturl) under the bulk deployment model.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3667 