### PR TITLE
fix: allow platform admin to add when disable-non-organization enabled

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -344,7 +344,7 @@ export const addGroup: ResolverFn = async (
     }
   } else {
     // otherwise fall back
-    if (DISABLE_NON_ORGANIZATION_GROUP_CREATION == "false") {
+    if (DISABLE_NON_ORGANIZATION_GROUP_CREATION == "false" || adminScopes.projectViewAll) {
       await hasPermission('group', 'add');
     } else {
       throw new Error(

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -25,7 +25,7 @@ const addNotificationGeneric = async (sqlClientPool, notificationTable, input) =
   return await query(sqlClientPool, knex(notificationTable).where('id', insertId).toString());
 }
 
-const checkOrgNotificationPermission = async (hasPermission, input) => {
+const checkOrgNotificationPermission = async (hasPermission, input, adminScopes) => {
   if (input.organization != null) {
     const organizationData = await organizationHelpers(sqlClientPool).getOrganizationById(input.organization);
     if (organizationData === undefined) {
@@ -43,7 +43,7 @@ const checkOrgNotificationPermission = async (hasPermission, input) => {
       );
     }
   } else {
-    if (DISABLE_NON_ORGANIZATION_NOTIFICATION_ASSIGNMENT == "false") {
+    if (DISABLE_NON_ORGANIZATION_NOTIFICATION_ASSIGNMENT == "false" || adminScopes.projectViewAll) {
       await hasPermission('notification', 'add');
     } else {
       throw new Error(
@@ -56,41 +56,41 @@ const checkOrgNotificationPermission = async (hasPermission, input) => {
 export const addNotificationMicrosoftTeams: ResolverFn = async (
   root,
   { input },
-  { sqlClientPool, hasPermission }
+  { sqlClientPool, hasPermission, adminScopes}
 ) => {
-  await checkOrgNotificationPermission(hasPermission, input)
+  await checkOrgNotificationPermission(hasPermission, input, adminScopes)
   return R.path([0], await addNotificationGeneric(sqlClientPool, 'notification_microsoftteams', input));
 };
 
 export const addNotificationEmail: ResolverFn = async (
   root,
   { input },
-  { sqlClientPool, hasPermission }
+  { sqlClientPool, hasPermission, adminScopes}
 ) => {
-  await checkOrgNotificationPermission(hasPermission, input)
+  await checkOrgNotificationPermission(hasPermission, input, adminScopes)
   return R.path([0], await addNotificationGeneric(sqlClientPool, 'notification_email', input));
 };
 
 export const addNotificationRocketChat: ResolverFn = async (
   root,
   { input },
-  { sqlClientPool, hasPermission }
+  { sqlClientPool, hasPermission, adminScopes }
 ) => {
-  await checkOrgNotificationPermission(hasPermission, input)
+  await checkOrgNotificationPermission(hasPermission, input, adminScopes)
   return R.path([0], await addNotificationGeneric(sqlClientPool, 'notification_rocketchat', input));
 };
 
 export const addNotificationSlack: ResolverFn = async (
   root,
   { input },
-  { sqlClientPool, hasPermission }
+  { sqlClientPool, hasPermission, adminScopes}
 ) => {
-  await checkOrgNotificationPermission(hasPermission, input)
+  await checkOrgNotificationPermission(hasPermission, input, adminScopes)
   return R.path([0], await addNotificationGeneric(sqlClientPool, 'notification_slack', input));
 };
 
-export const addNotificationWebhook: ResolverFn = async (root, { input }, { sqlClientPool, hasPermission }) => {
-  await checkOrgNotificationPermission(hasPermission, input)
+export const addNotificationWebhook: ResolverFn = async (root, { input }, { sqlClientPool, hasPermission, adminScopes}) => {
+  await checkOrgNotificationPermission(hasPermission, input, adminScopes)
   return R.path([0], await addNotificationGeneric(sqlClientPool, 'notification_webhook', input));
 };
 

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -268,7 +268,7 @@ export const addProject = async (
       }
     }
   } else {
-    if (DISABLE_NON_ORGANIZATION_PROJECT_CREATION == "false") {
+    if (DISABLE_NON_ORGANIZATION_PROJECT_CREATION == "false" || adminScopes.projectViewAll) {
       await hasPermission('project', 'add');
     } else {
       throw new Error(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

This just adds a fix that allows platform admins to be able to create projects, groups, or notifications when the disable global features for these things are enabled.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
