### PR TITLE
docs: remove uptimerobot references and add note about monitoring

### DIFF
--- a/docs/concepts-basics/lagoon-yml.md
+++ b/docs/concepts-basics/lagoon-yml.md
@@ -275,12 +275,20 @@ that's important!):
 
 ### Monitoring a specific path
 
-When [UptimeRobot](https://uptimerobot.com/) is configured for your cluster \(Kubernetes or OpenShift\), Lagoon will inject annotations to each route/ingress for use by the `stakater/IngressControllerMonitor`. The default action is to monitor the homepage of the route. If you have a specific route to be monitored, this can be overridden by adding a `monitoring-path` to your route specification. A common use is to set up a path for monitoring which bypasses caching to give a more real-time monitoring of your site.
+!!! Info
+    Lagoon does not provide any monitoring capabilties out of the box, only labels and annotations. Check with {{ defaults.helpstring }} if monitoring is supported.
+
+Lagoon will add the label `lagoon.sh/primaryIngress=true` to the first route defined in the `.lagoon.yml` file for an environment.
+
+If a specific path on a route requires monitoring, define `monitoring-path` with the path to use. Lagoon will add this path to the annotation `monitor.stakater.com/overridePath` to the route.
 
 ```yaml title=".lagoon.yml"
 - "www.example.com":
       monitoring-path: "/bypass-cache"
 ```
+
+!!! Info
+    The annotation `monitor.stakater.com/overridePath` used by monitoring-path references the stakater monitoring controller, this is not used by Lagoon. This annotation will eventually be replaced with a `lagoon.sh` scoped annotation in the future.
 
 ### Ingress annotations
 

--- a/docs/lagoonizing/index.md
+++ b/docs/lagoonizing/index.md
@@ -252,9 +252,6 @@ routes:
 
 environments:
   main:
-    monitoring_urls:
-      - "www.example.com"
-      - "www.example.com/special_page"
     routes:
       - nginx:
         - example.com
@@ -351,15 +348,6 @@ The following options are allowed:
 ### Environments
 
 Environment names match your deployed branches or pull requests. This allows each environment to have a different configuration. In this example, we have the environments main and staging.
-
-#### Monitoring a Specific Path
-
-When UptimeRobot is configured for your cluster, Lagoon will inject annotations to each route/ingress for use by the `stakater/IngressControllerMonitor`. The default action is to monitor the homepage of the route. If you have a specific route to be monitored, this can be overridden by adding a `monitoring-path` to your route specification. A common use is to set up a path for monitoring which bypasses caching to give a more real-time monitoring of your site.
-
-```yaml title=".lagoon.yml example"
-     - "www.example.com":
-            monitoring-path: "/bypass-cache"
-```
 
 #### `environments.[name].routes`
 

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -109,7 +109,6 @@ description: >-
 | TLS | Transport Layer Security |
 | Trivy | A simple and comprehensive vulnerability scanner for containers, suitable for CI. |
 | TTL | Time to live or hop limit is a mechanism that limits the lifespan or lifetime of data in a computer or network. |
-| Uptime Robot | Uptime monitoring service. |
 | Varnish | A powerful, open-source HTTP engine/reverse HTTP proxy that can speed up a website by caching \(or storing\) a copy of a webpage the first time a user visits. |
 | VM | Virtual Machine |
 | Webhook | A webhook is a way for an app like GitHub, GitLab, Bitbucket, etc, to provide other applications with immediate data and act upon something, like a pull request. |


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Removes references to UptimeRobot and updates documentation for the `monitoring-path` on routes to include a note that Lagoon does not provide monitoring capabilties out of the box, and that only labels and annotations are provided.

It is up to platform operators to use these labels and annotations to inform monitoring systems as they see fit.

As always though, people are free to add their own monitoring that they manage themselves outside of Lagoon if a platform operator does not offer a monitoring solution.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
