### PR TITLE
Improvement: validate migrating labels for active standby ingress migrations

### DIFF
--- a/taskimages/activestandby/dioscuri/certificates.go
+++ b/taskimages/activestandby/dioscuri/certificates.go
@@ -20,7 +20,7 @@ func copyCertificates(ctx context.Context, c client.Client, ingress *networkv1.I
 			break
 		}
 		certificates = append(certificates, certificate)
-		fmt.Println(fmt.Sprintf(">> Copying certificate %s in namespace %s", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace))
+		fmt.Printf(">> Copying certificate %s in namespace %s\n", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace)
 	}
 	return certificates
 }
@@ -30,14 +30,13 @@ func createCertificates(ctx context.Context, c client.Client, destinationNamespa
 	for _, certificate := range certificates {
 		certificate.ObjectMeta.Namespace = destinationNamespace
 		certificate.ResourceVersion = ""
-		certificate.SelfLink = ""
 		certificate.UID = ""
 		err := c.Create(ctx, certificate)
 		if err != nil {
 			break
 		}
 		// secrets = append(secrets, certificate)
-		fmt.Println(fmt.Sprintf(">> Creating certificate %s in namespace %s", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace))
+		fmt.Printf(">> Creating certificate %s in namespace %s\n", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace)
 	}
 	return nil
 }

