### PR TITLE
fix: get environment by namespacename before getting deployment

### DIFF
--- a/tests/tasks/api/get-latest-deployment-status.gql
+++ b/tests/tasks/api/get-latest-deployment-status.gql
@@ -1,0 +1,19 @@
+query environmentByKubernetesNamespaceName {
+  environmentByKubernetesNamespaceName(
+    kubernetesNamespaceName: "{{ namespace }}"
+  ){
+    deployments(limit: 1){
+      id
+      name
+      status
+      bulkId
+      bulkName
+      priority
+      started
+      created
+      completed
+      sourceUser
+      sourceType
+    }
+  }
+}

--- a/tests/tasks/api/get-latest-deployment-status.yaml
+++ b/tests/tasks/api/get-latest-deployment-status.yaml
@@ -1,4 +1,4 @@
-- name: "{{ testname }} - Verify that source user and type are correct"
+- name: "{{ testname }} - Verify that status are correct"
   block:
     - ansible.builtin.include_tasks: admin-token.yaml
     - name: "{{ testname }} - POST api check latest deployment {{ graphql_url }}"
@@ -9,7 +9,7 @@
           Authorization: "Bearer {{ admin_token }}"
         body_format: json
         body:
-          query: '{{ lookup("template", "./get-latest-deployment-source.gql") }}'
+          query: '{{ lookup("template", "./get-latest-deployment-status.gql") }}'
       register: apiresponse
       until:
         - apiresponse.json.data.environmentByKubernetesNamespaceName.deployments[0].status is defined
@@ -25,7 +25,7 @@
           Authorization: "Bearer {{ admin_token }}"
         body_format: json
         body:
-          query: '{{ lookup("template", "./get-latest-deployment-source.gql") }}'
+          query: '{{ lookup("template", "./get-latest-deployment-status.gql") }}'
       register: apiresponse
 
     - name: "{{ testname }} - POST api check response {{ graphql_url }}"
@@ -33,7 +33,7 @@
         msg: "api response: {{ apiresponse.json }}"
 
     - ansible.builtin.include_tasks: admin-token.yaml
-    - name: "{{ testname }} - POST api check latest deployment source user and type are correct {{ graphql_url }}"
+    - name: "{{ testname }} - POST api check latest deployment status are correct {{ graphql_url }}"
       uri:
         url: "{{ graphql_url }}"
         method: POST
@@ -41,11 +41,10 @@
           Authorization: "Bearer {{ admin_token }}"
         body_format: json
         body:
-          query: '{{ lookup("template", "./get-latest-deployment-source.gql") }}'
+          query: '{{ lookup("template", "./get-latest-deployment-status.gql") }}'
       register: apiresponse
       until:
-        - apiresponse.json.data.environmentByKubernetesNamespaceName.deployments[0].sourceUser == sourceUser
-        - apiresponse.json.data.environmentByKubernetesNamespaceName.deployments[0].sourceType == sourceType
+        - apiresponse.json.data.environmentByKubernetesNamespaceName.deployments[0].status == buildStatus
       retries: 60
       delay: 10
 

--- a/tests/tests/github/branch-picky.yaml
+++ b/tests/tests/github/branch-picky.yaml
@@ -24,6 +24,15 @@
     project: "{{ project }}"
     url: "{{ check_url }}"
 
+- name: "{{ testname }} - api check deployment status"
+  hosts: localhost
+  serial: 1
+  vars:
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+    buildStatus: "complete"
+  tasks:
+  - ansible.builtin.include_tasks: ../../tasks/api/get-latest-deployment-status.yaml
+
 - name: "{{ testname }} - webhook github delete push"
   hosts: localhost
   serial: 1

--- a/tests/tests/github/branch.yaml
+++ b/tests/tests/github/branch.yaml
@@ -88,6 +88,15 @@
     project: "{{ project }}"
     url: "{{ check_url }}"
 
+- name: "{{ testname }} - api check deployment status"
+  hosts: localhost
+  serial: 1
+  vars:
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+    buildStatus: "complete"
+  tasks:
+  - ansible.builtin.include_tasks: ../../tasks/api/get-latest-deployment-status.yaml
+
 - name: "{{ testname }} - webhook github delete push"
   hosts: localhost
   serial: 1

--- a/tests/tests/gitlab/branch.yaml
+++ b/tests/tests/gitlab/branch.yaml
@@ -78,6 +78,15 @@
     project: "{{ project }}"
     url: "{{ check_url }}"
 
+- name: "{{ testname }} - api check deployment status"
+  hosts: localhost
+  serial: 1
+  vars:
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+    buildStatus: "complete"
+  tasks:
+  - ansible.builtin.include_tasks: ../../tasks/api/get-latest-deployment-status.yaml
+
 - name: "{{ testname }} - webhook gitlab delete push"
   hosts: localhost
   serial: 1

--- a/tests/tests/nginx/nginx.yaml
+++ b/tests/tests/nginx/nginx.yaml
@@ -170,6 +170,15 @@
   tasks:
   - ansible.builtin.include_tasks: ../../tasks/api/get-latest-deployment-source.yaml
 
+- name: "{{ testname }} - api check deployment status"
+  hosts: localhost
+  serial: 1
+  vars:
+    namespace: "{{ project | regex_replace('_', '-') }}-{{ branch | regex_replace('/', '-') }}"
+    buildStatus: "complete"
+  tasks:
+  - ansible.builtin.include_tasks: ../../tasks/api/get-latest-deployment-status.yaml
+
 - name: "{{ testname }} - api deleteEnvironment on {{ project }}, which should remove all resources"
   hosts: localhost
   serial: 1


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

A small fix to the order of collecting the environment information in the actions-handler when receiving build updates. This is done because the actions-handler would try to get deploymentbyname using the "made safe" environment name, not the lagoon environment name (eg, `feature-this-branch` instead of the expected `feature/this/branch`)

This changes the process to collect the environment earlier using the namespace name and provide the lagoon environment name to the deploymentbyname query.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

