### PR TITLE
Change: Extends allNotifications with optional filters

### DIFF
--- a/services/api/src/resources/notification/helpers.ts
+++ b/services/api/src/resources/notification/helpers.ts
@@ -56,32 +56,37 @@ export const Helpers = (sqlClientPool: Pool) => ({
     await query(sqlClientPool, Sql.deleteProjectNotificationByProjectId(project, "email"));
     await query(sqlClientPool, Sql.deleteProjectNotificationByProjectId(project, "webhook"));
   },
-  selectAllNotifications: async () => {
+  selectAllNotifications: async (name: string = null) => {
     let type = "slack"
     // get all notifications
     const slacks = await query(
       sqlClientPool,
-      Sql.selectAllNotifications(type)
+      name ?
+      Sql.selectAllNotificationsByName(name, type) : Sql.selectAllNotifications(type)
     );
     type = "rocketchat"
     const rcs = await query(
       sqlClientPool,
-      Sql.selectAllNotifications(type)
+      name ?
+      Sql.selectAllNotificationsByName(name, type) : Sql.selectAllNotifications(type)
     );
     type = "microsoftteams"
     const teams = await query(
       sqlClientPool,
-      Sql.selectAllNotifications(type)
+      name ?
+      Sql.selectAllNotificationsByName(name, type) : Sql.selectAllNotifications(type)
     );
     type = "email"
     const email = await query(
       sqlClientPool,
-      Sql.selectAllNotifications(type)
+      name ?
+      Sql.selectAllNotificationsByName(name, type) : Sql.selectAllNotifications(type)
     );
     type = "webhook"
     const webhook = await query(
       sqlClientPool,
-      Sql.selectAllNotifications(type)
+      name ?
+      Sql.selectAllNotificationsByName(name, type) : Sql.selectAllNotifications(type)
     );
     let result = [...slacks, ...rcs, ...teams, ...email, ...webhook]
 

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -707,7 +707,7 @@ export const getAllNotifications: ResolverFn = async (
     rows = await query(sqlClientPool, Sql.selectNotificationByNameAndType(args.name, args.type));
 
     if (rows.length === 0) {
-      throw new Error(`No notification found for ${args.name} & ${args.type}`);
+      throw new Error(`Unauthorized: You don't have permission to "view" on "notification"`);
     }
 
     if (rows.length > 0) {

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -706,6 +706,10 @@ export const getAllNotifications: ResolverFn = async (
   if (args.name && args.type) {
     rows = await query(sqlClientPool, Sql.selectNotificationByNameAndType(args.name, args.type));
 
+    if (rows.length === 0) {
+      throw new Error(`No notification found for ${args.name} & ${args.type}`);
+    }
+
     if (rows.length > 0) {
       rows[0].type = args.type;
     }
@@ -720,10 +724,10 @@ export const getAllNotifications: ResolverFn = async (
   if (args.name) {
     await hasPermission('notification', 'viewAll');
 
-    const rows = await Helpers(sqlClientPool).selectAllNotifications(args.name);
+    rows = await Helpers(sqlClientPool).selectAllNotifications(args.name);
 
     if (rows.length === 0) {
-      throw new Error(`No notification found for ${args.name}`);
+      throw new Error(`No notifications found for ${args.name}`);
     }
 
     return rows;
@@ -732,12 +736,20 @@ export const getAllNotifications: ResolverFn = async (
   if (args.type) {
     await hasPermission('notification', 'viewAll');
 
-    const rows = await query(sqlClientPool, Sql.selectAllNotifications(args.type));
+    rows = await query(sqlClientPool, Sql.selectAllNotifications(args.type));
+
+    if (rows.length === 0) {
+      throw new Error(`No notifications found for type ${args.type}`);
+    }
 
     return rows;
   }
 
   await hasPermission('notification', 'viewAll');
   rows = await Helpers(sqlClientPool).selectAllNotifications();
+  if (rows.length === 0) {
+    throw new Error(`No notifications found`);
+  }
+
   return rows;
 };

--- a/services/api/src/resources/notification/sql.ts
+++ b/services/api/src/resources/notification/sql.ts
@@ -41,6 +41,15 @@ export const Sql = {
     knex(`notification_${type}`)
       .select('*', knex.raw(`'${type}' as type`))
       .toString(),
+  selectAllNotificationsByName: (name: string, type: string) =>
+    knex(`notification_${type}`)
+      .select('*', knex.raw(`'${type}' as type`))
+      .where('name', '=', name)
+      .toString(),
+  selectNotificationByNameAndType: (name: string, type: string) =>
+    knex(`notification_${type}`)
+      .where('name', '=', name)
+      .toString(),
   deleteProjectNotification: input => {
     const deleteQuery = knex.raw(
       `DELETE pn

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1424,9 +1424,9 @@ const typeDefs = gql`
     deployTargetConfigsByDeployTarget(deployTarget: Int!) : [DeployTargetConfig]  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
     allDeployTargetConfigs: [DeployTargetConfig]  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
     """
-    List all notifications
+    List all notifications matching the given filters (name & type) | returns all if no filter defined
     """
-    allNotifications: [Notification]
+    allNotifications(name: String, type: NotificationType): [Notification]
     """
     List all organizations
     """


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Extends `allNotifications` to have an optional `name` & `type` input.
