### PR TITLE
docs: Allow white-label and internationalise Lagoon docs

### DIFF
--- a/docs/_data/defaults.yml
+++ b/docs/_data/defaults.yml
@@ -1,0 +1,16 @@
+name: example.com
+webhookhandler: webhook.example.com
+sshport: 22
+sshhostname: ssh.example.com
+apiaddress: api.example.com
+helpstring: your Lagoon administrator
+helpstring_ja: Lagoon 管理者
+
+## Comment out any of the above, and uncomment the corresponding below to see the variables in action
+# name: amazee.io
+# webhookhandler: webhook.amazeeio.cloud
+# sshport: 32222
+# sshhostname: ssh.amazeeio.cloud
+# apiaddress: api.amazeeio.cloud
+# helpstring: "[amazee.io support](https://support.amazee.io)"
+# helpstring: "[amazee.io support](mailto:support@amazee.io)"

--- a/docs/applications/drupal/first-deployment-of-drupal.md
+++ b/docs/applications/drupal/first-deployment-of-drupal.md
@@ -19,13 +19,13 @@ git push
 
 This will trigger a push, and the Git hosting will inform Lagoon about this push via the configured webhook.
 
-If all is correct, you will see a notification in your configured chat system (this is configured by your friendly Lagoon administrator):
+If all is correct, you will see a notification in your configured chat system \(Contact {{ defaults.helpstring }} to configure this\):
 
 ![Slack notification of a deployment starting.](../../images/first_deployment_slack_start.jpg)
 
 This tells you that Lagoon has just started to deploy your code. Depending on the size of the codebase and amount of containers, this will take a couple of seconds. Just relax. If you'd like to know what's happening now, check out the [Build and Deploy Process of Lagoon](../../concepts-basics/build-and-deploy-process.md).
 
