### PR TITLE
fix: return an error if organization doesnt exist on addproject

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -242,12 +242,18 @@ export const addProject = async (
     await hasPermission('organization', 'addProject', {
       organization: input.organization
     });
+    // check the project quota before adding the project
+    const organization = await organizationHelpers(sqlClientPool).getOrganizationById(input.organization);
+    if (!organization) {
+      // org doesn't exist, unauth
+      throw new Error(
+        `Unauthorized: You don't have permission to "addProject" on "organization"`
+      );
+    }
     // if the project is created without the addOrgOwner boolean set to true, then do not add the user to the project as its owner
     if (!input.addOrgOwner) {
       userAlreadyHasAccess = true
     }
-    // check the project quota before adding the project
-    const organization = await organizationHelpers(sqlClientPool).getOrganizationById(input.organization);
     const projects = await organizationHelpers(sqlClientPool).getProjectsByOrganizationId(input.organization);
     if (projects.length >= organization.quotaProject && organization.quotaProject != -1) {
       throw new Error(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a simple fix to make sure an unauthorized error is returned if an organization doesn't exist when adding a project. Previously it would get to the check for quota and fail with an obscure error about the project quota.
```
Cannot read properties of undefined (reading 'quotaProject')
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
