### PR TITLE
fix: use utf8 instead of ascii when retrieving logs

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -91,7 +91,7 @@ export const getBuildLog: ResolverFn = async (
     if (!data) {
       return null;
     }
-    let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('ascii');
+    let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('utf-8');
     return logMsg;
   } catch (e) {
     // there is no fallback location for build logs, so there is no log to show the user

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -80,7 +80,7 @@ export const getTaskLog: ResolverFn = async (
     if (!data) {
       return null;
     }
-    let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('ascii');
+    let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('utf-8');
     return logMsg;
   } catch (e) {
     // if it isn't where it should be, check the fallback location which will be `tasklogs/projectName/taskId-remoteId.txt`
@@ -91,7 +91,7 @@ export const getTaskLog: ResolverFn = async (
       if (!data) {
         return null;
       }
-      let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('ascii');
+      let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('utf-8');
       return logMsg;
     } catch (e) {
       // otherwise there is no log to show the user


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Changes the log encoding to UTF8 instead of ASCII so the UI will display special characters correctly

![image](https://github.com/uselagoon/lagoon/assets/9973880/4236ebfc-c0a1-425c-a5bb-5e2beddbc4d4)

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3398 
