### PR TITLE
refactor: use existing cached member check to return membercount

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -539,16 +539,8 @@ export const Group = (clients: {
   const getGroupMemberCount = async (
     group: Group
   ): Promise<number> => {
-    const roleSubgroups = group.subGroups.filter(isRoleSubgroup);
-    let membership = 0;
-    for (const roleSubgroup of roleSubgroups) {
-      const keycloakUsers = await keycloakAdminClient.groups.listMembers({
-        id: roleSubgroup.id
-      });
-
-      membership = membership + keycloakUsers.length;
-    }
-    return membership;
+    const membership = await getGroupMembership(group)
+    return membership.length;
   };
 
   const addGroup = async (groupInput: Group, projectId?: number, organizationId?: number): Promise<Group> => {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a small one that refactors the group membercount to use an existing cached member query to do the count. The previous query would hit keycloak directly and could result in longer api response times.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
