### PR TITLE
fix: remove errant quotes in variable value for route quota

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -745,7 +745,7 @@ export const getEnvironmentsRouterPatternAndVariables = async function name(
       ...projectVars,
       {
         name: "LAGOON_ROUTE_QUOTA",
-        value: `"${curOrg.quotaRoute}"`,
+        value: `${curOrg.quotaRoute}`,
         scope: InternalEnvVariableScope.INTERNAL_SYSTEM
       }
     ];


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a quick fix for the route quota variable to remove quotes wrapped variable

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
