### PR TITLE
Docs: Removing Alanna from CoC and adding Lagoon alumni.

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [uselagoon@amazee.io](mailto:uselagoon@amazee.io). You may also reach out directly to either [Alanna](mailto:alanna.burke@amazee.io) or [Brandon](mailto:brandon.williams@amazee.io), both Lagoon team members who have completed [CoC training](https://www.drupal.org/community/cwg/code-of-conduct-contact-training). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [uselagoon@amazee.io](mailto:uselagoon@amazee.io). You may also reach out directly to [Brandon](mailto:brandon.williams@amazee.io), a Lagoon team member who has completed [CoC training](https://www.drupal.org/community/cwg/code-of-conduct-contact-training). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/maintainers.md
+++ b/maintainers.md
@@ -18,7 +18,6 @@ The Lagoon core team is responsible for the priorization, creation, development 
 They are responsible for the development, testing and release processes.
 
 - Toby Bellwood
-- Alanna Burke
 - Davit Darsavelidze
 - Chris Goodwin
 - Ben Jackson
@@ -42,6 +41,12 @@ They suggest and review features, develop integrations and tools, and work close
 - Justin Winter
 
 The Lagoon team would also like to acknowledge the massive contributions from everyone over the years to help get Lagoon to where we are today. ❤️
+
+## Lagoon Alumni
+
+- Alanna Burke
+- Tim Clifford
+- Tyler Ward
 
 ## Scope of the Lagoon team
 


### PR DESCRIPTION
Removes Alanna from CoC page and adds Alumni to maintainers. 