### PR TITLE
refactor:(make) dont download binaries if theyre already present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,9 +414,11 @@ ifeq ($(KUBECTL_VERSION), $(shell kubectl version --short --client 2>/dev/null |
 	$(info linking local kubectl version $(KUBECTL_VERSION))
 	ln -sf $(shell command -v kubectl) ./local-dev/kubectl
 else
+ifeq ($(KUBECTL_VERSION), $(shell kubectl version --short --client 2>/dev/null | sed -E 's/Client Version: v([0-9.]+).*/\1/'))
 	$(info downloading kubectl version $(KUBECTL_VERSION) for $(ARCH))
 	curl -sSLo local-dev/kubectl https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(ARCH)/amd64/kubectl
 	chmod a+x local-dev/kubectl
+endif
 endif
 
 # Symlink the installed helm client if the correct version is already
@@ -427,9 +429,11 @@ ifeq ($(HELM_VERSION), $(shell helm version --short --client 2>/dev/null | sed -
 	$(info linking local helm version $(HELM_VERSION))
 	ln -sf $(shell command -v helm) ./local-dev/helm
 else
+ifneq ($(HELM_VERSION), v$(shell ./local-dev/helm version --short --client 2>/dev/null | sed -nE 's/v([0-9.]+).*/\1/p'))
 	$(info downloading helm version $(HELM_VERSION) for $(ARCH))
 	curl -sSL https://get.helm.sh/helm-$(HELM_VERSION)-$(ARCH)-amd64.tar.gz | tar -xzC local-dev --strip-components=1 $(ARCH)-amd64/helm
 	chmod a+x local-dev/helm
+endif
 endif
 
 # Symlink the installed k3d client if the correct version is already
@@ -440,9 +444,11 @@ ifeq ($(K3D_VERSION), $(shell k3d version 2>/dev/null | sed -nE 's/k3d version (
 	$(info linking local k3d version $(K3D_VERSION))
 	ln -sf $(shell command -v k3d) ./local-dev/k3d
 else
+ifneq ($(K3D_VERSION), $(shell ./local-dev/k3d version 2>/dev/null | sed -nE 's/k3d version (v[0-9.]+).*/\1/p'))
 	$(info downloading k3d version $(K3D_VERSION) for $(ARCH))
 	curl -sSLo local-dev/k3d https://github.com/k3d-io/k3d/releases/download/$(K3D_VERSION)/k3d-$(ARCH)-amd64
 	chmod a+x local-dev/k3d
+endif
 endif
 
 # Symlink the installed jq client if the correct version is already
@@ -453,6 +459,7 @@ ifeq ($(GOJQ_VERSION), $(shell jq -v 2>/dev/null | sed -nE 's/gojq ([0-9.]+).*/v
 	$(info linking local jq version $(GOJQ_VERSION))
 	ln -sf $(shell command -v jq) ./local-dev/jq
 else
+ifneq ($(GOJQ_VERSION), $(shell ./local-dev/jq -v 2>/dev/null | sed -nE 's/gojq ([0-9.]+).*/v\1/p'))
 	$(info downloading gojq version $(GOJQ_VERSION) for $(ARCH))
 ifeq ($(ARCH), darwin)
 	TMPDIR=$$(mktemp -d) \
@@ -464,6 +471,7 @@ else
 endif
 	chmod a+x local-dev/jq
 endif
+endif
 
 # Symlink the installed stern client if the correct version is already
 # installed, otherwise downloads it.
@@ -473,9 +481,11 @@ ifeq ($(STERN_VERSION), $(shell stern --version 2>/dev/null | sed -nE 's/stern v
 	$(info linking local stern version $(STERN_VERSION))
 	ln -sf $(shell command -v stern) ./local-dev/stern
 else
+ifneq ($(STERN_VERSION), v$(shell ./local-dev/stern --version 2>/dev/null | sed -nE 's/stern version //p'))
 	$(info downloading stern version $(STERN_VERSION) for $(ARCH))
 	curl -sSLo local-dev/stern https://github.com/derdanne/stern/releases/download/$(STERN_VERSION)/stern_$(ARCH)_amd64
 	chmod a+x local-dev/stern
+endif
 endif
 
 .PHONY: helm/repos

--- a/Makefile
+++ b/Makefile
@@ -771,3 +771,22 @@ k3d/clean: local-dev/k3d
 ifeq ($(ARCH), darwin)
 	docker rm --force $(CI_BUILD_TAG)-k3d-proxy-32080 || true
 endif
+
+# clean up any old charts to prevent bloating of old charts from running k3d stacks regularly
+.PHONY: k3d/clean-charts
+k3d/clean-charts:
+	@for chart in $$(ls -1 | grep lagoon-charts | egrep -v "lagoon-charts.k3d|$$(ls -l | grep -o "lagoon-charts.k3d.lagoon.*" | awk '{print $$3}' | cut -c 3-)") ; do \
+		echo removing chart directory $$chart ; \
+		rm -rf $$chart ; \
+	done
+
+# clean up any old k3d kubeconfigs
+.PHONY: k3d/clean-k3dconfigs
+k3d/clean-k3dconfigs:
+	@for kubeconfig in $$(ls -1 | grep k3dconfig) ; do \
+		echo removing k3dconfig $$kubeconfig ; \
+		rm $$kubeconfig ; \
+	done
+
+.PHONY: k3d/clean-all
+k3d/clean-all: k3d/clean k3d/clean-k3dconfigs k3d/clean-charts

--- a/Makefile
+++ b/Makefile
@@ -410,11 +410,11 @@ DOCKER_NETWORK = k3d
 # installed, otherwise downloads it.
 .PHONY: local-dev/kubectl
 local-dev/kubectl:
-ifeq ($(KUBECTL_VERSION), $(shell kubectl version --short --client 2>/dev/null | sed -E 's/Client Version: v([0-9.]+).*/\1/'))
+ifeq ($(KUBECTL_VERSION), $(shell kubectl version --client 2>/dev/null | grep Client | sed -E 's/Client Version: v([0-9.]+).*/\1/'))
 	$(info linking local kubectl version $(KUBECTL_VERSION))
 	ln -sf $(shell command -v kubectl) ./local-dev/kubectl
 else
-ifeq ($(KUBECTL_VERSION), $(shell kubectl version --short --client 2>/dev/null | sed -E 's/Client Version: v([0-9.]+).*/\1/'))
+ifneq ($(KUBECTL_VERSION), v$(shell ./local-dev/kubectl version --client 2>/dev/null | grep Client | sed -E 's/Client Version: v([0-9.]+).*/\1/'))
 	$(info downloading kubectl version $(KUBECTL_VERSION) for $(ARCH))
 	curl -sSLo local-dev/kubectl https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(ARCH)/amd64/kubectl
 	chmod a+x local-dev/kubectl


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

#3811 fixed some issues symbolic linking, this incorporates some additional checks to prevent needlessly downloading the same versions of these binaries over and over again if they are already present.

Also includes some commands to clean up old `lagoon-chart` directories and k3dconfig temp files.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
