### PR TITLE
fix: environment-storage resolver and actions-handler mutation fix

### DIFF
--- a/services/actions-handler/go.mod
+++ b/services/actions-handler/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/cheshir/go-mq/v2 v2.0.1
-	github.com/uselagoon/machinery v0.0.17
+	github.com/uselagoon/machinery v0.0.19
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 )
 

--- a/services/actions-handler/go.sum
+++ b/services/actions-handler/go.sum
@@ -839,8 +839,8 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/uselagoon/machinery v0.0.17 h1:rykgkboGvSX+aMa6MPXtR22DJ67eTPC4WITwpVDuj+Y=
-github.com/uselagoon/machinery v0.0.17/go.mod h1:Duljjz/3d/7m0jbmF1nVRDTNaMxMr6m+5LkgjiRrQaU=
+github.com/uselagoon/machinery v0.0.19 h1:1R0DWe0Fz2cRhzisnM86SQJXFy+DO9d+9gEa2maRwC4=
+github.com/uselagoon/machinery v0.0.19/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -1154,8 +1154,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/services/actions-handler/handler/action_deploy.go
+++ b/services/actions-handler/handler/action_deploy.go
@@ -28,7 +28,7 @@ func (m *Messenger) handleDeployEnvironment(ctx context.Context, messageQueue *m
 		}
 		return nil
 	}
-	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", &token, false)
+	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", m.LagoonAPI.Version, &token, false)
 	deployment, err := lagoon.DeployLatest(ctx, deploy, l)
 	if err != nil {
 		// send the log to the lagoon-logs exchange to be processed

--- a/services/actions-handler/handler/action_storage.go
+++ b/services/actions-handler/handler/action_storage.go
@@ -43,7 +43,7 @@ func (m *Messenger) handleUpdateStorage(ctx context.Context, messageQueue *mq.Me
 	// the action data can contain multiple storage claims, so iterate over them here
 	var errs []error
 	for _, sc := range storageClaims.Claims {
-		l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", &token, false)
+		l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", m.LagoonAPI.Version, &token, false)
 		var envID int
 		var hasErr error
 		// if this is a newer storage calculator with the `kibUsed` field, use the new mutation

--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -38,7 +38,7 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue *mq.MessageQue
 	}
 
 	// set up a lagoon client for use in the following process
-	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", &token, false)
+	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", m.LagoonAPI.Version, &token, false)
 	environment, err := lagoon.GetEnvironmentByNamespace(ctx, message.Namespace, l)
 	if err != nil || environment == nil {
 		if err != nil {

--- a/services/actions-handler/handler/controller_remove.go
+++ b/services/actions-handler/handler/controller_remove.go
@@ -27,7 +27,7 @@ func (m *Messenger) handleRemoval(ctx context.Context, messageQueue *mq.MessageQ
 	}
 
 	// set up a lagoon client for use in the following process
-	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", &token, false)
+	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", m.LagoonAPI.Version, &token, false)
 	execute := false
 	deletedEnvironment, err := lagoon.DeleteEnvironment(ctx, message.Meta.Environment, message.Meta.Project, execute, l)
 	if err != nil {

--- a/services/actions-handler/handler/controller_tasks.go
+++ b/services/actions-handler/handler/controller_tasks.go
@@ -31,7 +31,7 @@ func (m *Messenger) handleTask(ctx context.Context, messageQueue *mq.MessageQueu
 	}
 
 	// set up a lagoon client for use in the following process
-	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", &token, false)
+	l := lclient.New(m.LagoonAPI.Endpoint, "actions-handler", m.LagoonAPI.Version, &token, false)
 
 	switch message.Meta.Key {
 	case "kubernetes:route:migrate", "deploytarget:route:migrate", "deploytarget:task:activestandby":

--- a/services/actions-handler/handler/handler.go
+++ b/services/actions-handler/handler/handler.go
@@ -21,6 +21,7 @@ type LagoonAPI struct {
 	TokenSigningKey string `json:"tokenSigningKey"`
 	JWTSubject      string `json:"subject"`
 	JWTIssuer       string `json:"issuer"`
+	Version         string `json:"version"`
 }
 
 // Action is the structure of an action that is received via the message queue.

--- a/services/actions-handler/main.go
+++ b/services/actions-handler/main.go
@@ -23,7 +23,7 @@ var (
 	startupConnectionAttempts    int
 	startupConnectionInterval    int
 	lagoonAPIHost                string
-	lagoonAppID                  string
+	lagoonAPIVersion             string
 	jwtTokenSigningKey           string
 	jwtAudience                  string
 	actionsQueueName             string
@@ -53,6 +53,8 @@ func main() {
 		"The duration between startup attempts.")
 	flag.StringVar(&lagoonAPIHost, "lagoon-api-host", "http://localhost:3000/graphql",
 		"The host for the lagoon api.")
+	flag.StringVar(&lagoonAPIVersion, "lagoon-api-version", "2.18.0",
+		"The version for the lagoon api.")
 	flag.StringVar(&jwtTokenSigningKey, "jwt-token-signing-key", "super-secret-string",
 		"The jwt signing token key or secret.")
 	flag.StringVar(&jwtAudience, "jwt-audience", "api.dev",
@@ -95,6 +97,7 @@ func main() {
 		JWTAudience:     jwtAudience,
 		JWTSubject:      jwtSubject,
 		JWTIssuer:       jwtIssuer,
+		Version:         lagoonAPIVersion,
 	}
 
 	log.Println("actions-handler running")

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -616,6 +616,7 @@ const resolvers = {
     deleteEnvironment,
     deleteAllEnvironments,
     addOrUpdateEnvironmentStorage,
+    addOrUpdateStorageOnEnvironment: addOrUpdateEnvironmentStorage,
     addNotificationSlack,
     updateNotificationSlack,
     deleteNotificationSlack,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Fixes the resolvers to include the new `addOrUpdateStorageOnEnvironment` alias that was missed in the initial pullrequest.

Updates the actions-handler machinery version to also fix an issue where the [new resolver was not being used](https://github.com/uselagoon/machinery/pull/51)

https://github.com/uselagoon/lagoon/pull/3658 is the initial pullrequest that introduced this feature, and initially it was going to use the one resolver, but a decision was made later to split it into a new resolver to not require deprecating an old field and being able to leverage the new `float` input sooner. As such, a couple of things were missed.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

