### PR TITLE
feat: add query-group permission to the service-api client

### DIFF
--- a/services/keycloak/lagoon-realm-2.16.0.json
+++ b/services/keycloak/lagoon-realm-2.16.0.json
@@ -528,6 +528,11 @@
       "realmRoles": [
         "default-roles-lagoon"
       ],
+      "clientRoles": {
+        "realm-management": [
+          "query-groups"
+        ]
+      },
       "notBefore": 0,
       "groups": []
     }

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -204,6 +204,15 @@ function migrate_to_custom_group_mapper {
 
 }
 
+function service-api_add_query-groups_permission {
+	if /opt/keycloak/bin/kcadm.sh get-roles -r lagoon --uusername service-account-service-api --cclientid realm-management --config /tmp/kcadm.config | jq -e '.[].name|contains("query-groups")' >/dev/null; then
+		echo "service-api already has query-groups realm-management role"
+	else
+		echo "adding service-api query-groups realm-management role"
+		/opt/keycloak/bin/kcadm.sh add-roles -r lagoon --uusername service-account-service-api --cclientid realm-management --rolename query-groups --config $CONFIG_PATH
+	fi
+}
+
 ##################
 # Initialization #
 ##################
@@ -231,6 +240,7 @@ function configure_keycloak {
     check_migrations_version
     migrate_to_custom_group_mapper
     #post 2.18.0+ migrations after this point
+    service-api_add_query-groups_permission
 
     # always run last
     sync_client_secrets


### PR DESCRIPTION
With the recent change in Lagoon to move project membership of groups
from Keycloak group annotations into the Lagoon API DB, the
ssh-portal-api can no longer rely on group annotations embedded in user
tokens to extract project-group membership.

Since v0.35.0, ssh-portal-api gets the project membership information
from the Lagoon API DB. But that is stored as group IDs, not group
names. So to map group IDs back to group names the ssh-portal-api now
queries Keycloak for a list of groups (IDs and names).

This new permission allows the service-api client used by ssh-portal-api
to query the Keycloak groups API.
