### PR TITLE
refactor: platform-owner storage-calculator and deployments-disabled fields

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -342,12 +342,14 @@ export const addProject = async (
   const openshiftProjectPattern =
     input.kubernetesNamespacePattern || input.openshiftProjectPattern;
 
-  // check if a user has permission to disable deployments of a project or not
-  let deploymentsDisabled = 0;
-  if (input.deploymentsDisabled) {
-    if (adminScopes.platformOwner) {
-      deploymentsDisabled = input.deploymentsDisabled
-    }
+  if (input.deploymentsDisabled && !adminScopes.platformOwner) {
+    // only platform owner can set this, it won't return an error, just ignores the value
+    delete input.deploymentsDisabled
+  }
+
+  if (input.storageCalc && !adminScopes.platformOwner) {
+    // only platform owner can set this, it won't return an error, just ignores the value
+    delete input.storageCalc
   }
 
   let buildImage = null;
@@ -648,6 +650,13 @@ export const updateProject: ResolverFn = async (
   if (deploymentsDisabled) {
     if (!adminScopes.platformOwner) {
       throw new Error('Disabling deployments is only available to administrators.');
+    }
+  }
+
+  // only platform owner can modify storage calculator
+  if (storageCalc) {
+    if (!adminScopes.platformOwner) {
+      throw new Error('Disabling storage calculator is only available to administrators.');
     }
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just a quick fix to only allow `platform-owner` to change the storage-calculator and deployments-disabled fields on projects

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
