### PR TITLE
fix: check if user has attributes before accessing attributes

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -391,20 +391,22 @@ export const getUsersByOrganizationId: ResolverFn = async (
         groupMembers[member].user.owner = false
         groupMembers[member].user.admin = false
         groupMembers[member].user.comment = null
-        if (groupMembers[member].user.attributes["comment"]) {
-          groupMembers[member].user.comment = groupMembers[member].user.attributes["comment"][0]
-        }
-        if (groupMembers[member].user.attributes["lagoon-organizations"]) {
-          for (const a in groupMembers[member].user.attributes["lagoon-organizations"]) {
-            if (parseInt(groupMembers[member].user.attributes["lagoon-organizations"][a]) == args.organization) {
-              groupMembers[member].user.owner = true
+        if (groupMembers[member].user.attributes) {
+          if (groupMembers[member].user.attributes["comment"]) {
+            groupMembers[member].user.comment = groupMembers[member].user.attributes["comment"][0]
+          }
+          if (groupMembers[member].user.attributes["lagoon-organizations"]) {
+            for (const a in groupMembers[member].user.attributes["lagoon-organizations"]) {
+              if (parseInt(groupMembers[member].user.attributes["lagoon-organizations"][a]) == args.organization) {
+                groupMembers[member].user.owner = true
+              }
             }
           }
-        }
-        if (groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
-          for (const a in groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
-            if (parseInt(groupMembers[member].user.attributes["lagoon-organizations-admin"][a]) == args.organization) {
-              groupMembers[member].user.admin = true
+          if (groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
+            for (const a in groupMembers[member].user.attributes["lagoon-organizations-admin"]) {
+              if (parseInt(groupMembers[member].user.attributes["lagoon-organizations-admin"][a]) == args.organization) {
+                groupMembers[member].user.admin = true
+              }
             }
           }
         }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

In the `usersByOrganization` query, there are checks against attributes of a user from keycloak. If a user has no attributes though, this check fails.

This fix checks if attributes are defined before trying to access them.
