### PR TITLE
chore: fix keycloak local-dev for live theme loading

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -170,6 +170,7 @@ services:
     user: '111111111'
     depends_on:
       - keycloak-db
+    command: 'start-dev'
     ports:
       - '8088:8080'
     environment:
@@ -179,9 +180,9 @@ services:
       # - NEW_RELIC_LICENSE_KEY=
       # - NEW_RELIC_APP_NAME=keycloak-local
     volumes:
-      - "./services/keycloak/profile.properties:/opt/jboss/keycloak/standalone/configuration/profile.properties"
-      - "./services/keycloak/startup-scripts:/opt/jboss/startup-scripts"
-      - "./services/keycloak/themes/lagoon:/opt/jboss/keycloak/themes/lagoon"
+      - "./services/keycloak/profile.properties:/opt/keycloak/standalone/configuration/profile.properties"
+      - "./services/keycloak/startup-scripts:/opt/keycloak/startup-scripts"
+      - "./services/keycloak/themes/lagoon:/opt/keycloak/themes/lagoon"
       - "./local-dev/keycloak:/lagoon/keycloak"
   keycloak-db:
     image: ${IMAGE_REPO:-lagoon}/keycloak-db


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Fixes some paths for local dev themes to remove jboss references, and changes the start command to be `start-dev` for local development

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