-You can also check your Lagoon UI to see the progress of any deployment (your Lagoon administrator has the info).
+You can also check your Lagoon UI to see the progress of any deployment \(Contact {{ defaults.helpstring }} for the URL if you don't have it\).
 
 ## 3. A fail
 
@@ -65,12 +65,12 @@ You should see something like:
 
 ```bash title="Drush sql-sync results"
 [drupal-example]cli-drupal:/app$ drush sql-sync @self @develop
-You will destroy data in ssh.lagoon.amazeeio.cloud/drupal and replace with data from drupal.
+You will destroy data in {{ defaults.sshhostname }}/drupal and replace with data from drupal.
 Do you really want to continue? (y/n): y
 Starting to dump database on Source.                                                                              [ok]
 Database dump saved to /home/drush-backups/drupal/20180227075813/drupal_20180227_075815.sql.gz               [success]
 Starting to discover temporary files directory on Destination.                                                    [ok]
-You will delete files in drupal-example-develop@ssh.lagoon.amazeeio.cloud:/tmp/drupal_20180227_075815.sql.gz and replace with data from /home/drush-backups/drupal/20180227075813/drupal_20180227_075815.sql.gz
+You will delete files in drupal-example-develop@{{ defaults.sshhostname }}:/tmp/drupal_20180227_075815.sql.gz and replace with data from /home/drush-backups/drupal/20180227075813/drupal_20180227_075815.sql.gz
 Do you really want to continue? (y/n): y
 Copying dump file from Source to Destination.                                                                     [ok]
 Starting to import dump file onto Destination database.
@@ -87,7 +87,7 @@ This time all should be green:
 
 ![Deployment Success!](../../images/first_deployment_slack_success.jpg)
 
-Click on the links in the notification, and you should see your Drupal site loaded in all its beauty! It will probably not have images yet, which we will handle in [Step 6](./first-deployment-of-drupal.md#6-synchronize-local-files-to-the-remote-lagoon-environment).
+Click on the links in the notification, and you should see your Drupal site loaded in all its beauty! It will probably not have images yet, which we will handle in [Step 6](./first-deployment-of-drupal.md#5-synchronize-local-files-to-the-remote-lagoon-environment).
 
 If it is still failing, check the logs link for more information.
 
@@ -103,7 +103,7 @@ It should show you something like:
 
 ```bash title="Drush rsync results"
 [drupal-example]cli-drupal:/app$ drush rsync @self:%files @develop:%files
-You will delete files in drupal-example-develop@ssh.lagoon.amazeeio.cloud:/app/web/sites/default/files and replace with data from /app/web/sites/default/files/
+You will delete files in drupal-example-develop@{{ defaults.sshhostname }}:/app/web/sites/default/files and replace with data from /app/web/sites/default/files/
 Do you really want to continue? (y/n): y
 ```
 
@@ -111,7 +111,7 @@ In some cases, though, it might not look correct, like here:
 
 ```bash title="Drush rsync results"
 [drupal-example]cli-drupal:/app$ drush rsync @self:%files @develop:%files
-You will delete files in drupal-example-develop@ssh.lagoon.amazeeio.cloud:'/app/web/%files' and replace with data from '/app/web/%files'/
+You will delete files in drupal-example-develop@{{ defaults.sshhostname }}:'/app/web/%files' and replace with data from '/app/web/%files'/
 Do you really want to continue? (y/n):
 ```
 
@@ -141,4 +141,4 @@ That's the beauty of Lagoon: it's exactly the same: Push the branch name you def
 Did the deployment fail? Oh no! But we're here to help:
 
 1. Click on the `logs` link in the error notification. It will tell you where in the deployment process the failure happened.
-2. If you can't figure it out, ask your Lagoon administrator, they are here to help!
+2. If you can't figure it out, contact {{ defaults.helpstring }}, they are here to help!

--- a/docs/applications/drupal/first-deployment-of-drupal.md
+++ b/docs/applications/drupal/first-deployment-of-drupal.md
@@ -19,17 +19,17 @@ git push
 
 This will trigger a push, and the Git hosting will inform Lagoon about this push via the configured webhook.
 
-If all is correct, you will see a notification in your configured chat system \(Contact {{ defaults.helpstring }} to configure this\):
+If all is correct, you will see a notification in your configured chat system. \(Contact {{ defaults.helpstring }} to configure this\):
 
 ![Slack notification of a deployment starting.](../../images/first_deployment_slack_start.jpg)
 
 This tells you that Lagoon has just started to deploy your code. Depending on the size of the codebase and amount of containers, this will take a couple of seconds. Just relax. If you'd like to know what's happening now, check out the [Build and Deploy Process of Lagoon](../../concepts-basics/build-and-deploy-process.md).
 
-You can also check your Lagoon UI to see the progress of any deployment \(Contact {{ defaults.helpstring }} for the URL if you don't have it\).
+You can also check your Lagoon UI to see the progress of any deployment. \(Contact {{ defaults.helpstring }} for the URL if you don't have it\).
 
 ## 3. A fail
 
-Depending on the post-rollout tasks defined in `.lagoon.yml` , you might have run some tasks like `drush updb` or `drush cr`. These Drush tasks depend on a database existing within the environment, which obviously does not exist yet. Let's fix that! Keep reading.
+Depending on the post-rollout tasks defined in `.lagoon.yml`, you might have run some tasks like `drush updb` or `drush cr`. These Drush tasks depend on a database existing within the environment, which obviously does not exist yet. Let's fix that! Keep reading.
 
 ## 4. Synchronize local database to the remote Lagoon environment
 
@@ -38,7 +38,7 @@ With full Drush site alias support in Lagoon, you can synchronize a local databa
 !!! warning
     You may have to tell pygmy about your public keys before the next step.
 
-If you get an error like `Permission denied (publickey)`, check out the documentation here: [pygmy - adding ssh keys](https://pygmy.readthedocs.io/en/master/ssh_agent)
+If you get an error like `Permission denied (publickey)`, check out the documentation here: [pygmy - adding ssh keys](https://pygmy.readthedocs.io/en/master/ssh_agent).
 
 First let's make sure that you can see the Drush site aliases:
 
@@ -115,7 +115,7 @@ You will delete files in drupal-example-develop@{{ defaults.sshhostname }}:'/app
 Do you really want to continue? (y/n):
 ```
 
-The reason for that is that the Drupal cannot resolve the path of the files directory. This most probably has to do that the Drupal is not fully configured or has a missing database. For a workaround you can use `drush rsync @self:sites/default/files @develop:sites/default/files`, but we suggest that you actually check your local and remote Drupal \(you can test with `drush status` to see if the files directory is correctly configured\).
+The reason for that is that the Drupal cannot resolve the path of the files directory. This most probably has to do with Drupal not being fully configured or having a missing database. For a workaround you can use `drush rsync @self:sites/default/files @develop:sites/default/files`, but we suggest that you actually check your local and remote Drupal \(you can test with `drush status` to see if the files directory is correctly configured\).
 
 ## 6. It's done
 

--- a/docs/concepts-advanced/environment-idling.md
+++ b/docs/concepts-advanced/environment-idling.md
@@ -6,7 +6,7 @@ Lagoon can utilize the [Aergia controller](https://github.com/amazeeio/aergia-co
 
 ### How does an environment get idled?
 
-The environment idler has many different configuration capabilities. Here are the defaults of a standard Lagoon installation \(these could be quite different in your Lagoon, check with your Lagoon administrator!\)
+The environment idler has many different configuration capabilities. Here are the defaults of a standard Lagoon installation \(these could be quite different in your Lagoon, Contact {{ defaults.helpstring }}!\)
 
 * Idling is tried every 4 hours.
 * Production environments are never idled.
@@ -25,4 +25,4 @@ The un-idling will take a couple of seconds, as the Kubernetes cluster needs to 
 Yes, there is a field `autoIdle` on the project \(impacts all environments\) and environment \(if you need to target just one environment\), as to whether idling is allowed to take place. A value of `1` indicates the project/environment is eligible for idling. If the project is set to `0` the environments will never be idled, even if the environment is set to `0`
 The default is always `1`\(idling is enabled\).
 
-Talk to your Lagoon administrator if you are unsure how to set these project/environment fields.
+Contact {{ defaults.helpstring }} if you are unsure how to set these project/environment fields.

--- a/docs/concepts-advanced/environment-idling.md
+++ b/docs/concepts-advanced/environment-idling.md
@@ -6,7 +6,7 @@ Lagoon can utilize the [Aergia controller](https://github.com/amazeeio/aergia-co
 
 ### How does an environment get idled?
 
-The environment idler has many different configuration capabilities. Here are the defaults of a standard Lagoon installation \(these could be quite different in your Lagoon, Contact {{ defaults.helpstring }}!\)
+The environment idler has many different configuration capabilities. Here are the defaults of a standard Lagoon installation \(these could be quite different in your Lagoon, contact {{ defaults.helpstring }}!\)
 
 * Idling is tried every 4 hours.
 * Production environments are never idled.

--- a/docs/concepts-advanced/environment-types.md
+++ b/docs/concepts-advanced/environment-types.md
@@ -11,7 +11,7 @@ But that's it. Lagoon itself handles `development` and `production` environments
 
 There are a couple of things that will use this information:
 
-* By default, `development` environments are idled after 4 hours with no hits \(don't worry, they wake up automatically\). It is also possible for your Lagoon administrator to disable auto-idling on a per-environment basis, just ask!
+* By default, `development` environments are idled after 4 hours with no hits \(don't worry, they wake up automatically\). It is also possible for {{ defaults.helpstring }} to disable auto-idling on a per-environment basis, just ask!
 * Our default Drupal `settings.php` files load additional settings files for `development.settings.php` and `production.settings.php` so you can define settings and configurations different per environment type.
 * If you try to delete an environment that is defined as the production environment \(either via webhooks or REST\), Lagoon will politely refuse to delete the production environment, as it tries to prevent you from making a mistake. In order to delete a production environment, you can either change the `productionEnvironment` in the API or use the secret `forceDeleteProductionEnvironment: true` POST payload for the REST API.
-* The Lagoon administrator might use the production environment information for some additional things. For example, at amazee.io we're calculating only the hits of the production environments to calculate the price of the hosting.
+* Sometimes {{ defaults.helpstring }} might use the production environment information for some additional things, such as calculating only the hits of the production environments to calculate the price of the hosting.

--- a/docs/concepts-advanced/index.md
+++ b/docs/concepts-advanced/index.md
@@ -2,4 +2,4 @@
 
 This section covers some of the more advanced concepts in Lagoon. If you're new to Lagoon, start with [Basic Lagoon Concepts](../concepts-basics/index.md).
 
-If you need help, contact your Lagoon administrator or reach out to the community and maintainers in our [Discord](../community/discord.md).
+If you need help, contact {{ defaults.helpstring }} or reach out to the community and maintainers in our [Discord](../community/discord.md).

--- a/docs/concepts-basics/building-blocks/groups.md
+++ b/docs/concepts-basics/building-blocks/groups.md
@@ -2,4 +2,4 @@
 
 _Groups_ are made up of users who have roles. An organization can have one or more groups. Each project can be assigned one or more groups. Groups can be assigned to multiple projects. Groups are created independently of projects, and then assigned to them.
 
-Organizations have a quota to limit the number of groups assigned to it. If you need to change the quota, please contact your Lagoon administrator.
+Organizations have a quota to limit the number of groups assigned to it. If you need to change the quota, please contact {{ defaults.helpstring }}.

--- a/docs/concepts-basics/building-blocks/organizations.md
+++ b/docs/concepts-basics/building-blocks/organizations.md
@@ -4,6 +4,6 @@ An _organization_ is an entity which can contain one or more projects, groups, u
 
 Organizations add a layer of structure to help imitate life - for example, you may be a project manager who creates an organization to reflect the team working on a specific site. So that organization would contain the project or projects that make up that site, all of the people who need access to work on the site as users in a group called _developers_, and maybe another group of people who just need access to Lagoon to view the site and any issues, called _viewers_, each with the appropriate roles.
 
-Organizations have a quota to limit the number of projects, groups, notifications, and environments that can be assigned to it. If you need to change this quota, please contact your Lagoon administrator.
+Organizations have a quota to limit the number of projects, groups, notifications, and environments that can be assigned to it. If you need to change this quota, please contact {{ defaults.helpstring }}.
 
 [Learn more about how to interact with Organizations](../../interacting/organizations.md).

--- a/docs/concepts-basics/building-blocks/roles.md
+++ b/docs/concepts-basics/building-blocks/roles.md
@@ -19,7 +19,7 @@ Members of organizations can be given the following roles:
 
 !!! info inline end "Changing Quotas"
 
-    If you need to change quotas, please contact your Lagoon administrator.
+    If you need to change quotas, please contact {{ defaults.helpstring }}.
 
 An _organization owner_ can do everything to do with administering an organization aside from changing quotas. They can add and delete users, groups, projects, deploy targets, and notifcations
 

--- a/docs/concepts-basics/docker-compose-yml.md
+++ b/docs/concepts-basics/docker-compose-yml.md
@@ -146,7 +146,7 @@ In many cases, Lagoon knows where that persistent storage needs to go. For examp
 * `lagoon.persistent` - The **absolute** path where the persistent storage should be mounted (the above example uses `/app/web/sites/default/files/` which is where Drupal expects its persistent storage).
 * `lagoon.persistent.name` - Tells Lagoon to not create a new persistent storage for that service, but instead mounts the persistent storage of another defined service into this service.
 * `lagoon.persistent.size` - The size of persistent storage you require (Lagoon usually gives you minimum 5G of persistent storage, if you need more, define it here).
-* `lagoon.persistent.class` - By default Lagoon automatically assigns the right storage class for your service (like SSDs for MySQL, bulk storage for Nginx, etc.). If you need to overwrite this, you can do so here. This is highly dependent on the underlying Kubernetes/OpenShift that Lagoon runs on. Ask your Lagoon administrator about this.
+* `lagoon.persistent.class` - By default Lagoon automatically assigns the right storage class for your service (like SSDs for MySQL, bulk storage for Nginx, etc.). If you need to overwrite this, you can do so here. This is highly dependent on the underlying Kubernetes/OpenShift that Lagoon runs on. Contact {{ defaults.helpstring }} for this.
 
 ### Auto-generated Routes
 
@@ -210,7 +210,7 @@ By default, Lagoon expects that services from custom templates are rolled out vi
 * `daemonset` - Expects a [`Daemonset`](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) object in the template for the service.
 * `false` - Will not monitor any rollouts, and will just be happy if the template applies and does not throw any errors.
 
-You can also overwrite the rollout for just one specific environment. This is done in [`.lagoon.yml`](lagoon-yml.md#environments-name-rollouts).
+You can also overwrite the rollout for just one specific environment. This is done in [`.lagoon.yml`](lagoon-yml.md#environmentsnamerollouts).
 
 ## Docker Compose v2 compatibility
 

--- a/docs/concepts-basics/index.md
+++ b/docs/concepts-basics/index.md
@@ -2,4 +2,4 @@
 
 This section covers some of the basic concepts in Lagoon. If you're already familiar with these, move on to [Advanced Lagoon Concepts](../concepts-advanced/index.md).
 
-If you need help, contact your Lagoon administrator or reach out to the community and maintainers in our [Discord](../community/discord.md).
+If you need help, contact {{ defaults.helpstring }} or reach out to the community and maintainers in our [Discord](../community/discord.md).

--- a/docs/concepts-basics/lagoon-yml.md
+++ b/docs/concepts-basics/lagoon-yml.md
@@ -271,7 +271,7 @@ that's important!):
 !!! Info
     If you plan to switch from a SSL certificate signed by a Certificate
     Authority (CA) to a Let's Encrypt certificate, it's best to get in touch
-    with your Lagoon administrator to oversee the transition.
+    with {{ defaults.helpstring }} to oversee the transition.
 
 ### Monitoring a specific path
 
@@ -285,7 +285,7 @@ When [UptimeRobot](https://uptimerobot.com/) is configured for your cluster \(Ku
 ### Ingress annotations
 
 !!! Warning
-    Route/Ingress annotations are only supported by projects that deploy into clusters that run nginx-ingress controllers! Check with your Lagoon administrator if this is supported.
+    Route/Ingress annotations are only supported by projects that deploy into clusters that run nginx-ingress controllers! Check with {{ defaults.helpstring }} if this is supported.
 
 * `annotations` can be a YAML map of [annotations supported by the nginx-ingress controller](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/). This is specifically useful for easy redirects and other configurations.
 
@@ -344,7 +344,7 @@ This example would trust the CIDR `1.2.3.4/32` \(the IP `1.2.3.4` in this case\)
 
 ### `Environments.[name].types`
 
-The Lagoon build process checks the `lagoon.type` label from the `docker-compose.yml` file in order to learn what type of service should be deployed \(read more about them in the [documentation of `docker-compose.yml`](docker-compose-yml.md#custom-templates)\).
+The Lagoon build process checks the `lagoon.type` label from the `docker-compose.yml` file in order to learn what type of service should be deployed \(read more about them in the [documentation of `docker-compose.yml`](docker-compose-yml.md#types)\).
 
 Sometimes you might want to override the **type** just for a single environment, and not for all of them. For example, if you want a standalone MariaDB database \(instead of letting the Service Broker/operator provision a shared one\) for your non-production environment called `develop`:
 
@@ -510,14 +510,14 @@ poly-project2:
 ???+ Info
     If you run directly on amazee.io hosted Lagoon you will not need this key set.
 
-With the key `api` you can define another URL that should be used by the Lagoon CLI and `drush` to connect to the Lagoon GraphQL API. This needs to be a full URL with a scheme, like: `http://localhost:3000` This usually does not need to be changed, but there might be situations where your Lagoon administrator tells you to do so.
+With the key `api` you can define another URL that should be used by the Lagoon CLI and `drush` to connect to the Lagoon GraphQL API. This needs to be a full URL with a scheme, like: `http://localhost:3000` This usually does not need to be changed, but there might be situations where {{ defaults.helpstring }} tells you to do so.
 
 ### `ssh`
 
 ???+ Info
     If you run directly on amazee.io hosted Lagoon you will not need this key set.
 
-With the key `ssh` you can define another SSH endpoint that should be used by the Lagoon CLI and `drush` to connect to the Lagoon remote shell service. This needs to be a hostname and a port separated by a colon, like: `localhost:2020` This usually does not need to be changed, but there might be situations where your Lagoon administrator tells you to do so.
+With the key `ssh` you can define another SSH endpoint that should be used by the Lagoon CLI and `drush` to connect to the Lagoon remote shell service. This needs to be a hostname and a port separated by a colon, like: `localhost:2020` This usually does not need to be changed, but there might be situations where {{ defaults.helpstring }} tells you to do so.
 
 ### `container-registries`
 

--- a/docs/interacting/graphql.md
+++ b/docs/interacting/graphql.md
@@ -10,17 +10,17 @@ To generate this token, use the remote shell via the `token` command:
 ssh -p [PORT] -t lagoon@[HOST] token
 ```
 
-Example for amazee.io:
+{{ defaults.name }} connection string:
 
-```bash title="Get amazee.io token"
-ssh -p 32222 -t lagoon@ssh.lagoon.amazeeio.cloud token
+```bash title="Get {{ defaults.name }} token"
+ssh -p {{ defaults.sshport }} -t lagoon@{{ defaults.sshhostname }} token
 ```
 
 This will return a long string, which is the JWT token.
 
-We also need the URL of the API endpoint. Ask your Lagoon administrator for this.
+We also need the URL of the API endpoint. Contact {{ defaults.helpstring }} for this.
 <!-- markdown-link-check-disable-next-line -->
-On amazee.io this is [`https://api.lagoon.amazeeio.cloud/graphql`](https://api.lagoon.amazeeio.cloud/graphql).
+For {{ defaults.name }} this is [`https://{{ defaults.apiaddress }}/graphql`](https://{{ defaults.apiaddress }}/graphql/graphql).
 
 Now we need a GraphQL client! Technically this is just HTTP, but we suggest GraphiQL. It has a nice UI that allows you to write GraphQL requests with autocomplete. Download, install and start it. \[[GraphiQL App](https://github.com/skevy/graphiql-app)\]
 

--- a/docs/interacting/lagoon-ui.md
+++ b/docs/interacting/lagoon-ui.md
@@ -1,5 +1,5 @@
 # The Lagoon UI
 
-The Lagoon UI can be accessed at https://ui-lagoon-master.ch.amazee.io. If you have any issues with access, please contact your Lagoon administrator.
+The Lagoon UI is your first point of call with Lagoon. If you have any issues with access, please contact {{ defaults.helpstring }}.
 
 The UI allows you to complete a variety of tasks with your projects and organizations. [Learn more about organizations here](../concepts-basics/building-blocks/organizations.md). and [what you can do with organizations in the UI here](../interacting/organizations.md).

--- a/docs/interacting/rbac.md
+++ b/docs/interacting/rbac.md
@@ -22,7 +22,7 @@ The organization owner role allows for the creation and deletion of projects, gr
 
 They can add users to groups, change the roles of users within those groups, and associate projects with groups. This gives the organization owner the ability to clearly see who has access, and quickly add and remove users.
 
-Organization owners now also have the ability to create Slack or other notifications directly, and associate those notifications with a project without requiring help from a Lagoon administrator.
+Organization owners now also have the ability to create Slack or other notifications directly, and associate those notifications with a project without requiring help from {{ defaults.helpstring }}.
 
 !!! Warning "NOTE"
     By default this role does not allow organization owners to create environments or trigger deployments within a project. They can add themselves to a group with a role that does grant them this permission. When creating a project, an organization owner can opt to be added as an owner of the project default group.

--- a/docs/interacting/ssh.md
+++ b/docs/interacting/ssh.md
@@ -62,14 +62,14 @@ Connecting is straightforward and follows the following pattern:
 ssh -p [PORT] -t [PROJECT-ENVIRONMENT-NAME]@[HOST]
 ```
 
-* `PORT` - The remote shell SSH endpoint port (for amazee.io: `32222`).
-* `HOST` - The remote shell SSH endpoint host (for amazee.io `ssh.lagoon.amazeeio.cloud`).
+* `PORT` - The remote shell SSH endpoint port (for example: `{{ defaults.sshport }}`).
+* `HOST` - The remote shell SSH endpoint host (for example `{{ defaults.sshhostname }}`).
 * `PROJECT-ENVIRONMENT-NAME` - The environment you want to connect to. This is most commonly in the pattern `PROJECTNAME-ENVIRONMENT`.
 
 As an example:
 
 ```bash title="SSH example"
-ssh -p 32222 -t drupal-example-main@ssh.lagoon.amazeeio.cloud
+ssh -p {{ defaults.sshport }} -t drupal-example-main@{{ defaults.sshhostname }}
 ```
 
 This will connect you to the project `drupal-example` on the environment `main`.
@@ -91,7 +91,7 @@ ssh -p [PORT] -t [PROJECT-ENVIRONMENT-NAME]@[HOST] service=[SERVICE-NAME] contai
 For example, to connect to the `php` container within the `nginx` pod:
 
 ```bash title="SSH to php container"
-ssh -p 32222 -t drupal-example-main@ssh.lagoon.amazeeio.cloud service=nginx container=php
+ssh -p {{ defaults.sshport }} -t drupal-example-main@{{ defaults.sshhostname }} service=nginx container=php
 ```
 
 ## Copying files
@@ -101,19 +101,19 @@ The common case of copying a file into your `cli` pod can be acheived with the u
 ### scp
 
 ```bash title="Copy file with scp"
-scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [local_path] [project_name]-[environment_name]@ssh.lagoon.amazeeio.cloud:[remote_path]
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P {{ defaults.sshport }} [local_path] [project_name]-[environment_name]@{{ defaults.sshhostname }}:[remote_path]
 ```
 
 ### rsync
 
 ```bash title="Copy files with rsync"
-rsync --rsh='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222' [local_path] [project_name]-[environment_name]@ssh.lagoon.amazeeio.cloud:[remote_path]
+rsync --rsh='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p {{ defaults.sshport }}' [local_path] [project_name]-[environment_name]@{{ defaults.sshhostname }}:[remote_path]
 ```
 
 ### tar
 
 ```bash
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [project_name]-[environment_name]@ssh.lagoon.amazee.io tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P {{ defaults.sshport }} [project_name]-[environment_name]@{{ defaults.sshhostname }} tar -zcf - [remote_path] | tar -zxf - -C /tmp/
 ```
 
 ### Specifying non-CLI pod/service
@@ -123,7 +123,7 @@ In the rare case that you need to specify a non-CLI service you can specify the 
 Piping `tar` through the `ssh` connection is the simplest method, and can be used to copy a file or directory using the usual `tar` flags:
 
 ```bash
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 32222 [project_name]-[environment_name]@ssh.lagoon.amazee.io service=solr tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P {{ defaults.sshport }} [project_name]-[environment_name]@{{ defaults.sshhostname }} service=solr tar -zcf - [remote_path] | tar -zxf - -C /tmp/
 ```
 
 You can also use `rsync` with a wrapper script to reorder the arguments to `ssh` in the manner required by Lagoon's SSH service:
@@ -132,13 +132,13 @@ You can also use `rsync` with a wrapper script to reorder the arguments to `ssh`
 #!/usr/bin/env sh
 svc=$1 user=$3 host=$4
 shift 4
-exec ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222 -l "$user" "$host" "$svc" "$@"
+exec ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p {{ defaults.sshport }} -l "$user" "$host" "$svc" "$@"
 ```
 
 Put that in an executable shell script `rsh.sh` and specify the `service=...` in the `rsync` command:
 
 ```bash title="rsync to non-CLI pod"
-rsync --rsh="/path/to/rsh.sh service=cli" /tmp/foo [project_name]-[environment_name]@ssh.lagoon.amazeeio.cloud:/tmp/foo
+rsync --rsh="/path/to/rsh.sh service=cli" /tmp/foo [project_name]-[environment_name]@{{ defaults.sshhostname }}:/tmp/foo
 ```
 
 The script could also be adjusted to also handle a `container=...` argument.

--- a/docs/lagoonizing/index.md
+++ b/docs/lagoonizing/index.md
@@ -32,9 +32,9 @@ If you don’t have one already, you’ll need a Git client of some kind. Comman
 - [GitHub Desktop](https://desktop.github.com/) (Mac, Windows)
 - [GitKraken](https://www.gitkraken.com/git-client) (Mac, Windows, Linux - free for public repositories)
 
-## What Your Lagoon Administrator Needs
+## What {{ defaults.helpstring }} Needs
 
-Your Lagoon administrator, the person who is setting up your Lagoon, will need some information, [which is detailed here](../using-lagoon-the-basics/setup-project.md).
+The person setting up your Lagoon, usually {{ defaults.helpstring }} will need some information, [which is detailed here](../using-lagoon-the-basics/setup-project.md).
 
 ## Configure Webhooks
 
@@ -379,7 +379,7 @@ The simplest route is the `example.com` example in our sample `.lagoon.yml` abov
 #### Annotations
 
 !!! info
-    Route/Ingress annotations are only supported by projects that deploy into clusters that run nginx-ingress controllers! Check with your Lagoon administrator if this is supported.
+    Route/Ingress annotations are only supported by projects that deploy into clusters that run nginx-ingress controllers! Check with {{ defaults.helpstring }} if this is supported.
 
 Annotations can be a YAML map of annotations supported by the `nginx-ingress` controller, this is specifically useful for easy redirects:
 
@@ -426,7 +426,7 @@ You can of course also redirect to any other URL not hosted on Lagoon. This will
 - Only the `max-age` parameter is required. The required max-age parameter indicates the length of time, in seconds, the HSTS policy is in effect for.
 
 !!! info
-    If you plan to switch from a SSL certificate signed by a Certificate Authority (CA) to a Let's Encrypt certificate, it's best to get in touch with your Lagoon administrator to oversee the transition.
+    If you plan to switch from a SSL certificate signed by a Certificate Authority (CA) to a Let's Encrypt certificate, it's best to get in touch with {{ defaults.helpstring }} to oversee the transition.
 
 #### `environments.[name].types`
 
@@ -693,7 +693,7 @@ A Drupal site also consists of the files directory. To migrate your files from y
 
 ## Deploy
 
-If you’ve done everything in this guide, and your amazee.io administrator has everything set up, you are now ready to deploy your site!
+If you’ve done everything in this guide, and {{ defaults.helpstring }} has everything set up, you are now ready to deploy your site!
 
 If you are deploying a Drupal site, [follow this deployment guide](../applications/drupal/first-deployment-of-drupal.md).
 

--- a/docs/logging/kibana-examples.md
+++ b/docs/logging/kibana-examples.md
@@ -38,14 +38,14 @@ Running the query above will give you a general look at all the traffic to your 
 We are going to start off with the same query as above, but we are going to add a couple of things.
 
 * First, add the following fields: `client_ip` and `http_request`.
-* This will show you a list of all IP addresses and the page they requested. Here is what we see for the Amazee.io page:
+* This will show you a list of all IP addresses and the page they requested. Here is what we see for the amazee.io website:
 
 ![All IP addresses and the page they requested.](../images/kibana_example2.png)
 
 That looks good, but what if we wanted to just show requests from a specific IP address? You can filter for the address by adding it to your search criteria.
 
 * We are going to add: `AND client_ip: "IP address"`.
-* That will filter the results to just show you hits from that specific IP address, and the page they were requesting. Here is what it looks like for our Amazee.io website:
+* That will filter the results to just show you hits from that specific IP address, and the page they were requesting. Here is what it looks like for our amazee.io website:
 
 ![Hits from a specific IP address.](../images/kibana_example3.png)
 

--- a/docs/logging/logging.md
+++ b/docs/logging/logging.md
@@ -31,7 +31,7 @@ Lagoon provides access to the following logs via Kibana:
     * Ensure logs are structured as JSON encoded objects.
     * Ensure the `type` field contains the name of the Kubernetes namespace (`$LAGOON_PROJECT-$LAGOON_ENVIRONMENT`).
 
-To access the logs, please check with your Lagoon administrator to get the URL for the Kibana route \(for amazee.io, this is [https://logs.amazeeio.cloud/](https://logs.amazeeio.cloud/)\).
+To access the logs, please contact {{ defaults.helpstring }} to get the URL for the Kibana route.
 
 Each Lagoon user account has their own login and will see the logs only for the projects to which they have access.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ mkdocs-redirects
 mdx_truly_sane_lists
 mkdocs-git-revision-date-localized-plugin
 mkdocs-awesome-pages-plugin
+mkdocs-markdownextradata-plugin
+mkdocs-static-i18n

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -1,12 +1,12 @@
 # FAQ
 
-## How do I contact my Lagoon administrator?
-
-You should have a private Slack channel that was set up for you to communicate - if not, or you've forgotten how to contact us, reach out at [support@amazee.io](mailto:support@amazee.io).
-
 ## I found a bug! 🐞
 
-If you've found a bug or security issue, please send your findings to [support@amazee.io](mailto:support@amazee.io). Please DO NOT file a GitHub issue for them.
+If you've found a bug, please raise a GitHub issue for it, or contact {{ defaults.helpstring }}.
+
+## I found a security issue! 🐞
+
+If you've found a security issue, please send your findings to [security@amazee.io](mailto:security@amazee.io). Please DO NOT file a GitHub issue for it.
 
 ## I'm interested in amazee.io's hosting services with Lagoon
 
@@ -97,7 +97,7 @@ This typically indicates an issue with Pygmy. You can find our troubleshooting d
 
 ## My deployments fail with a message saying: "drush needs a more functional environment"
 
-This usually means that there is no database uploaded to the project. [Follow our step-by-step guide to add a database to your project](../applications/drupal/first-deployment-of-drupal.md#5-synchronize-local-database-to-the-remote-lagoon-environment).
+This usually means that there is no database uploaded to the project. [Follow our step-by-step guide to add a database to your project](../applications/drupal/first-deployment-of-drupal.md#4-synchronize-local-database-to-the-remote-lagoon-environment).
 
 ## When I start Pygmy I see an "address already in use" error?
 
@@ -137,8 +137,8 @@ Once you've added a runtime environment variable to your production environment 
 
 For cloud hosting customers, you can SFTP to your Lagoon environment by using the following information:
 
-* Server Hostname: `ssh.lagoon.amazeeio.cloud`
-* Port: 32222
+* Server Hostname: `{{ defaults.sshhostname }}`
+* Port: {{ defaults.sshport }}
 * Username: &lt;Project-Environment-Name&gt;
 
 Your username is going to be the name of the environment you are connecting to, most commonly in the pattern _`PROJECTNAME-ENVIRONMENT`_.
@@ -173,4 +173,4 @@ We suggest only exposing web services (NGINX/Varnish/Node.js) in your deployed e
 
 ## I have a question that isn't answered here
 
-You can reach out to the team via [Discord](https://discord.gg/te5hHe95JE) or email at [uselagoon@amazee.io](mailto:uselagoon@amazee.io).
+You should contact {{ defaults.helpstring }} for any hosting-related enquiries, but you can also reach out to the Lagoon team via [Discord](https://discord.gg/te5hHe95JE) or email at [uselagoon@amazee.io](mailto:uselagoon@amazee.io).

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -85,7 +85,7 @@ description: >-
 | Puppet | An open-source software configuration management and deployment tool. |
 | PV | PersistentVolume -  a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using Storage Classes.|
 | PVC | Persistent Volume Claim - a request for storage by a user. |
-| Pygmy | An amazee.io flavored local development system. |
+| Pygmy | A Lagoon flavored local development system. |
 | Python | Python is an open-source, interpreted, high-level, general-purpose programming language. |
 | RabbitMQ | An open-source message-broker software. |
 | RBAC | Role-Based Access Control |

--- a/docs/using-lagoon-advanced/custom-tasks.md
+++ b/docs/using-lagoon-advanced/custom-tasks.md
@@ -123,7 +123,7 @@ The values that the user selects will be available as environment variables in t
 
 ### System wide tasks
 
-Platform administrators are able to register system wide tasks. These tasks will appear for all environments, subject to the user's permission to invoke them.
+Only {{ defaults.helpstring }} is able to register system wide tasks. These tasks will appear for all environments, subject to the user's permission to invoke them.
 
 Creating a system wide task is almost exactly the same as other task types, with two exceptions.
 

--- a/docs/using-lagoon-advanced/index.md
+++ b/docs/using-lagoon-advanced/index.md
@@ -2,4 +2,4 @@
 
 This section covers some of the more advanced features and functionality of Lagoon. If you're new to Lagoon, start with [Using Lagoon - the Basics](../using-lagoon-the-basics/index.md).
 
-If you need help, contact your Lagoon administrator or reach out to the community and maintainers in our [Discord](../community/discord.md).
+If you need help, contact {{ defaults.helpstring }} or reach out to the community and maintainers in our [Discord](../community/discord.md).

--- a/docs/using-lagoon-advanced/using-harbor/README.md
+++ b/docs/using-lagoon-advanced/using-harbor/README.md
@@ -8,7 +8,7 @@
 If you are running Lagoon locally, you can access that UI at [localhost:8084](https://localhost:8084/). The username is `admin` and the password is `admin`.
 
 !!! Note
-    If you are hosting a site with a provider (such as amazee.io), they may not allow customer access to the Harbor UI.
+    If you are hosting a site with a provider, they may not allow customer access to the Harbor UI.
 
 Once logged in, the first screen is a list of all repositories your user has access to. Each "repository" in Harbor correlates to a project in Lagoon.
 

--- a/docs/using-lagoon-the-basics/first-deployment.md
+++ b/docs/using-lagoon-the-basics/first-deployment.md
@@ -28,13 +28,13 @@ git push
 
 This will trigger a push, and your Git hosting will inform Lagoon about this push via the configured webhook.
 
-If all is correct, you should see a notification in your configured chat system \(Contact {{ defaults.helpstring }} for this\):
+If all is correct, you should see a notification in your configured chat system. \(Contact {{ defaults.helpstring }} for this\):
 
 ![Slack notification that a push has been made in a Lagoonized repository.](../images/first_deployment_slack_start.jpg)
 
 This informs you that Lagoon has just started to deploy your code. Depending on the size of the code and amount of containers, this will take a couple of seconds. Just relax. If you want to know what's happening now, check out the [Build and Deploy Process of Lagoon](../concepts-basics/build-and-deploy-process.md).
 
-You can also check your Lagoon UI to see the progress of any deployment \(Contact {{ defaults.helpstring }} for this\).
+You can also check your Lagoon UI to see the progress of any deployment. \(Contact {{ defaults.helpstring }} for this\).
 
 ## 3. It's done
 

--- a/docs/using-lagoon-the-basics/first-deployment.md
+++ b/docs/using-lagoon-the-basics/first-deployment.md
@@ -28,13 +28,13 @@ git push
 
 This will trigger a push, and your Git hosting will inform Lagoon about this push via the configured webhook.
 
-If all is correct, you should see a notification in your configured chat system \(this has been configured by your friendly Lagoon administrator\):
+If all is correct, you should see a notification in your configured chat system \(Contact {{ defaults.helpstring }} for this\):
 
 ![Slack notification that a push has been made in a Lagoonized repository.](../images/first_deployment_slack_start.jpg)
 
 This informs you that Lagoon has just started to deploy your code. Depending on the size of the code and amount of containers, this will take a couple of seconds. Just relax. If you want to know what's happening now, check out the [Build and Deploy Process of Lagoon](../concepts-basics/build-and-deploy-process.md).
 
-You can also check your Lagoon UI to see the progress of any deployment \(your Lagoon administrator has the info\).
+You can also check your Lagoon UI to see the progress of any deployment \(Contact {{ defaults.helpstring }} for this\).
 
 ## 3. It's done
 
@@ -63,5 +63,5 @@ Did the deployment fail? Oh no! But we're here to help:
 
 1. If you deployed a Drupal site, make sure to read the [Drupal-specific first deployment documentation](../applications/drupal/first-deployment-of-drupal.md), which explains why this happens.
 2. Click on the `Logs` link in the error notification, it will tell you where in the deployment process the failure happened.
-3. If you can't figure it out, just ask your Lagoon support, we are here to help!
+3. If you can't figure it out, just ask {{ defaults.helpstring }}, they are here to help!
 4. Reach out to us in your support channel or in [the community Discord](https://discord.gg/te5hHe95JE).

--- a/docs/using-lagoon-the-basics/going-live.md
+++ b/docs/using-lagoon-the-basics/going-live.md
@@ -8,7 +8,7 @@ Congratulations, you're _this_ close to going live with your website on Lagoon! 
 
 Check to be sure that all routes have been set up in your `.lagoon.yml`. Be aware that if you don't point the domains towards Lagoon, you should disable Let's Encrypt \(LE\) certificate creation, as it will lead to issues. Domains not pointing towards Lagoon will be disabled after a while in order to not exceed the Let's Encrypt quotas.
 
-If you use Certificate Authority \(CA\) signed certificates, you can set `tls-acme` to `false` , but leave the `insecure` flag set to `Allow` or `Redirect`. In the case of CA certificates, let your Lagoon administrator know the routes and the SSL certificate that needs to be put in place.
+If you use Certificate Authority \(CA\) signed certificates, you can set `tls-acme` to `false` , but leave the `insecure` flag set to `Allow` or `Redirect`. In the case of CA certificates, contact {{ defaults.helpstring }} with the routes and the SSL certificate that needs to be put in place.
 
 ```yaml title=".lagoon.yml"
 environments:
@@ -51,7 +51,7 @@ Check if your cron jobs have been set up for your production environment - see [
 
 ## DNS
 
-To make it as smooth as possible for you to get your site pointing to our servers, we have dedicated load-balancer DNS records. Those technical DNS resource records are used for getting your site linked to the amazee.io infrastructure and serve no other purpose. If you are in doubt of the CNAME record, ask your Lagoon administrator about the exact CNAME you need to set up.
+To make it as smooth as possible for you to get your site pointing to our servers, we have dedicated load-balancer DNS records. Those technical DNS resource records are used for getting your site linked to the amazee.io infrastructure and serve no other purpose. If you are in doubt of the CNAME record, contact {{ defaults.helpstring }} about the exact CNAME you need to set up.
 
 **Example on amazee.io :** `<region-identifier>.amazee.io`
 
@@ -86,7 +86,7 @@ Configuring the root domain \(e.g. example.com\) can be a bit tricky because the
 * CNAME at [CloudFlare](https://www.cloudflare.com/)
 * CNAME at [NS1](http://ns1.com)
 
-If your DNS provider needs an IP address for the root domain, get in touch with your Lagoon administrator to give you the load balancer IP addresses.
+If your DNS provider needs an IP address for the root domain, get in touch contact {{ defaults.helpstring }} to give you the load balancer IP addresses.
 
 ## Production environment
 
@@ -94,6 +94,6 @@ Lagoon understands the concept of development and production environments. Devel
 
 `X-Robots-Tag: noindex, nofollow`
 
-During project setup, the production environment should already be defined. If that's omitted, your environment will run in development mode. You can check if the environment is set as production environment in the Lagoon user interface. If the production environment is not set, let your Lagoon administrator know, and they will configure the system accordingly.
+During project setup, the production environment should already be defined. If that's omitted, your environment will run in development mode. You can check if the environment is set as production environment in the Lagoon user interface. If the production environment is not set, let {{ defaults.helpstring }} know, and they will configure the system accordingly.
 
 ![The production environment is labelled in green on the left. ](../images/lagoon-ui-production.png)

--- a/docs/using-lagoon-the-basics/going-live.md
+++ b/docs/using-lagoon-the-basics/going-live.md
@@ -86,7 +86,7 @@ Configuring the root domain \(e.g. example.com\) can be a bit tricky because the
 * CNAME at [CloudFlare](https://www.cloudflare.com/)
 * CNAME at [NS1](http://ns1.com)
 
-If your DNS provider needs an IP address for the root domain, get in touch contact {{ defaults.helpstring }} to give you the load balancer IP addresses.
+If your DNS provider needs an IP address for the root domain, get in touch with {{ defaults.helpstring }} to give you the load balancer IP addresses.
 
 ## Production environment
 

--- a/docs/using-lagoon-the-basics/index.md
+++ b/docs/using-lagoon-the-basics/index.md
@@ -2,7 +2,7 @@
 
 This section covers some of the basic features and functionality in Lagoon. If you're familiar with these, move on to [Using Lagoon - Advanced](../using-lagoon-advanced/index.md).
 
-If you need help, contact your Lagoon administrator or reach out to the community and maintainers in our [Discord](../community/discord.md).
+If you need help, contact {{ defaults.helpstring }} or reach out to the community and maintainers in our [Discord](../community/discord.md).
 
 ## Requirements
 

--- a/docs/using-lagoon-the-basics/lagoon-build-errors-and-warnings.md
+++ b/docs/using-lagoon-the-basics/lagoon-build-errors-and-warnings.md
@@ -4,7 +4,7 @@ Newer releases of Lagoon have the capability to identify potential issues with t
 
 For example, if the Lagoon team makes a change to a setting in `lagoon.yml`, and there’s something that users need to change, the warning will mention it, so users will be able to change it before it becomes a breaking change. They should be resolved ASAP wherever possible, as future releases of Lagoon may not be able to handle the errors, but they shouldn't stop your build.
 
-If you aren't sure how to resolve these errors, please reach out to your Lagoon administrator, or ask a question in the [Lagoon community](../community/discord.md).
+If you aren't sure how to resolve these errors, please reach out to {{ defaults.helpstring }}, or ask a question in the [Lagoon community](../community/discord.md).
 
 ## Docker Compose Errors
 

--- a/docs/using-lagoon-the-basics/local-development-environments.md
+++ b/docs/using-lagoon-the-basics/local-development-environments.md
@@ -14,7 +14,7 @@ Even though Lagoon has only a hard dependency on Docker and [Docker Compose](htt
 
 ### pygmy
 
-Lagoon has traditionally worked best with `pygmy` , which is the amazee.io flavored system of the above tools and works out of the box with Lagoon. It lives at [https://github.com/pygmystack/pygmy](https://github.com/pygmystack/pygmy)
+Lagoon has traditionally worked best with `pygmy` , which is a preconfigured system of the above tools and works out of the box with Lagoon. It lives at [https://github.com/pygmystack/pygmy](https://github.com/pygmystack/pygmy)
 
 `pygmy` is written in Golang, so to install it, run:
 

--- a/docs/using-lagoon-the-basics/setup-project.md
+++ b/docs/using-lagoon-the-basics/setup-project.md
@@ -3,9 +3,9 @@
 !!! Note
     We are working hard on getting our CLI and GraphQL API set up to allow everyone using Lagoon to set up and configure their projects themselves. Right now, it needs more testing before we can release those features, so hold tight!
 
-Until then, the setup of a new project involves talking to your Lagoon administrator, which is ok, as they are much friendlier than APIs. 😊
+Until then, the setup of a new project involves talking to {{ defaults.helpstring }}, which is ok, as they are much friendlier than APIs. 😊
 
-Please have the following information ready for your Lagoon administrator:
+Please have the following information ready for {{ defaults.helpstring }}:
 
 * A name you would like the project to be known by
   * This name can only contain lowercase characters, numbers and dashes
@@ -13,7 +13,7 @@ Please have the following information ready for your Lagoon administrator:
 * SSH public keys, email addresses and the names of everybody that will work on this project. Here are instructions for generating and copying SSH keys for [GitHub](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh), [GitLab](https://docs.gitlab.com/ee/ssh/), and [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html).
 * The URL of the Git repository where your code is hosted \(`git@example.com:test/test.git`\).
 * The name of the Git branch you would like to use for your production environment \(see [Environment Types](../concepts-advanced/environment-types.md) for details about the environments\).
-* Which branches and pull requests you would like to deploy to your additional environments. With Lagoon, you can filter branches and pull requests by name with regular expressions, and your Lagoon administrator can get this set up for you.
+* Which branches and pull requests you would like to deploy to your additional environments. With Lagoon, you can filter branches and pull requests by name with regular expressions, and {{ defaults.helpstring }} can get this set up for you.
 
 We suggest deploying specific important branches \(like `develop` and `main`\) and pull requests. But that's all up to you! \(see [Workflows](../concepts-advanced/workflows.md) for some more information\)
 
@@ -27,7 +27,7 @@ If this is not the case, check out the list of [Step-by-Step Guides](index.md#st
 
 In order to deploy your code, Lagoon needs access to it. By design and for security, Lagoon only needs read access to your Git repository.
 
-Your Lagoon administrator will tell you the SSH public key or the Git account to give read access to.
+You may need {{ defaults.helpstring }} to tell you the SSH public key or the Git account to give read access to.
 
 ## 3. Configure Webhooks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,8 +238,18 @@ markdown_extensions:
       baselevel: 1
 
 plugins:
-  - search
+  - search:
+      lang:
+      - en
   - awesome-pages
+  - markdownextradata: {}
+  - i18n:
+      docs_structure: folder
+      languages:
+        - locale: en
+          default: true
+          name: English
+          build: true
   - redirects:
       redirect_maps:
         # Shortcut URLs for build and compose errors


### PR DESCRIPTION
This PR introduces the ability to white-label Lagoon documentation.

The use of the `markdownextradata` plugin allows a defaults.yml file to be populated, and this will then replace any variables in the documentation.