### PR TITLE
refactor: exclude any disabled projects from polysite count

### DIFF
--- a/services/webhooks2tasks/src/webhooks/projects.ts
+++ b/services/webhooks2tasks/src/webhooks/projects.ts
@@ -141,8 +141,14 @@ export async function processProjects(
     return;
   }
 
+  // count if any projects are disabled in the result
+  let disabledProjects = projects.filter(function(element){
+    return element.deploymentsDisabled == 1;
+  }).length
+
   // if there are more than 1 projects returned, it is probably a polysite deployment
-  if (projects.length > 1) {
+  // also if the number of projects minus the number of any disabled projects is more than 1
+  if (projects.length > 1 && (projects.length - disabledProjects > 1)) {
     // label them as a bulk or grouped deployment
     // assign a random uuid
     webhook.bulkId = crypto.randomUUID()


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

#3668 introduced grouping deployments of polysites under a bulk label. This is a small fix to exclude projects where deployments are disabled from being evaluated under the count.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

