### PR TITLE
docs: add make target for serving docs locally in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ PUBLISH_PLATFORM_ARCH := linux/amd64,linux/arm64
 # Skip image scanning by default to make building images substantially faster
 SCAN_IMAGES := false
 
+# Settings for the MKDocs serving
+MKDOCS_IMAGE ?= ghcr.io/amazeeio/mkdocs-material
+MKDOCS_SERVE_PORT ?= 8000
+
 # Init the file that is used to hold the image tag cross-reference table
 $(shell >build.txt)
 $(shell >scan.txt)
@@ -823,3 +827,13 @@ k3d/clean-k3dconfigs:
 
 .PHONY: k3d/clean-all
 k3d/clean-all: k3d/clean k3d/clean-k3dconfigs k3d/clean-charts
+
+.PHONY: docs/serve
+docs/serve:
+	@echo "Starting container to serve documentation"
+	@docker pull $(MKDOCS_IMAGE)
+	@docker run --rm -it \
+		-p 127.0.0.1:$(MKDOCS_SERVE_PORT):$(MKDOCS_SERVE_PORT) \
+		-v ${PWD}:/docs \
+		--entrypoint sh $(MKDOCS_IMAGE) \
+		-c 'mkdocs serve -s --dev-addr=0.0.0.0:$(MKDOCS_SERVE_PORT) -f mkdocs.yml'

--- a/docs/contributing-to-lagoon/documentation.md
+++ b/docs/contributing-to-lagoon/documentation.md
@@ -11,7 +11,7 @@ We use [mkdocs](https://www.mkdocs.org/) with the excellent [Material](https://s
 From the root of the Lagoon repository (you'll need Docker), run:
 
 ```bash title="Get local docs up and running."
-docker run --rm -it -p 127.0.0.1:8000:8000 -v ${PWD}:/docs ghcr.io/amazeeio/mkdocs-material
+make docs/serve
 ```
 
 <!-- markdown-link-check-disable-next-line -->


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Just adds `make docs/serve` to start docs locally without having mkdocs installed
