### PR TITLE
refactor: strip existing project when adding it to an organization

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -828,34 +828,11 @@ export const Group = (clients: {
     groups: Group[]
   ): Promise<void> => {
     for (const g in groups) {
-      const group = groups[g]
-      const groupProjectIds = getProjectIdsFromGroup(group)
-      const newGroupProjects = R.pipe(
-        R.without([projectId]),
-        R.uniq,
-        R.join(',')
-        // @ts-ignore
-      )(groupProjectIds);
-
       try {
-        await keycloakAdminClient.groups.update(
-          {
-            id: group.id
-          },
-          {
-            name: group.name,
-            attributes: {
-              ...group.attributes,
-              'lagoon-projects': [newGroupProjects],
-              'group-lagoon-project-ids': [`{${JSON.stringify(group.name)}:[${newGroupProjects}]}`]
-            }
-          }
-        );
-        // purge the caches to ensure current data
-        await purgeGroupCache(group)
+        await removeProjectFromGroup(projectId, groups[g])
       } catch (err) {
         throw new Error(
-          `Error setting projects for group ${group.name}: ${err.message}`
+          `Error setting projects for group ${groups[g].name}: ${err.message}`
         );
       }
     }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

There exists a condition when adding an existing project to an organization that could result in a project and any groups it has being left in a disconnected state. This refactor is to make sure that the project and any access it previously had is stripped entirely when adding the project to the organization. Effectively it would appear as a fresh project (still retaining all of its environments etc. though)

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

