### PR TITLE
docs: add notes about removal of harbor from api and warning about upgrading

### DIFF
--- a/docs/releases/2.17.0.md
+++ b/docs/releases/2.17.0.md
@@ -15,5 +15,6 @@ There are no required actions or considerations with this release. As always, we
 * This release introduces a new active/standby task image that does not require the use of the [dioscuri controller](https://github.com/amazeeio/dioscuri). Dioscuri is deprecated and will eventually be removed from the `lagoon-remote` helm chart. If you use active/standby functionality in your clusters, you should upgrade to lagoon v2.17.0 and update your remote clusters to the version of the `lagoon-remote` helm chart the v2.17.0 release says to use (see release notes for v2.17.0)
 ### API Harbor support
 * Support for Harbor in the API will be removed in a future release. If you currently have your core installation with Harbor support, you should move to using the integration within lagoon-remote instead. See the documentation [here](https://docs.lagoon.sh/installing-lagoon/install-lagoon-remote) and read the section about Harbor.
+* Removed in [v2.20.0](https://docs.lagoon.sh/releases/2.20.0)
 ### Harbor 2.1 and earlier support
 * Support for Harbor 2.1.x (chart version 1.5.x) and older in `lagoon-remote` will be removed in a future release. You should consider upgrading Harbor to a newer version (currently Lagoon supports up to v2.9.x (chart version 1.13.x)), following any recommended upgrade paths from Harbor.

--- a/docs/releases/2.20.0.md
+++ b/docs/releases/2.20.0.md
@@ -9,7 +9,7 @@ This release contains changes that you may need to be aware of. Read carefully b
 
 ### Harbor 2.1.x and earlier
 * This release removes the support for Harbor from the Lagoon API. If you're still using the Harbor support in the API, you should NOT upgrade until you have configured your `lagoon-remote` installations to use Harbor instead. See the documentation [here](https://docs.lagoon.sh/installing-lagoon/install-lagoon-remote) and read the section about Harbor.
-* We also recommend that if you're using Harbor version 2.1.x and earlier, that you upgrade this as soon as possible. Follow any instructions that Harbor recommend for upgrading. As of this release, `lagoon-remote` works with Harbor version 2.10.0 (helm chart version 1.14.0). [Lagoon will stop supporting Harbor 2.1.x and earlier in a future release](https://docs.lagoon.sh/releases/2.17.0/#harbor-21-and-earlier-support).
+* We also recommend that if you're using Harbor version 2.1.x and earlier, that you upgrade this as soon as possible. Follow any instructions that Harbor recommend for upgrading. As of this release, `lagoon-remote` has been tested up to Harbor version 2.10.0 (helm chart version 1.14.0). [Lagoon will stop supporting Harbor 2.1.x and earlier in a future release](https://docs.lagoon.sh/releases/2.17.0/#harbor-21-and-earlier-support).
 
 ## Deprecations
 

--- a/docs/releases/2.20.0.md
+++ b/docs/releases/2.20.0.md
@@ -4,9 +4,23 @@
     This version has not been released yet
 
 ## Upgrades
-There are no required actions or considerations with this release. As always, we suggest upgrading all minor versions.
+
+This release contains changes that you may need to be aware of. Read carefully before you upgrade.
+
+### Harbor 2.1.x and earlier
+* This release removes the support for Harbor from the Lagoon API. If you're still using the Harbor support in the API, you should NOT upgrade until you have configured your `lagoon-remote` installations to use Harbor instead. See the documentation [here](https://docs.lagoon.sh/installing-lagoon/install-lagoon-remote) and read the section about Harbor.
+* We also recommend that if you're using Harbor version 2.1.x and earlier, that you upgrade this as soon as possible. Follow any instructions that Harbor recommend for upgrading. As of this release, `lagoon-remote` works with Harbor version 2.10.0 (helm chart version 1.14.0). [Lagoon will stop supporting Harbor 2.1.x and earlier in a future release](https://docs.lagoon.sh/releases/2.17.0/#harbor-21-and-earlier-support).
 
 ## Deprecations
 
 ### Deleted Backups
 * When a backup is deleted via the webhook, it will now actually removed from the API rather than being flagged as deleted. The `Backup` type field `deleted` is deprecated, and will be removed in a future release. Additionally, `includeDeleted` if requested when querying backups will not change the result as there will be no deleted backups to include.
+
+### API Harbor support
+* In [v2.17.0](https://docs.lagoon.sh/releases/2.17.0/#api-harbor-support) we announced that Harbor support in the API was deprecated. This release of Lagoon removes all support for Harbor from the API. See upgrade notes above.
+
+### DeleteAll/RemoveAll mutations removed
+* This release removes all `DeleteAllX` and `RemoveAllX` from the API. These were only ever meant for local development and are no longer relevant.
+
+### Error handling on deployment triggers
+* In the past, if triggering a deployment using any of the `DeployEnvironmentX` mutations and an error was encountered, the API would not return an actual error, just a string that contained the error. This was changed in this release to actually return an error now. As this is a change in behaviour, it may impact any users that may have previously been capturing the string error text and parsing it to check for errors.


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just adds some notes to the release docs for 2.20.0 about the removal of harbor from the API in #3259. Informing users to not upgrade if they're still using the core implementation of harbor and an older version of harbor in general.

Plus some other notes for #3753 and #3568.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->