### PR TITLE
Fix links to Redis docker image in documentation

### DIFF
--- a/docs/docker-images/redis.md
+++ b/docs/docker-images/redis.md
@@ -57,7 +57,7 @@ See [https://raw.githubusercontent.com/antirez/redis/4.0/redis.conf](https://raw
 
 ## Redis-persistent
 
-Based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/5.Dockerfile), the [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/5.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode \(ie. with a persistent volume where keys will be saved to disk\).
+Based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile), the [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode \(ie. with a persistent volume where keys will be saved to disk\).
 
 It differs from `redis` only with the `FLAVOR` environment variable, which will use the [respective Redis configuration](https://github.com/uselagoon/lagoon-images/tree/main/images/redis/conf) according to the version of redis in use.
 


### PR DESCRIPTION
Redis 5 no longer exists. Switch to Redis 6.

Redis 7 is also available. We could also link to the directory containing all the currently available Docker files e.g.
https://github.com/uselagoon/lagoon-images/tree/main/images/redis and https://github.com/uselagoon/lagoon-images/tree/main/images/redis-persistent.