### PR TITLE
fix: remove usergroup injection from org project groups to prevent duplicates

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -654,6 +654,9 @@ export const addGroupsToProject: ResolverFn = async (
 
   for (const groupInput of groupsInput) {
     const group = await models.GroupModel.loadGroupByIdOrName(groupInput);
+    if (R.prop('lagoon-organization', group.attributes) === undefined && project.organization != null) {
+      throw new Error('Group must be in same organization as the project');
+    }
     if (R.prop('lagoon-organization', group.attributes) && project.organization != null) {
       if (project.organization == R.prop('lagoon-organization', group.attributes)) {
         // if this is a group in an organization, check that the user removing members from the group in this org is in the org
@@ -661,7 +664,7 @@ export const addGroupsToProject: ResolverFn = async (
           organization: R.prop('lagoon-organization', group.attributes)
         });
       } else {
-        throw new Error('Project must be in same organization as groups');
+        throw new Error('Group must be in same organization as the project');
       }
     }
     await models.GroupModel.addProjectToGroup(project.id, group);


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

If an organization owner was a member of a group and also the organization owner, when viewing the groups of a project it would result in duplicate groups appearing due to the way the resolver consolidated groups.

This fix is to remove the part of the resolver where the users groups are injected into the resulting projects groups so that only groups attached to the project are returned.

Due to the way groups work in Lagoon prior to organizations, there exists the possibility that a group that did not exist within the organization could have been attached to a project, however this is unlikely (but not impossible)

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->