### PR TITLE
refactor: check if project has already been recursed when importing to org

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -1065,8 +1065,11 @@ const checkProjectGroups = async (groupProjectIds, projectIds, projectsGroups, m
           groupProjectIds.push({group: group.name, project: project})
           projectsGroups.push(group)
         }
-        // recurse the project
-        await checkProjectGroups(groupProjectIds, projectIds, projectsGroups, models, sqlClientPool, project)
+        // recurse the project if it hasn't already had been done
+        let index2 = projectIds.findIndex((item) => item === project);
+        if (index2 === -1) {
+          await checkProjectGroups(groupProjectIds, projectIds, projectsGroups, models, sqlClientPool, project)
+        }
       }
     }
   }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just quick check before performing the project recursion to see if the project has already been done.

This results in the same that #3716 was meant to fix, and the [associated gist](https://gist.github.com/shreddedbacon/85bb4735363101557047ea15d7edc487) is still valid and the result is the same for a deep group association

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->