### PR TITLE
fix: check if user has attributes before accessing attributes

### DIFF
--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -199,6 +199,7 @@ const apolloServer = new ApolloServer({
         currentUser = await User.User(modelClients).loadUserById(keycloakGrant.access_token.content.sub);
         // grab the users project ids and roles in the first request
         groupRoleProjectIds = await User.User(modelClients).getAllProjectsIdsForUser(currentUser.id, keycloakUsersGroups);
+        await User.User(modelClients).userLastAccessed(currentUser);
       }
 
       // do a permission check to see if the user is platform admin/owner, or has permission for `viewAll` on certain resources

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -184,7 +184,7 @@ export const User = (clients: {
     for (const user of users) {
       // set the lastaccessed attribute
       let date = null;
-      if (user['attributes']['last_accessed']) {
+      if (user['attributes'] && user['attributes']['last_accessed']) {
         date = new Date(user['attributes']['last_accessed']*1000).toISOString()
       }
       usersWithGitlabIdFetch.push({

--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -187,8 +187,6 @@ export const keycloakHasPermission = (grant, requestCache, modelClients, service
       currentUser: [currentUser.id]
     };
 
-    await UserModel.userLastAccessed(currentUser);
-
     const usersAttribute = R.prop('users', attributes);
     if (usersAttribute && usersAttribute.length) {
       claims = {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

#3675 introduced `last_accessed` attribute to users. Most users get an attribute added to them when they are created, but users created via an IDP do not. This is just a quick fix to check that attributes exist before trying to access the attribute value.

Also moves the lastaccessed call to apollo so it is only called once on the initial request, rather than every haspermission check

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

