### PR TITLE
feat: ssh configurable number of public key attempts before failing

### DIFF
--- a/services/ssh/docker-entrypoint.sh
+++ b/services/ssh/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 export USER_ID=$(id -u)
 
+ep /etc/ssh/sshd_config
+
 ep /home/token.sh
 ep /home/grant.sh
 ep /home/token-debug.sh

--- a/services/ssh/etc/ssh/sshd_config
+++ b/services/ssh/etc/ssh/sshd_config
@@ -6,6 +6,9 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 
 LogLevel INFO
 
+# Sets the allowed number of ssh-agent key attempts before failure
+MaxAuthTries ${MAX_AUTH_TRIES:-6}
+
 PermitRootLogin no
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Problem

When using `lagoon-cli` to SSH or login, an error is returned: `error: maximum authentication attempts exceeded`.

# Solution

Increase the `MaxAuthTries` of the SSH server. I added the setting as an environment variable `MAX_AUTH_TRIES` so that it can be changed on a per-case basis.

# Background

Edit: the below issues with lagoon-cli are mostly fixed with https://github.com/uselagoon/lagoon-cli/pull/355, but this can still be triggered when using non-lagoon tools like ddev.

`lagoon-cli` will iterate over all of the keys in the system ssh-agent, but the order of the keys is non-deterministic. In the case where a user has more than six SSH keys, it's possible that the correct one is at the end of the list and the max auth attempts is exceeded.

Now that `lagoon-cli` and `lagoon-sync` have integrated SSH go libraries, they no longer call out to the system ssh binary. The side effect is that ssh client config files are no longer used. Previously, a user could set the `IdentityFile` in their `~/.ssh/config` and avoid this problem.

The `lagoon-cli` can be configured with a specific ssh key (either in `~/.lagoon.yml` or by passing `-i`) but then the user will be asked to enter their password for every command.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