--- a/taskimages/activestandby/dioscuri/checks.go
+++ b/taskimages/activestandby/dioscuri/checks.go
@@ -1,0 +1,85 @@
+package dioscuri
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	networkv1 "k8s.io/api/networking/v1"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func collectandCheckIngress(ctx context.Context, c client.Client, rData *ReturnData) (*networkv1.IngressList, *networkv1.IngressList, error) {
+	ingressSourceToDestination, err := getIngressWithLabel(ctx,
+		c,
+		rData.SourceNamespace,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check ingress in source namespace, error was: %v`, err)
+	}
+	// get the ingress from the destination namespace, these will get moved to the source namespace
+	ingressDestinationToSource, err := getIngressWithLabel(ctx,
+		c,
+		rData.DestinationNamespace,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check ingress in destination namespace, error was: %v`, err)
+	}
+	// check that the services for the ingress we are moving exist in each namespace
+	migrateDestinationToSource, err := checkKubernetesServices(ctx,
+		c,
+		ingressDestinationToSource,
+		rData.SourceNamespace,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check services in source namespace, error was: %v`, err)
+	}
+	migrateSourceToDestination, err := checkKubernetesServices(ctx,
+		c,
+		ingressSourceToDestination,
+		rData.DestinationNamespace,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check services in destination namespace, error was: %v`, err)
+	}
+	if err := checkSecrets(ctx,
+		c,
+		migrateDestinationToSource,
+		rData.SourceNamespace,
+	); err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check ingress secrets in source namespace, error was: %v`, err)
+	}
+	// check that the secrets for the ingress we are moving don't already exist in each namespace
+	if err := checkSecrets(ctx,
+		c,
+		migrateSourceToDestination,
+		rData.DestinationNamespace,
+	); err != nil {
+		return nil, nil, fmt.Errorf(`task failed to check ingress secrets in destination namespace, error was: %v`, err)
+	}
+	return migrateDestinationToSource, migrateSourceToDestination, nil
+}
+
+func validateMigratingLabel(migrateSourceToDestination, migrateDestinationToSource *networkv1.IngressList, valid bool) error {
+	for _, ingress := range migrateSourceToDestination.Items {
+		val, ok := ingress.ObjectMeta.Labels["activestandby.lagoon.sh/migrating"]
+		if !ok {
+			return fmt.Errorf(`task failed due to ingress %s missing the migrating label`, ingress.ObjectMeta.Labels)
+		}
+		vBool, _ := strconv.ParseBool(val)
+		if vBool != valid {
+			return fmt.Errorf(`task failed due to ingress %s having the wrong label value for the migration, it should be %t (got %t)`, ingress.ObjectMeta.Name, valid, vBool)
+		}
+	}
+	for _, ingress := range migrateDestinationToSource.Items {
+		val, ok := ingress.ObjectMeta.Labels["activestandby.lagoon.sh/migrating"]
+		if !ok {
+			return fmt.Errorf(`task failed due to ingress %s missing the migrating label`, ingress.ObjectMeta.Name)
+		}
+		vBool, _ := strconv.ParseBool(val)
+		if vBool != valid {
+			return fmt.Errorf(`task failed due to ingress %s having the wrong label value for the migration, it should be %t (got %t)`, ingress.ObjectMeta.Name, valid, vBool)
+		}
+	}
+	return nil
+}

--- a/taskimages/activestandby/dioscuri/checks_test.go
+++ b/taskimages/activestandby/dioscuri/checks_test.go
@@ -1,0 +1,136 @@
+package dioscuri
+
+import (
+	"testing"
+
+	networkv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_validateMigratingLabel(t *testing.T) {
+	type args struct {
+		migrateSourceToDestination *networkv1.IngressList
+		migrateDestinationToSource *networkv1.IngressList
+		valid                      bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test1 - should exist and be true",
+			args: args{
+				valid: true,
+				migrateSourceToDestination: &networkv1.IngressList{
+					Items: []networkv1.Ingress{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "ingress1",
+								Namespace: "ingress1-ns",
+								Labels: map[string]string{
+									"activestandby.lagoon.sh/migrate":   "true",
+									"activestandby.lagoon.sh/migrating": "true",
+								},
+							},
+						},
+					},
+				},
+				migrateDestinationToSource: &networkv1.IngressList{},
+			},
+		},
+		{
+			name: "test2 - should exist and be false",
+			args: args{
+				valid: false,
+				migrateSourceToDestination: &networkv1.IngressList{
+					Items: []networkv1.Ingress{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "ingress1",
+								Namespace: "ingress1-ns",
+								Labels: map[string]string{
+									"activestandby.lagoon.sh/migrate":   "true",
+									"activestandby.lagoon.sh/migrating": "false",
+								},
+							},
+						},
+					},
+				},
+				migrateDestinationToSource: &networkv1.IngressList{},
+			},
+		},
+		{
+			name: "test3 - should exist and be false, but error because it is true",
+			args: args{
+				valid: false,
+				migrateSourceToDestination: &networkv1.IngressList{
+					Items: []networkv1.Ingress{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "ingress1",
+								Namespace: "ingress1-ns",
+								Labels: map[string]string{
+									"activestandby.lagoon.sh/migrate":   "true",
+									"activestandby.lagoon.sh/migrating": "true",
+								},
+							},
+						},
+					},
+				},
+				migrateDestinationToSource: &networkv1.IngressList{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test4 - should exist and be true, but error because it is false",
+			args: args{
+				valid: true,
+				migrateSourceToDestination: &networkv1.IngressList{
+					Items: []networkv1.Ingress{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "ingress1",
+								Namespace: "ingress1-ns",
+								Labels: map[string]string{
+									"activestandby.lagoon.sh/migrate":   "true",
+									"activestandby.lagoon.sh/migrating": "false",
+								},
+							},
+						},
+					},
+				},
+				migrateDestinationToSource: &networkv1.IngressList{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test5 - label does not exist, but should be true",
+			args: args{
+				valid: true,
+				migrateSourceToDestination: &networkv1.IngressList{
+					Items: []networkv1.Ingress{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "ingress1",
+								Namespace: "ingress1-ns",
+								Labels: map[string]string{
+									"activestandby.lagoon.sh/migrate": "true",
+								},
+							},
+						},
+					},
+				},
+				migrateDestinationToSource: &networkv1.IngressList{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateMigratingLabel(tt.args.migrateSourceToDestination, tt.args.migrateDestinationToSource, tt.args.valid); (err != nil) != tt.wantErr {
+				t.Errorf("validateMigratingLabel() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/taskimages/activestandby/dioscuri/dioscuri.go
+++ b/taskimages/activestandby/dioscuri/dioscuri.go
@@ -37,7 +37,7 @@ func RunMigration(c client.Client, rData *ReturnData, podName, podNamespace stri
 	ctx := context.Background()
 	var activeMigratedIngress []string
 	var standbyMigratedIngress []string
-	fmt.Println(fmt.Sprintf("> Running migration checks for ingress in %s moving to %s", rData.SourceNamespace, rData.DestinationNamespace))
+	fmt.Printf("> Running migration checks for ingress in %s moving to %s\n", rData.SourceNamespace, rData.DestinationNamespace)
 
 	// check destination namespace exists
 	namespace := corev1.Namespace{}
@@ -48,102 +48,47 @@ func RunMigration(c client.Client, rData *ReturnData, podName, podNamespace stri
 		&namespace,
 	); err != nil {
 		return fmt.Errorf(`========================================
