### PR TITLE
Fix: Updates updateNotification resolvers & removes channel from UpdateNotificationMicrosoftTeamsPatchInput

### DIFF
--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -511,7 +511,7 @@ export const updateNotificationMicrosoftTeams: ResolverFn = async (
   if (isPatchEmpty(input)) {
     throw new Error('input.patch requires at least 1 attribute');
   }
-  const { name } = input;
+  const { name, patch: {name: newName = ''} } = input;
   const check = await query(
     sqlClientPool,
     Sql.selectNotificationMicrosoftTeamsByName(name)
@@ -535,7 +535,7 @@ export const updateNotificationMicrosoftTeams: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    Sql.selectNotificationMicrosoftTeamsByName(name)
+    Sql.selectNotificationMicrosoftTeamsByName(newName ? newName : name)
   );
 
   return R.prop(0, rows);
@@ -552,7 +552,7 @@ export const updateNotificationWebhook: ResolverFn = async (
   if (isPatchEmpty(input)) {
     throw new Error('input.patch requires at least 1 attribute');
   }
-  const { name } = input;
+  const { name, patch: {name: newName = ''} } = input;
   const check = await query(
     sqlClientPool,
     Sql.selectNotificationWebhookByName(name)
@@ -576,7 +576,7 @@ export const updateNotificationWebhook: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    Sql.selectNotificationWebhookByName(name),
+    Sql.selectNotificationWebhookByName(newName ? newName : name),
   );
 
   return R.prop(0, rows);
@@ -590,7 +590,7 @@ export const updateNotificationEmail: ResolverFn = async (
   if (isPatchEmpty(input)) {
     throw new Error('input.patch requires at least 1 attribute');
   }
-  const { name } = input;
+  const { name, patch: {name: newName = ''} } = input;
   const check = await query(
     sqlClientPool,
     Sql.selectNotificationEmailByName(name)
@@ -614,7 +614,7 @@ export const updateNotificationEmail: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    Sql.selectNotificationEmailByName(name)
+    Sql.selectNotificationEmailByName(newName ? newName : name)
   );
 
   return R.prop(0, rows);
@@ -628,7 +628,7 @@ export const updateNotificationRocketChat: ResolverFn = async (
   if (isPatchEmpty(input)) {
     throw new Error('input.patch requires at least 1 attribute');
   }
-  const { name } = input;
+  const { name, patch: {name: newName = ''} } = input;
   const check = await query(
     sqlClientPool,
     Sql.selectNotificationRocketChatByName(name)
@@ -652,7 +652,7 @@ export const updateNotificationRocketChat: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    Sql.selectNotificationRocketChatByName(name)
+    Sql.selectNotificationRocketChatByName(newName ? newName : name)
   );
 
   return R.prop(0, rows);
@@ -666,7 +666,7 @@ export const updateNotificationSlack: ResolverFn = async (
   if (isPatchEmpty(input)) {
     throw new Error('input.patch requires at least 1 attribute');
   }
-  const { name } = input;
+  const { name, patch: {name: newName = ''} } = input;
   const check = await query(
     sqlClientPool,
     Sql.selectNotificationSlackByName(name)
@@ -690,7 +690,7 @@ export const updateNotificationSlack: ResolverFn = async (
 
   const rows = await query(
     sqlClientPool,
-    Sql.selectNotificationSlackByName(name)
+    Sql.selectNotificationSlackByName(newName ? newName : name)
   );
 
   return R.prop(0, rows);

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -2076,7 +2076,6 @@ const typeDefs = gql`
   input UpdateNotificationMicrosoftTeamsPatchInput {
     name: String
     webhook: String
-    channel: String
   }
   input UpdateNotificationEmailPatchInput {
     name: String

--- a/services/workflows/internal/lagoonclient/schema.graphql
+++ b/services/workflows/internal/lagoonclient/schema.graphql
@@ -1976,7 +1976,6 @@ input UpdateNotificationMicrosoftTeamsInput {
 input UpdateNotificationMicrosoftTeamsPatchInput {
   name: String
   webhook: String
-  channel: String
 }
 
 input UpdateNotificationRocketChatInput {


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

If a notification name is updated via any of the `updateNotification` resolvers no data is returned as the select query is using the previous notification name. This updates all `updateNotification` resolvers to use the `newName`, if provided, to return the relevant data. This also removes the `channel` field from `UpdateNotificationMicrosoftTeamsPatchInput` as it's not valid for Teams notifications.
