### PR TITLE
refactor: use api to store last accessed for user

### DIFF
--- a/services/api/database/migrations/20241213000000_user_last_accessed.js
+++ b/services/api/database/migrations/20241213000000_user_last_accessed.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    organizations = await knex.schema.hasTable('user');
+    if (!organizations) {
+        return knex.schema
+        .createTable('user', function (table) {
+            table.specificType('usid', 'CHAR(36)');
+            table.datetime('last_accessed');
+            table.primary(['usid']);
+        })
+    }
+    else {
+        return knex.schema
+    }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+};

--- a/services/api/database/migrations/20241229000000_user_last_accessed.js
+++ b/services/api/database/migrations/20241229000000_user_last_accessed.js
@@ -3,8 +3,8 @@
  * @returns { Promise<void> }
  */
 exports.up = async function(knex) {
-    organizations = await knex.schema.hasTable('user');
-    if (!organizations) {
+    userTable = await knex.schema.hasTable('user');
+    if (!userTable) {
         return knex.schema
         .createTable('user', function (table) {
             table.specificType('usid', 'CHAR(36)');
@@ -22,5 +22,5 @@ exports.up = async function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = async function(knex) {
-    return knex.schema
+    return knex.schema.dropTable('user');
 };

--- a/services/api/src/resources/user/sql.ts
+++ b/services/api/src/resources/user/sql.ts
@@ -38,4 +38,23 @@ export const Sql = {
       .where('sk.key_fingerprint', keyFingerprint)
       .select('user_ssh_key.usid')
       .toString(),
+  updateLastAccessed: (id: string) =>
+    knex('user')
+      .insert({
+        usid: id,
+        lastAccessed: knex.fn.now(),
+      })
+      .onConflict('usid')
+      .merge()
+      .toString(),
+  selectLastAccessed: (id: string) =>
+    knex('user')
+      .select('last_accessed')
+      .where('usid','=',id)
+      .toString(),
+  deleteFromUser: (id: string) =>
+    knex('user')
+      .where('usid', id)
+      .delete()
+      .toString(),
 };

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -459,10 +459,9 @@ const typeDefs = gql`
     # This just returns the group name, id and the role the user has in that group.
     # This is a neat way to visualize a users specific access without having to get all members of a group
     groupRoles: [GroupRoleInterface]
-    # @TODO: no op last accessed for the time being due to raciness
-    # @TODO: refactor later
-    # lastAccessed: String
     platformRoles: [PlatformRole]
+    created: String
+    lastAccessed: String
   }
 
   enum PlatformRole {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Saves the last user accessed time to the API DB, previous attempts stored this attribute in keycloak but encountered race conditions.

Also include the user created timestamp from keycloak.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