-Task failed to check destination namespace, error was: %v
+task failed to check destination namespace, error was: %v
 ========================================
-This means the task has not performed any migrations yet and failed during pre-flight checks.
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
+this means the task has not performed any migrations yet and failed during pre-flight checks.
+the task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
+provide a copy of this entire log to the team`, err)
 	}
 
 	// START CHECKING SERVICES SECTION
-	// migrateLabels := map[string]string{"activestandby.lagoon.sh/migrate": "true"}
 	// get the ingress from the source namespace, these will get moved to the destination namespace
-	ingressSourceToDestination := &networkv1.IngressList{}
-	ingressSourceToDestination, err := getIngressWithLabel(ctx,
-		c,
-		rData.SourceNamespace,
-	)
+	migrateDestinationToSource, migrateSourceToDestination, err := collectandCheckIngress(ctx, c, rData)
 	if err != nil {
 		return fmt.Errorf(`========================================
-Task failed to check ingress in source namespace, error was: %v
+%v
 ========================================
-This means the task has not performed any migrations yet and failed during pre-flight checks.
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
+this means the task has not performed any migrations yet and failed during pre-flight checks.
+the task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
+provide a copy of this entire log to the team`, err)
 	}
-	// get the ingress from the destination namespace, these will get moved to the source namespace
-	ingressDestinationToSource, err := getIngressWithLabel(ctx,
-		c,
-		rData.DestinationNamespace,
-	)
-	if err != nil {
-		return fmt.Errorf(`========================================
-Task failed to check ingress in destination namespace, error was: %v
-========================================
-This means the task has not performed any migrations yet and failed during pre-flight checks.
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
-	}
-	// check that the services for the ingress we are moving exist in each namespace
-	migrateDestinationToSource := &networkv1.IngressList{}
-	if err := checkKubernetesServices(ctx,
-		c,
-		ingressDestinationToSource,
-		migrateDestinationToSource,
-		rData.SourceNamespace,
-	); err != nil {
-		return fmt.Errorf(`========================================
-Task failed to check services in source namespace, error was: %v
-========================================
-This means the task has not performed any migrations yet and failed during pre-flight checks.
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
-	}
-	migrateSourceToDestination := &networkv1.IngressList{}
-	if err := checkKubernetesServices(ctx,
-		c,
-		ingressSourceToDestination,
-		migrateSourceToDestination,
-		rData.DestinationNamespace,
-	); err != nil {
-		return fmt.Errorf(`========================================
-Task failed to check services in destination namespace, error was: %v
-========================================
-This means the task has not performed any migrations yet and failed during pre-flight checks.
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
-	}
-	if err := checkSecrets(ctx,
-		c,
-		ingressDestinationToSource,
-		rData.SourceNamespace,
-	); err != nil {
-		return fmt.Errorf(`========================================
-Task failed to check ingress secrets in source namespace, error was: %v
-========================================
-This means the task has not performed any migrations yet, and failed during pre-flight checks
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
-	}
-	// check that the secrets for the ingress we are moving don't already exist in each namespace
-	if err := checkSecrets(ctx,
-		c,
-		ingressSourceToDestination,
-		rData.DestinationNamespace,
-	); err != nil {
-		return fmt.Errorf(`========================================
-Task failed to check ingress secrets in destination namespace, error was: %v
-========================================
-This means the task has not performed any migrations yet, and failed during pre-flight checks
-The task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
-Provide a copy of this entire log to the team.`, err)
-	}
-	// END CHECKING SERVICES SECTION
 
-	// START MIGRATING ROUTES SECTION
-	fmt.Println(fmt.Sprintf("> Running ingress migrations in %s moving to %s", rData.SourceNamespace, rData.DestinationNamespace))
-	// actually start the migrations here
+	// START MIGRATING ROUTES PREFLIGHT SECTION
+
 	var migratedIngress []MigratedIngress
+	// label the ingress before they're migrated, this is to ensure that the label exists before anything is moved
+	for _, ingress := range migrateDestinationToSource.Items {
+		// before we move anything we may need to modify some annotations
+		// patch all the annotations we are given in the `pre-migrate-resource-annotations`
+		// with the provided values
+		if err := patchIngress(ctx,
+			c,
+			&ingress,
+			map[string]interface{}{"activestandby.lagoon.sh/migrating": "true"},
+		); err != nil {
+			return fmt.Errorf(`========================================
+task failed to patch ingress %s, error was: %v
+========================================
+the active standby switch failed to patch the ingress before the migration took place.
+This means the task has not performed any migrations yet and failed during pre-flight checks.
+the task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
+provide a copy of this entire log to the team`, ingress.ObjectMeta.Name, err)
+		}
+	}
 	for _, ingress := range migrateSourceToDestination.Items {
 		// before we move anything we need to modify some annotations/labels
 		// with the provided values
@@ -153,18 +98,42 @@ Provide a copy of this entire log to the team.`, err)
 			map[string]interface{}{"activestandby.lagoon.sh/migrating": "true"},
 		); err != nil {
 			return fmt.Errorf(`========================================
-Task failed to patch ingress %s, error was: %v
+task failed to patch ingress %s, error was: %v
 ========================================
-The active standby switch failed to patch an ingress before the migration took place.
-Depending on where this fails, the environment may have already migrated one or more ingress.
-
-DO NOT PERFORM THIS TASK AGAIN
-
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
+the active standby switch failed to patch the ingress before the migration took place.
+This means the task has not performed any migrations yet and failed during pre-flight checks.
+the task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
+provide a copy of this entire log to the team`, ingress.ObjectMeta.Name, err)
 		}
+	}
 
