### PR TITLE
feat: add inviteUser boolean to addUserToGroup

### DIFF
--- a/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-lagoon-demo-org.gql
+++ b/local-dev/api-data-watcher-pusher/api-data/02-populate-api-data-lagoon-demo-org.gql
@@ -74,6 +74,21 @@ mutation PopulateApi {
     name
   }
 
+  UIOrganizationUserInviteToGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"invite@example.com"
+      }
+      group: {
+        name: "lagoon-demo-organization-group"
+      }
+      role: GUEST
+      inviteUser: true
+    }
+  ) {
+    name
+  }
+
   UIOrganizationAddViewer: addUserToOrganization(input: {user: {email: "orgviewer@example.com"}, organization: 1}) {
     id
   }

--- a/local-dev/k3d-seed-data/00-populate-kubernetes.gql
+++ b/local-dev/k3d-seed-data/00-populate-kubernetes.gql
@@ -237,6 +237,21 @@ mutation PopulateApi {
     name
   }
 
+  UIOrganizationUserInviteToGroup: addUserToGroup(
+    input: {
+      user: {
+        email:"invite@example.com"
+      }
+      group: {
+        name: "lagoon-demo-organization-group"
+      }
+      role: GUEST
+      inviteUser: true
+    }
+  ) {
+    name
+  }
+
   UIOrganizationAddViewer: addUserToOrganization(input: {user: {email: "orgviewer@example.com"}, organization: 1}) {
     id
   }

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -471,7 +471,7 @@ export const User = (clients: {
           `Username ${R.prop('username', userInput)} exists`
         );
       } else {
-        throw new Error(`Error creating Keycloak user: ${err.message}`);
+        throw new Error(`Error creating Lagoon user account: ${err.message}`);
       }
     }
 
@@ -537,7 +537,7 @@ export const User = (clients: {
       if (err.response.status && err.response.status === 404) {
         throw new UserNotFoundError(`User not found: ${id}`);
       } else {
-        throw new Error(`Error updating Keycloak user: ${err.message}`);
+        throw new Error(`Error updating Lagoon user account: ${err.message}`);
       }
     }
   };
@@ -629,7 +629,7 @@ export const User = (clients: {
       if (err.response.status && err.response.status === 404) {
         throw new UserNotFoundError(`User not found: ${userInput.id}`);
       } else {
-        throw new Error(`Error updating Keycloak user: ${err.message}`);
+        throw new Error(`Error updating Lagoon user account: ${err.message}`);
       }
     }
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -2266,6 +2266,7 @@ const typeDefs = gql`
     user: UserInput!
     group: GroupInput!
     role: GroupRole!
+    inviteUser: Boolean
   }
 
   input ProjectGroupsInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a simple one to make adding users to groups a little bit nicer if the user doesn't exist. Adds an `inviteUser` boolean to `addUserToGroup` input that will create the user account if one doesn't exist.

The UI could then expose a checkbox when adding a user to a group that asks if they want to invite the user if the user doesn't exist.

If `inviteUser` is set and the account does not already exist, it will be created, and a password reset email will be sent.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
