### PR TITLE
refactor: last_accessed on user noops

### DIFF
--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -183,13 +183,17 @@ export const User = (clients: {
 
     for (const user of users) {
       // set the lastaccessed attribute
+      // @TODO: no op last accessed for the time being due to raciness
+      // @TODO: refactor later
+      /*
       let date = null;
       if (user['attributes'] && user['attributes']['last_accessed']) {
         date = new Date(user['attributes']['last_accessed']*1000).toISOString()
+        user.lastAccessed = date
       }
+      */
       usersWithGitlabIdFetch.push({
         ...user,
-        lastAccessed: date,
         gitlabId: await fetchGitlabId(user)
       });
     }
@@ -544,6 +548,9 @@ export const User = (clients: {
 
   const userLastAccessed = async (userInput: User): Promise<Boolean> => {
     // set the last accessed as a unix timestamp on the user attributes
+    // @TODO: no op last accessed for the time being due to raciness
+    // @TODO: refactor later
+    /*
     try {
       const lastAccessed = {last_accessed: Math.floor(Date.now() / 1000)}
       await keycloakAdminClient.users.update(
@@ -564,6 +571,7 @@ export const User = (clients: {
         logger.warn(`Error updating Keycloak user: ${err.message}`);
       }
     }
+    */
     return true
   };
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -453,7 +453,9 @@ const typeDefs = gql`
     # This just returns the group name, id and the role the user has in that group.
     # This is a neat way to visualize a users specific access without having to get all members of a group
     groupRoles: [GroupRoleInterface]
-    lastAccessed: String
+    # @TODO: no op last accessed for the time being due to raciness
+    # @TODO: refactor later
+    # lastAccessed: String
   }
 
   type GroupMembership {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Last accessed is a bit racy still, so just noop them for now, we can refactor later. 
Alternative approach is a user table in #3761 

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