-		// migrate these ingress
+	fmt.Printf("> Running ingress migrations validation checks for %s moving to %s\n", rData.SourceNamespace, rData.DestinationNamespace)
+	// collect the ingress again after they are labeled
+	migrateDestinationToSource, migrateSourceToDestination, err = collectandCheckIngress(ctx, c, rData)
+	if err != nil {
+		return err
+	}
+	// validate that the migrating label is added to the ingress
+	err = validateMigratingLabel(migrateSourceToDestination, migrateDestinationToSource, true)
+	if err != nil {
+		return fmt.Errorf(`========================================
+%v
+========================================
+this means the task has not performed any migrations yet and failed during pre-flight checks.
+the task may be performed again, but successive failures of this type should be reported to your Lagoon administrator.
+provide a copy of this entire log to the team`, err)
+	}
+
+	// wait a sec before migrating the ingress after validating the ingress
+	checkInterval := time.Duration(10)
+	time.Sleep(checkInterval * time.Second)
+
+	fmt.Printf("> Running ingress migrations in %s moving to %s\n", rData.SourceNamespace, rData.DestinationNamespace)
+	// START MIGRATING ROUTES SECTION
+	// actually start the migrations here
+	for _, ingress := range migrateSourceToDestination.Items {
+		// migrate these ingress from the source environment, to the destination environment
+		// this process deletes the ingress, then re-creates it in the destination environment
 		newIngress, err := individualIngressMigration(ctx,
 			c,
 			&ingress,
@@ -173,14 +142,14 @@ Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
 		)
 		if err != nil {
 			return fmt.Errorf(`========================================
-Task failed to migrate ingress %s, error was: %v
+task failed to migrate ingress %s, error was: %v
 ========================================
-The active standby switch failed to migrate and ingress in the source namespace to the destination namespace
+the active standby switch failed to migrate and ingress in the source namespace to the destination namespace
 
 DO NOT PERFORM THIS TASK AGAIN
 
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, ingress.ObjectMeta.Name, err)
 		}
 		migratedIngress = append(migratedIngress,
 			MigratedIngress{
@@ -197,26 +166,8 @@ Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
 		}
 	}
 	for _, ingress := range migrateDestinationToSource.Items {
-		// before we move anything we may need to modify some annotations
-		// patch all the annotations we are given in the `pre-migrate-resource-annotations`
-		// with the provided values
-		if err := patchIngress(ctx,
-			c,
-			&ingress,
-			map[string]interface{}{"activestandby.lagoon.sh/migrating": "true"},
-		); err != nil {
-			return fmt.Errorf(`========================================
-Task failed to patch ingress %s, error was: %v
-========================================
-The active standby switch failed to patch an ingress before the migration took place.
-Depending on where this fails, the environment may have already migrated one or more ingress.
-
-DO NOT PERFORM THIS TASK AGAIN
-
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
-		}
-		// migrate these ingress
+		// migrate these ingress from the destination environment, to the source environment
+		// this process deletes the ingress, then re-creates it in the source environment
 		newIngress, err := individualIngressMigration(ctx,
 			c,
 			&ingress,
@@ -225,14 +176,14 @@ Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
 		)
 		if err != nil {
 			return fmt.Errorf(`========================================
-Task failed to migrate ingress %s, error was: %v
+task failed to migrate ingress %s, error was: %v
 ========================================
-The active standby switch failed to migrate and ingress in the destination namespace to the source namespace
+the active standby switch failed to migrate and ingress in the destination namespace to the source namespace
 
 DO NOT PERFORM THIS TASK AGAIN
 
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, ingress.ObjectMeta.Name, err)
 		}
 		// add the migrated ingress so we go through and fix them up later
 		migratedIngress = append(migratedIngress,
@@ -248,8 +199,8 @@ Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
 			activeMigratedIngress = append(activeMigratedIngress, fmt.Sprintf("%s%s", ingressScheme, rule.Host))
 		}
 	}
+
 	// wait a sec before updating the ingress
-	checkInterval := time.Duration(1)
 	time.Sleep(checkInterval * time.Second)
 
 	// once we move all the ingress, we have to go through and do a final update on them to make sure any `HostAlreadyClaimed` warning/errors go away
@@ -266,16 +217,45 @@ Provide a copy of this entire log to the team.`, ingress.ObjectMeta.Name, err)
 		)
 		if err != nil {
 			return fmt.Errorf(`========================================
-Task failed to update ingress, error was: %v
+task failed to update ingress, error was: %v
 ========================================
-The active standby switch failed to update one or more ingress after the migration took place,
+the active standby switch failed to update one or more ingress after the migration took place,
 this means that the task likely completed successfully, but the updates may not appear in Lagoon.
 
 DO NOT PERFORM THIS TASK AGAIN
 
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, err)
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, err)
 		}
+	}
+
+	fmt.Printf("> Running post ingress migrations validation checks for %s moving to %s\n", rData.SourceNamespace, rData.DestinationNamespace)
+	migrateDestinationToSource, migrateSourceToDestination, err = collectandCheckIngress(ctx, c, rData)
+	if err != nil {
+		return fmt.Errorf(`========================================
+%v
+========================================
+the active standby switch failed to check an ingress after the migration took place,
+this means that the task likely completed successfully, but there was an error verifying the post migration status.
+
+DO NOT PERFORM THIS TASK AGAIN
+
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, err)
+	}
+	// validate that the migrating label is added to the ingress
+	err = validateMigratingLabel(migrateSourceToDestination, migrateDestinationToSource, false)
+	if err != nil {
+		return fmt.Errorf(`========================================
+%v
+========================================
+the active standby switch failed to validate an ingress after the migration took place,
+this means that the task likely completed successfully, but there was an error verifying the post migration status.
+
+DO NOT PERFORM THIS TASK AGAIN
+
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, err)
 	}
 
 	rData.Status = "Completed"
@@ -306,14 +286,14 @@ Provide a copy of this entire log to the team.`, err)
 		Name:      podName,
 	}, &pod); err != nil {
 		return fmt.Errorf(`========================================
-Task failed to get the pod to update, error was: %v
+task failed to get the pod to update, error was: %v
 ========================================
-The active standby switch completed, but Lagoon has not been updated to reflect the changes.
+the active standby switch completed, but Lagoon has not been updated to reflect the changes.
 
 DO NOT PERFORM THIS TASK AGAIN UNTIL LAGOON REFLECTS THE CHANGES REQUIRED
 
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, err)
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, err)
 	}
 	// the job data to send back to lagoon must be base64 encoded
 	mergePatch, _ := json.Marshal(map[string]interface{}{
@@ -326,14 +306,14 @@ Provide a copy of this entire log to the team.`, err)
 	// update the pod with the annotation
 	if err := c.Patch(context.Background(), &pod, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
 		return fmt.Errorf(`========================================
-Task failed to update pod with return information, error was: %v
+task failed to update pod with return information, error was: %v
 ========================================
-The active standby switch completed, but Lagoon has not been updated to reflect the changes.
+the active standby switch completed, but Lagoon has not been updated to reflect the changes.
 
 DO NOT PERFORM THIS TASK AGAIN UNTIL LAGOON REFLECTS THE CHANGES REQUIRED
 
-Please contact your Lagoon administrator to make sure your project gets updated correctly.
-Provide a copy of this entire log to the team.`, err)
+please contact your Lagoon administrator to make sure your project gets updated correctly.
+provide a copy of this entire log to the team`, err)
 	}
 	return nil
 }
@@ -341,10 +321,10 @@ Provide a copy of this entire log to the team.`, err)
 func checkKubernetesServices(ctx context.Context,
 	c client.Client,
 	ingressList *networkv1.IngressList,
-	ingressToMigrate *networkv1.IngressList,
 	destinationNamespace string,
-) error {
+) (*networkv1.IngressList, error) {
 	// check service for ingress exists in destination namespace
+	ingressToMigrate := &networkv1.IngressList{}
 	for _, ingress := range ingressList.Items {
 		for _, host := range ingress.Spec.Rules {
 			for _, path := range host.HTTP.Paths {
@@ -358,14 +338,14 @@ func checkKubernetesServices(ctx context.Context,
 				)
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						return fmt.Errorf("Service %s for ingress %s doesn't exist in namespace %s, skipping ingress",
+						return nil, fmt.Errorf("service %s for ingress %s doesn't exist in namespace %s, skipping ingress",
 							path.Backend.Service.Name, host.Host, destinationNamespace)
 					}
-					return fmt.Errorf("Error getting service, error was: %v", err)
+					return nil, fmt.Errorf("error getting service, error was: %v", err)
 				}
 				ingressToMigrate.Items = append(ingressToMigrate.Items, ingress)
 			}
 		}
 	}
-	return nil
+	return ingressToMigrate, nil
 }

--- a/taskimages/activestandby/dioscuri/ingress_test.go
+++ b/taskimages/activestandby/dioscuri/ingress_test.go
@@ -134,7 +134,6 @@ func Test_patchIngress(t *testing.T) {
 func Test_individualIngressMigration(t *testing.T) {
 	type args struct {
 		ctx                  context.Context
-		ingress              *networkv1.Ingress
 		seedIngress          string
 		sourceNamespace      string
 		destinationNamespace string

--- a/taskimages/activestandby/dioscuri/secrets.go
+++ b/taskimages/activestandby/dioscuri/secrets.go
@@ -30,10 +30,10 @@ func checkSecrets(ctx context.Context,
 			)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					// fmt.Println(fmt.Sprintf(">> Secret %s for ingress %s doesn't exist in namespace %s", hosts.SecretName, hosts, destinationNamespace))
+					// fmt.Printf(">> Secret %s for ingress %s doesn't exist in namespace %s", hosts.SecretName, hosts, destinationNamespace))
 					return nil
 				}
-				return fmt.Errorf("Error getting secret, error was: %v", err)
+				return fmt.Errorf("error getting secret, error was: %v", err)
 			}
 			// return fmt.Errorf("Secret %s for ingress %s exists in namespace %s, skipping ingress", hosts.SecretName, hosts, destinationNamespace)
 		}
@@ -51,7 +51,7 @@ func copySecrets(ctx context.Context, c client.Client, ingress *networkv1.Ingres
 			break
 		}
 		secrets = append(secrets, secret)
-		fmt.Println(fmt.Sprintf(">> Copying secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+		fmt.Printf(">> Copying secret %s in namespace %s\n", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace)
 	}
 	return secrets
 }
@@ -61,14 +61,13 @@ func createSecrets(ctx context.Context, c client.Client, destinationNamespace st
 	for _, secret := range secrets {
 		secret.ObjectMeta.Namespace = destinationNamespace
 		secret.ResourceVersion = ""
-		secret.SelfLink = ""
 		secret.UID = ""
 		err := c.Create(ctx, secret)
 		if err != nil {
 			break
 		}
 		secrets = append(secrets, secret)
-		fmt.Println(fmt.Sprintf(">> Creating secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+		fmt.Printf(">> Creating secret %s in namespace %s\n", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace)
 	}
 	return nil
 }
@@ -82,7 +81,7 @@ func deleteOldSecrets(ctx context.Context, c client.Client, namespace string, in
 		if err == nil {
 			certificates[tls.SecretName] = false
 			if err = c.Delete(ctx, certificate); err != nil {
-				fmt.Println(fmt.Sprintf(">> Unable to delete certificate %s in namespace %s; error was: %v", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace, err))
+				fmt.Printf(">> Unable to delete certificate %s in namespace %s; error was: %v\n", certificate.ObjectMeta.Name, certificate.ObjectMeta.Namespace, err)
 				continue
 			}
 			certificates[tls.SecretName] = true
@@ -92,12 +91,12 @@ func deleteOldSecrets(ctx context.Context, c client.Client, namespace string, in
 		if err == nil {
 			secrets[tls.SecretName] = false
 			if err = c.Delete(ctx, secret); err != nil {
-				fmt.Println(fmt.Sprintf(">> Unable to patch secret %s in namespace %s; error was: %v", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace, err))
+				fmt.Printf(">> Unable to patch secret %s in namespace %s; error was: %v\n", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace, err)
 				continue
 			}
 			secrets[tls.SecretName] = true
 		} // else the secret didn't exist, so nothing to try and delete
-		// fmt.Println(fmt.Sprintf(">> Added delete annotation to secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+		// fmt.Printf(">> Added delete annotation to secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
 	}
 	return certificates, secrets
 }

--- a/taskimages/activestandby/main.go
+++ b/taskimages/activestandby/main.go
@@ -36,7 +36,7 @@ func main() {
 		// read the legacy deployer token if for some reason the serviceaccount is not found.
 		token, err = os.ReadFile("/var/run/secrets/lagoon/deployer/token")
 		if err != nil {
-			fmt.Println(fmt.Sprintf("Task failed to find a kubernetes token to use, error was: %v", err))
+			fmt.Printf("Task failed to find a kubernetes token to use, error was: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -51,19 +51,19 @@ func main() {
 	// create the client using the rest config.
 	c, err := client.New(config, client.Options{})
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Task failed creating the kubernetes client, error was: %v", err))
+		fmt.Printf("Task failed creating the kubernetes client, error was: %v\n", err)
 		os.Exit(1)
 	}
 
 	// decode the payload data and unmarshal it.
 	payloadBytes, err := base64.StdEncoding.DecodeString(JSONPayload)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Task failed to decode the supplied payload data, error was: %v", err))
+		fmt.Printf("Task failed to decode the supplied payload data, error was: %v\n", err)
 		os.Exit(1)
 	}
 	var payloadData map[string]interface{}
 	if err := json.Unmarshal(payloadBytes, &payloadData); err != nil {
-		fmt.Println(fmt.Sprintf("Task failed to unsmarshal the supplied payload data, error was: %v", err))
+		fmt.Printf("Task failed to unsmarshal the supplied payload data, error was: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

This refactors the activestandby task to perform validations of the migrating status label before migrations take place. It ensures that the label exists on the resources before they are migrated, and then post migration ensures that the label is reset.

This is done to help prevent the potential for race condition between the label being added to the ingress right before the migration of that ingress takes place.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

