### PR TITLE
feat: add new organization admin role

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-lagoon-demo-org.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-lagoon-demo-org.gql
@@ -35,6 +35,14 @@ mutation PopulateApi {
   ) {
     id
   }
+  UIOrganizationAdmin: addUser(
+    input: {
+      email: "orgadmin@example.com"
+      comment: "user that will be an organization admin"
+    }
+  ) {
+    id
+  }
   UIOrganizationOwner: addUser(
     input: {
       email: "orgowner@example.com"
@@ -67,6 +75,10 @@ mutation PopulateApi {
   }
 
   UIOrganizationAddViewer: addUserToOrganization(input: {user: {email: "orgviewer@example.com"}, organization: 1}) {
+    id
+  }
+
+  UIOrganizationAddAdmin: addUserToOrganization(input: {user: {email: "orgadmin@example.com"}, organization: 1, admin: true}) {
     id
   }
 

--- a/local-dev/k3d-seed-data/00-populate-kubernetes.gql
+++ b/local-dev/k3d-seed-data/00-populate-kubernetes.gql
@@ -198,6 +198,14 @@ mutation PopulateApi {
   ) {
     id
   }
+  UIOrganizationAdmin: addUser(
+    input: {
+      email: "orgadmin@example.com"
+      comment: "user that will be an organization admin"
+    }
+  ) {
+    id
+  }
   UIOrganizationOwner: addUser(
     input: {
       email: "orgowner@example.com"
@@ -230,6 +238,10 @@ mutation PopulateApi {
   }
 
   UIOrganizationAddViewer: addUserToOrganization(input: {user: {email: "orgviewer@example.com"}, organization: 1}) {
+    id
+  }
+
+  UIOrganizationAddAdmin: addUserToOrganization(input: {user: {email: "orgadmin@example.com"}, organization: 1, admin: true}) {
     id
   }
 

--- a/local-dev/k3d-seed-data/seed-users.sh
+++ b/local-dev/k3d-seed-data/seed-users.sh
@@ -10,7 +10,7 @@ function is_keycloak_running {
 function configure_user_passwords {
 
   LAGOON_DEMO_USERS=("guest@example.com" "reporter@example.com" "developer@example.com" "maintainer@example.com" "owner@example.com")
-  LAGOON_DEMO_ORG_USERS=("orguser@example.com" "orgviewer@example.com" "orgowner@example.com" "platformowner@example.com")
+  LAGOON_DEMO_ORG_USERS=("orguser@example.com" "orgviewer@example.com" "orgadmin@example.com" "orgowner@example.com" "platformowner@example.com")
 
   for i in ${LAGOON_DEMO_USERS[@]}
   do

--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -212,10 +212,20 @@ export const getGroupsByProjectId: ResolverFn = async (
     // when listing project groups
     const userGroups = keycloakUsersGroups;
     const usersOrgs = R.defaultTo('', R.prop('lagoon-organizations',  user.attributes)).toString()
+    const usersOrgsAdmin = R.defaultTo('', R.prop('lagoon-organizations-admin',  user.attributes)).toString()
     const usersOrgsViewer = R.defaultTo('', R.prop('lagoon-organizations-viewer',  user.attributes)).toString()
 
     if (usersOrgs != "" ) {
       const uOrgs = usersOrgs.split(',');
+      for (const userOrg of uOrgs) {
+        const orgGroups = await Helpers(sqlClientPool).selectGroupsByOrganizationId(models, userOrg)
+        for (const pGroup of orgGroups) {
+          userGroups.push(pGroup)
+        }
+      }
+    }
+    if (usersOrgsAdmin != "" ) {
+      const uOrgs = usersOrgsAdmin.split(',');
       for (const userOrg of uOrgs) {
         const orgGroups = await Helpers(sqlClientPool).selectGroupsByOrganizationId(models, userOrg)
         for (const pGroup of orgGroups) {
@@ -751,9 +761,19 @@ export const getAllProjectsInGroup: ResolverFn = async (
       keycloakGrant.access_token.content.sub
     );
     const usersOrgs = R.defaultTo('', R.prop('lagoon-organizations',  user.attributes)).toString()
+    const usersOrgsAdmin = R.defaultTo('', R.prop('lagoon-organizations-admin',  user.attributes)).toString()
     const usersOrgsViewer = R.defaultTo('', R.prop('lagoon-organizations-viewer',  user.attributes)).toString()
     if (usersOrgs != "" ) {
       const uOrgs = usersOrgs.split(',');
+      for (const userOrg of uOrgs) {
+        const orgGroups = await Helpers(sqlClientPool).selectGroupsByOrganizationId(models, userOrg)
+        for (const pGroup of orgGroups) {
+          userGroups.push(pGroup)
+        }
+      }
+    }
+    if (usersOrgsAdmin != "" ) {
+      const uOrgs = usersOrgsAdmin.split(',');
       for (const userOrg of uOrgs) {
         const orgGroups = await Helpers(sqlClientPool).selectGroupsByOrganizationId(models, userOrg)
         for (const pGroup of orgGroups) {

--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -389,6 +389,7 @@ export const getUsersByOrganizationId: ResolverFn = async (
       if (!exists) {
         // quick check to set the owner flag or not
         groupMembers[member].user.owner = false
+        groupMembers[member].user.admin = false
         groupMembers[member].user.comment = null
         if (groupMembers[member].user.attributes["comment"]) {
           groupMembers[member].user.comment = groupMembers[member].user.attributes["comment"][0]
@@ -397,6 +398,13 @@ export const getUsersByOrganizationId: ResolverFn = async (
           for (const a in groupMembers[member].user.attributes["lagoon-organizations"]) {
             if (parseInt(groupMembers[member].user.attributes["lagoon-organizations"][a]) == args.organization) {
               groupMembers[member].user.owner = true
+            }
+          }
+        }
+        if (groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
+          for (const a in groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
+            if (parseInt(groupMembers[member].user.attributes["lagoon-organizations-admin"][a]) == args.organization) {
+              groupMembers[member].user.admin = true
             }
           }
         }
@@ -423,6 +431,7 @@ export const getUserByEmailAndOrganizationId: ResolverFn = async (
     const queryUserGroups = await models.UserModel.getAllGroupsForUser(user.id, organization);
 
     user.owner = false
+    user.admin = false
     user.comment = null
     if (user.attributes["comment"]) {
       user.comment = user.attributes["comment"][0]
@@ -431,6 +440,13 @@ export const getUserByEmailAndOrganizationId: ResolverFn = async (
       for (const a in user.attributes["lagoon-organizations"]) {
         if (parseInt(user.attributes["lagoon-organizations"][a]) == organization) {
           user.owner = true
+        }
+      }
+    }
+    if (user.attributes["lagoon-organizations-admin"]) {
+      for (const a in user.attributes["lagoon-organizations-admin"]) {
+        if (parseInt(user.attributes["lagoon-organizations-admin"][a]) == organization) {
+          user.admin = true
         }
       }
     }

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1088,6 +1088,7 @@ const typeDefs = gql`
     email: String
     firstName: String
     lastName: String
+    admin: Boolean
     owner: Boolean
     comment: String
     groupRoles: [GroupRoleInterface]
@@ -1937,6 +1938,7 @@ const typeDefs = gql`
   input addUserToOrganizationInput {
     user: UserInput!
     organization: Int!
+    admin: Boolean
     owner: Boolean
   }
 

--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -181,6 +181,7 @@ export const keycloakHasPermission = (grant, requestCache, modelClients, service
       userGroupRole?: [string];
       organizationQuery?: [string];
       userOrganizations?: [string];
+      userOrganizationsAdmin?: [string];
       userOrganizationsView?: [string];
     } = {
       currentUser: [currentUser.id]
@@ -206,6 +207,13 @@ export const keycloakHasPermission = (grant, requestCache, modelClients, service
       claims = {
         ...claims,
         userOrganizations: [`${R.prop('lagoon-organizations', currentUser.attributes)}`]
+      };
+    }
+    // check organization admin attributes
+    if (R.prop('lagoon-organizations-admin', currentUser.attributes)) {
+      claims = {
+        ...claims,
+        userOrganizationsAdmin: [`${R.prop('lagoon-organizations-admin', currentUser.attributes)}`]
       };
     }
     // check organization viewer attributes

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -87,7 +87,7 @@ COPY themes/lagoon /opt/keycloak/themes/lagoon
 COPY --from=commons /tmp/lagoon-scripts.jar /opt/keycloak/providers/lagoon-scripts.jar
 COPY --from=builder /target/custom-protocol-mapper-1.0.0.jar /opt/keycloak/providers/custom-protocol-mapper-1.0.0.jar
 
-COPY lagoon-realm-2.16.0.json /lagoon/seed/lagoon-realm-2.16.0.json
+COPY lagoon-realm-base-import.json /lagoon/seed/lagoon-realm-base-import.json
 
 RUN /opt/keycloak/bin/kc.sh build
 

--- a/services/keycloak/javascript/META-INF/keycloak-scripts.json
+++ b/services/keycloak/javascript/META-INF/keycloak-scripts.json
@@ -88,6 +88,11 @@
       "fileName": "policies/user-is-owner-of-organization.js"
     },
     {
+      "name": "[Lagoon] User is admin of organization",
+      "description": "Checks that the user is admin of an organization via attribute",
+      "fileName": "policies/user-is-admin-of-organization.js"
+    },
+    {
       "name": "[Lagoon] User is viewer of organization",
       "description": "Checks that the user is viewer of an organization via attribute",
       "fileName": "policies/user-is-viewer-of-organization.js"

--- a/services/keycloak/javascript/policies/user-is-admin-of-organization.js
+++ b/services/keycloak/javascript/policies/user-is-admin-of-organization.js
@@ -1,0 +1,33 @@
+var realm = $evaluation.getRealm();
+var ctx = $evaluation.getContext();
+var ctxAttr = ctx.getAttributes();
+
+if (!ctxAttr.exists('organizationQuery') || !ctxAttr.exists('userOrganizationsAdmin')) {
+    $evaluation.deny();
+} else {
+    var organization = ctxAttr.getValue('organizationQuery').asString(0);
+    var organizations = ctxAttr.getValue('userOrganizationsAdmin').asString(0);
+    var organizationsArr = organizations.split(',');
+    var grant = false;
+
+    for (var i=0; i<organizationsArr.length; i++) {
+        if (organization == organizationsArr[i]) {
+            grant = true;
+            break;
+        }
+    }
+
+    if (grant) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+}
+
+if (ctxAttr.exists('currentUser')) {
+    var currentUser = ctxAttr.getValue('currentUser').asString(0);
+
+    if (realm.isUserInRealmRole(currentUser, 'platform-owner')) {
+        $evaluation.grant();
+    }
+}

--- a/services/keycloak/lagoon-realm-base-import.json
+++ b/services/keycloak/lagoon-realm-base-import.json
@@ -1393,6 +1393,14 @@
             "config": {}
           },
           {
+            "name": "[Lagoon] User is admin of organization",
+            "description": "Checks that the user is admin of an organization via attribute",
+            "type": "script-policies/user-is-admin-of-organization.js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {}
+          },
+          {
             "name": "Default Policy",
             "description": "A policy that grants access only for users within this realm",
             "type": "script-policies/default-policy.js",
@@ -1817,7 +1825,7 @@
             "config": {
               "resources": "[\"organization\"]",
               "scopes": "[\"view\",\"viewProject\",\"viewGroup\",\"viewNotification\",\"viewUser\",\"viewUsers\"]",
-              "applyPolicies": "[\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\",\"[Lagoon] User is viewer of organization\"]"
+              "applyPolicies": "[\"[Lagoon] User is admin of organization\",\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\",\"[Lagoon] User is viewer of organization\"]"
             }
           },
           {
@@ -1975,14 +1983,47 @@
             }
           },
           {
-            "name": "Manage Organization",
+            "name": "Manage Organization Owners",
             "type": "scope",
             "logic": "POSITIVE",
             "decisionStrategy": "AFFIRMATIVE",
             "config": {
               "resources": "[\"organization\"]",
-              "scopes": "[\"addNotification\",\"removeNotification\",\"addProject\",\"updateNotification\",\"updateProject\",\"removeGroup\",\"deleteProject\",\"addViewer\",\"addOwner\",\"addGroup\"]",
+              "scopes": "[\"addViewer\",\"addOwner\"]",
               "applyPolicies": "[\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\"]"
+            }
+          },
+          {
+            "name": "Manage Organization Projects",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"organization\"]",
+              "scopes": "[\"addProject\",\"updateProject\",\"deleteProject\"]",
+              "applyPolicies": "[\"[Lagoon] User is admin of organization\",\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\"]"
+            }
+          },
+          {
+            "name": "Manage Organization Groups",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"organization\"]",
+              "scopes": "[\"removeGroup\",\"addGroup\"]",
+              "applyPolicies": "[\"[Lagoon] User is admin of organization\",\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\"]"
+            }
+          },
+          {
+            "name": "Manage Organization Notifications",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"organization\"]",
+              "scopes": "[\"addNotification\",\"removeNotification\",\"updateNotification\"]",
+              "applyPolicies": "[\"[Lagoon] User is admin of organization\",\"[Lagoon] User is owner of organization\",\"[Lagoon] Users role for realm is Platform Owner\"]"
             }
           },
           {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

This adds a new role for organizations that allows a user to be granted `admin` permission, which is the same as `owner` except that admins cannot make changes to the management users of an organization, ie, they will not be able to add or remove other users as organization admins or owners. 

The role is only designed to allow interaction with projects, groups (and the group users), and notifications.

When adding a user to an organization as a manager, there is a new boolean called `admin`, used in a similar way to the `owner` boolean. Only `platform-owner` and `organization-owners` will be able to add users as admins.

```
addUserToOrganization(
	input: {
		user: {
			email: "orgadmin@example.com"
		}
		organization: 1
		admin: true
	}
) {
	id
}
```

Also, I have renamed the realm import file to better represent that it is a base import, rather than a specific version.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
