### PR TITLE
chore: use lagoon v222 branches for build/test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,7 +230,7 @@ pipeline {
         TOKEN = credentials('git-amazeeio-helmfile-ci-trigger')
       }
       steps {
-        sh script: "curl -X POST -F token=$TOKEN -F ref=main https://git.amazeeio.cloud/api/v4/projects/86/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
+        sh script: "curl -X POST -F token=$TOKEN -F ref=lagoon_v222 https://git.amazeeio.cloud/api/v4/projects/86/trigger/pipeline", label: "Trigger lagoon-core helmfile sync on amazeeio-test6"
       }
     }
     stage ('push images to uselagoon/*') {

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ STERN_VERSION = v2.6.1
 CHART_TESTING_VERSION = v3.11.0
 K3D_IMAGE = docker.io/rancher/k3s:v1.31.0-k3s1
 TESTS = [nginx,api,features-kubernetes,bulk-deployment,features-kubernetes-2,features-variables,active-standby-kubernetes,tasks,drush,python,gitlab,github,bitbucket,services,workflows]
-CHARTS_TREEISH = main
+CHARTS_TREEISH = lagoon_v222
 TASK_IMAGES = task-activestandby
 
 # the name of the docker network to create

--- a/tests/tests/bulk-deployment/bulk-deployment.yaml
+++ b/tests/tests/bulk-deployment/bulk-deployment.yaml
@@ -131,6 +131,14 @@
   tasks:
   - ansible.builtin.include_tasks: ../../tasks/api/add-environment.yaml
 
+- name: "{{ testname }} - wait for 30 seconds to give all projects time to create"
+  hosts: localhost
+  serial: 1
+  vars:
+    seconds: "30"
+  tasks:
+  - ansible.builtin.include_tasks: ../../tasks/pause.yaml
+
 - name: "{{ testname }} - Trigger bulk deployment"
   hosts: localhost
   serial: 1


### PR DESCRIPTION
this switches Lagoon to use the upcoming 2.22 branch from the charts for a more complete run.