### PR TITLE
fix: only set the subgroups of a parentgroup to the users group

### DIFF
--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -336,6 +336,8 @@ export const User = (clients: {
             continue
           }
         }
+        // only set the users role-group as the subgroup, this is because `loadGroupByName` retrieves all the subgroups not just the one the user is in
+        parentGroup.subGroups = [ug]
         userGroups.push(parentGroup);
       }
     }

--- a/services/api/src/resources/group/helpers.ts
+++ b/services/api/src/resources/group/helpers.ts
@@ -41,6 +41,9 @@ export const Helpers = (sqlClientPool: Pool) => {
                 for (const o in groups) {
                   projectGroups.push(await models.GroupModel.loadGroupById(groups[o]))
                 }
+                projectGroups.sort(function(a, b) {
+                    return a.name.localeCompare(b.name);
+                });
                 return projectGroups
             }
             return []
@@ -57,6 +60,9 @@ export const Helpers = (sqlClientPool: Pool) => {
                 for (const o in groups) {
                     orgGroups.push(await models.GroupModel.loadGroupById(groups[o]))
                 }
+                orgGroups.sort(function(a, b) {
+                    return a.name.localeCompare(b.name);
+                });
                 return orgGroups
             }
             return []


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a quick fix that makes sure that only the users group is loaded as the subgroups of their parent group.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

