### PR TITLE
fix: use api-db for project and org group attributes instead of keycloak

### DIFF
--- a/services/api/src/resources/group/helpers.ts
+++ b/services/api/src/resources/group/helpers.ts
@@ -7,24 +7,24 @@ import { logger } from '../../loggers/logger';
 
 export const Helpers = (sqlClientPool: Pool) => {
     return {
-        selectProjectIdsByGroupIDs: async (groupIds: string[]) => {
+        selectProjectIdsByGroupIDs: async (groupIds: string[]): Promise<number[]> => {
             const projectIdsArray = await query(
                 sqlClientPool,
                 Sql.selectProjectIdsByGroupIDs(groupIds)
             )
             if (projectIdsArray[0]["projectIds"] != null) {
-                const values = projectIdsArray[0]["projectIds"].split(',');
+                const values = projectIdsArray[0]["projectIds"].split(',').map(Number);
                 return values
             }
             return []
         },
-        selectProjectIdsByGroupID: async (groupId: string) => {
+        selectProjectIdsByGroupID: async (groupId: string): Promise<number[]> => {
             const projectIdsArray = await query(
                 sqlClientPool,
                 Sql.selectProjectIdsByGroupID(groupId)
             )
             if (projectIdsArray[0]["projectIds"] != null) {
-                const values = projectIdsArray[0]["projectIds"].split(',');
+                const values = projectIdsArray[0]["projectIds"].split(',').map(Number);
                 return values
             }
             return []
@@ -68,10 +68,24 @@ export const Helpers = (sqlClientPool: Pool) => {
             return []
         },
         selectOrganizationByGroupId: async (groupId: string) => {
-            return await query(
+            const organization = await query(
                 sqlClientPool,
                 Sql.selectOrganizationByGroupId(groupId)
             )
+            if (organization[0] != null) {
+                return organization[0]
+            }
+            return null
+        },
+        selectOrganizationIdByGroupId: async (groupId: string) => {
+            const organization = await query(
+                sqlClientPool,
+                Sql.selectOrganizationByGroupId(groupId)
+            )
+            if (organization[0] != null) {
+                return organization[0].organizationId
+            }
+            return null
         },
         removeProjectFromGroup: async (projectId: number, groupId: string) => {
             await query(
@@ -94,6 +108,17 @@ export const Helpers = (sqlClientPool: Pool) => {
                 await query(
                     sqlClientPool,
                     Sql.addOrganizationToGroup({organizationId, groupId})
+                );
+            } catch (err) {
+                return null
+            }
+        },
+        removeGroupFromOrganization: async (groupId: string) => {
+            try {
+                // delete the reference for the group from the group_organization table
+                await query(
+                    sqlClientPool,
+                    Sql.deleteOrganizationGroup(groupId)
                 );
             } catch (err) {
                 return null

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -394,11 +394,13 @@ export const addProject = async (
   let group;
   let attributes = {
     type: ['project-default-group'],
+    // lagoon-projects and group-lagoon-project-ids attributes are added for legacy reasons only, theses values are stored in the api-db now
     'lagoon-projects': [project.id],
     'group-lagoon-project-ids': [`{${JSON.stringify(`project-${project.name}`)}:[${project.id}]}`]
   };
   // add the organization attribute if this exists
   if (input.organization != null) {
+    // lagoon-organization attribute is added for legacy reasons only, theses values are stored in the api-db now
     attributes['lagoon-organization'] = [input.organization];
   }
   try {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Fixes some functions that were still checking group attributes for projects and organization from keycloak instead of the api database where this information is now stored.

The project and organization attributes being added to groups in keycloak were only done for legacy purposes and will be removed eventually.
