### PR TITLE
Documentation: Adds documentation pointing to client libraries

### DIFF
--- a/docs/other-tools/client-libraries.md
+++ b/docs/other-tools/client-libraries.md
@@ -1,0 +1,26 @@
+# Lagoon client libraries
+
+If you're interested in developing tooling for the Lagoon ecosystem, there are a few libraries that you may find helpful.
+
+## Golang
+### Machinery
+
+The Machinery library is the most actively supported and developed of the tooling libraries for Lagoon.
+It is a central store of all the basic operations used across all our golang based tool types, primarily -- but not exclusively -- for API interaction.
+
+[https://github.com/uselagoon/machinery/](https://github.com/uselagoon/machinery/)
+
+
+## PHP
+
+If you're looking for PHP integration, the php-sdk may give you a good jumping off point for your work.
+
+[https://github.com/uselagoon/lagoon-php-sdk](https://github.com/uselagoon/lagoon-php-sdk)
+
+# Third Party Libraries
+
+## Ansible
+
+A frequently updated and expanding Ansible library for interacting with Lagoon.
+
+[https://github.com/salsadigitalauorg/lagoon_ansible_collection](https://github.com/salsadigitalauorg/lagoon_ansible_collection)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,8 @@ nav:
   - Lagoon Examples: https://github.com/uselagoon/lagoon-examples
 - Other Tools:
   - Lagoon CLI: https://uselagoon.github.io/lagoon-cli/
+  - Lagoon Sync: https://github.com/uselagoon/lagoon-sync
+  - Client Libraries: other-tools/client-libraries.md
 
 theme:
   name: 'material'


### PR DESCRIPTION
This PR adds some additional documentation regarding client libraries for the development of Lagoon ecosystem tooling.

It adds links to
- Machinery
- the "official" php library
- Salsa Digital's Ansible library

Further, it adds a link to lagoon-sync