### PR TITLE
fix: backup handler to ignore namespaces lagoon does not care about

### DIFF
--- a/services/backup-handler/go.mod
+++ b/services/backup-handler/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/isayme/go-amqp-reconnect v0.0.0-20210303120416-fc811b0bcda2
 	github.com/streadway/amqp v1.0.0
-	github.com/uselagoon/machinery v0.0.22
+	github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941
 )
 
 require (

--- a/services/backup-handler/go.mod
+++ b/services/backup-handler/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/isayme/go-amqp-reconnect v0.0.0-20210303120416-fc811b0bcda2
 	github.com/streadway/amqp v1.0.0
-	github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941
+	github.com/uselagoon/machinery v0.0.25
 )
 
 require (

--- a/services/backup-handler/go.sum
+++ b/services/backup-handler/go.sum
@@ -18,3 +18,5 @@ github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941 h1:clRmB6HIdP9KQtviEQjRTJJYNEWqudBZE3diNFAadnU=
 github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
+github.com/uselagoon/machinery v0.0.25 h1:Xaf7f8c+U16HYQBqoChCv37dCBdH+aUgOkuHG5YXLCo=
+github.com/uselagoon/machinery v0.0.25/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=

--- a/services/backup-handler/go.sum
+++ b/services/backup-handler/go.sum
@@ -16,5 +16,5 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
-github.com/uselagoon/machinery v0.0.22 h1:4FVJRLS8he2NAZYMIJXQqVb25jQ03tF8dNhQbrBMX3g=
-github.com/uselagoon/machinery v0.0.22/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
+github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941 h1:clRmB6HIdP9KQtviEQjRTJJYNEWqudBZE3diNFAadnU=
+github.com/uselagoon/machinery v0.0.25-0.20240731103619-a4140d3a8941/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

#3724 introduced machinery, but an issue with the returned data resulting in the backup handler also processing namespaces that lagoon does not know about.

This fixes the issue to use a new [specific query](https://github.com/uselagoon/machinery/pull/60) crafted just for backups by namespace.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

