### PR TITLE
Replace Jenkins builds on any branch prefixed with `docs/` with github action

### DIFF
--- a/.github/workflows/test-mkdocs.yml
+++ b/.github/workflows/test-mkdocs.yml
@@ -1,0 +1,38 @@
+name: Test mkdocs
+on:
+  push:
+    branches:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/test-mkdocs.yml'
+
+jobs:
+  mkdocs:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Install mkdocs and dependencies
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs
+          pip install -r docs/requirements.txt
+      -
+        name: Check docs build ok in native mkdocs
+        run: |
+          mkdocs -V
+          mkdocs build -s
+      -
+        name: Check docs build ok with amazee.io mkdocs image
+        run: |
+          docker run --rm ghcr.io/amazeeio/mkdocs-material -V
+          docker run --rm -p 8000:8000 -v ${PWD}:/docs ghcr.io/amazeeio/mkdocs-material build -s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+def skipRemainingStages = false
+
 pipeline {
   agent { label 'lagoon' }
   environment {
@@ -20,6 +22,20 @@ pipeline {
         sh 'env'
       }
     }
+    stage ('skip on docs commit') {
+      when {
+        anyOf {
+          changeRequest branch: 'docs\\/.*', comparator: 'REGEXP'
+          branch pattern: "docs\\/.*", comparator: "REGEXP"
+        }
+      }
+      steps {
+        script {
+          skipRemainingStages = true
+          echo "Docs only update, no build needed."
+        }
+      }
+    }
     // in order to have the newest images from upstream (with all the security
     // updates) we clean our local docker cache on tag deployments
     // we don't do this all the time to still profit from image layer caching
@@ -28,12 +44,20 @@ pipeline {
     stage ('clean docker image cache') {
       when {
         buildingTag()
+        expression {
+            !skipRemainingStages
+        }
       }
       steps {
         sh script: "docker image prune -af", label: "Pruning images"
       }
     }
     stage ('build and push images') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       environment {
         PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
       }
@@ -46,11 +70,21 @@ pipeline {
       }
     }
     stage ('show trivy scan results') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       steps {
         sh script: "cat scan.txt", label: "Display scan results"
       }
     }
     stage ('setup test cluster') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       parallel {
         stage ('0: setup test cluster') {
           steps {
@@ -72,6 +106,11 @@ pipeline {
       }
     }
     stage ('run first test suite') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       parallel {
         stage ('1: run first test suite') {
           steps {
@@ -106,6 +145,11 @@ pipeline {
       }
     }
     stage ('run second test suite') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       parallel {
         stage ('2: run second test suite') {
           steps {
@@ -126,6 +170,11 @@ pipeline {
       }
     }
     stage ('run third test suite') {
+      when {
+        expression {
+            !skipRemainingStages
+        }
+      }
       parallel {
         stage ('3: run third test suite') {
           steps {
@@ -146,10 +195,13 @@ pipeline {
       }
     }
     stage ('push images to testlagoon/* with :latest tag') {
-      when {
+       when {
         branch 'main'
         not {
           environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
+        }
+        expression {
+            !skipRemainingStages
         }
       }
       environment {
@@ -166,6 +218,9 @@ pipeline {
         not {
           environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
         }
+        expression {
+            !skipRemainingStages
+        }
       }
       environment {
         TOKEN = credentials('git-amazeeio-helmfile-ci-trigger')
@@ -179,6 +234,9 @@ pipeline {
         buildingTag()
         not {
           environment name: 'SKIP_IMAGE_PUBLISH', value: 'true'
+        }
+        expression {
+            !skipRemainingStages
         }
       }
       environment {
@@ -194,6 +252,9 @@ pipeline {
         anyOf {
           branch 'testing/scans'
           buildingTag()
+        }
+        expression {
+            !skipRemainingStages
         }
       }
       steps {


### PR DESCRIPTION
Currently, Jenkins builds and tests every PR generated. For a simple docs-only commit, this is not only an unnecessary use of resources, it adds time to the ability to propagate updates to the website.

This PR adds a check step into the Jenkins pipeline to check the source branch of a PR (and additionally any branch push, although docs/ is skipped in config already), and if it sees the docs/ prefix, it sets a variable that is then used to skip all remaining stages.

Additionally, it includes a github action that does a strict build on the docs, intended to fail on any error.