### PR TITLE
chore: remove branch overrides after v2.18.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
         TOKEN = credentials('git-amazeeio-helmfile-ci-trigger')
       }
       steps {
-        sh script: "curl -X POST -F token=$TOKEN -F ref=test6_lagoon_v218 https://git.amazeeio.cloud/api/v4/projects/86/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
+        sh script: "curl -X POST -F token=$TOKEN -F ref=main https://git.amazeeio.cloud/api/v4/projects/86/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
       }
     }
     stage ('push images to uselagoon/*') {

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ STERN_VERSION = v2.6.1
 CHART_TESTING_VERSION = v3.10.1
 K3D_IMAGE = docker.io/rancher/k3s:v1.28.6-k3s2
 TESTS = [nginx,api,features-kubernetes,bulk-deployment,features-kubernetes-2,features-variables,active-standby-kubernetes,tasks,drush,python,gitlab,github,bitbucket,services,workflows]
-CHARTS_TREEISH = prerelease/lagoon_v218
+CHARTS_TREEISH = main
 TASK_IMAGES = task-activestandby
 
 # Symlink the installed kubectl client if the correct version is already


### PR DESCRIPTION
This PR reverts the lagoon branch to use the main branches for the upstream and downstream charts.