### PR TITLE
FIX: fixes migration deletion logic for duplicate environment_services

### DIFF
--- a/services/api/database/migrations/20240114000000_environment_services.js
+++ b/services/api/database/migrations/20240114000000_environment_services.js
@@ -4,7 +4,7 @@
  */
 exports.up = async function(knex) {
     return knex.schema
-    .raw(`DELETE es1 FROM environment_service es1 INNER JOIN environment_service es2  WHERE  es1.id < es2.id AND es1.name = es2.name;`)
+    .raw(`DELETE o FROM environment_service AS o LEFT JOIN (SELECT MIN(id) AS id FROM environment_service GROUP BY environment, name) AS i ON o.id = i.id WHERE i.id IS NULL;`)
     .alterTable('environment_service', function (table) {
         table.string('type', 300);
         table.timestamp('updated').notNullable().defaultTo(knex.fn.now());


### PR DESCRIPTION
This PR changes the logic of the existing migration (described in #3704 )
This fix is done in the actual migration because
1. If the current migration has already been run, there is nothing for a brand new migration to do
2. If the current migration hasn't been run, running it will cause data loss. We could no-op the existing migration, but that would just mean a second migration with complex logic to determine which version of the current migration (broken or no-op) had been run.

This closes #3704 

