### PR TITLE
chore: add some seed scripts for keycloak

### DIFF
--- a/local-dev/k3d-seed-data/00-populate-kubernetes.gql
+++ b/local-dev/k3d-seed-data/00-populate-kubernetes.gql
@@ -87,21 +87,6 @@ mutation PopulateApi {
     id
   }
 
-  LagoonDemoToGroup: addGroupsToProject(
-    input: {
-      project: {
-        name: "lagoon-demo"
-      }
-      groups: [
-        {
-          name: "lagoon-demo-group"
-        }
-      ]
-    }
-  ) {
-    id
-  }
-
   UserExampleGuestGroup: addUserToGroup(
     input: {
       user: {
@@ -428,6 +413,21 @@ mutation PopulateApi {
       productionEnvironment: "main"
       problemsUi: 1
       factsUi: 1
+    }
+  ) {
+    id
+  }
+
+  LagoonDemoToGroup: addGroupsToProject(
+    input: {
+      project: {
+        name: "lagoon-demo"
+      }
+      groups: [
+        {
+          name: "lagoon-demo-group"
+        }
+      ]
     }
   ) {
     id

--- a/local-dev/k3d-seed-data/configure-webauthn.sh
+++ b/local-dev/k3d-seed-data/configure-webauthn.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+CONFIG_PATH=/tmp/kcadm.config
+/opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --user $KEYCLOAK_ADMIN_USER --password $KEYCLOAK_ADMIN_PASSWORD --realm master
+
+if [ "$(/opt/keycloak/bin/kcadm.sh get authentication/flows -r "lagoon" --fields id,alias --config $CONFIG_PATH | jq -r '.[] | select(.alias==("Browser-Webauthn")) | .id')" == "" ]; then
+    echo "Creating browser flow for webauthn"
+    /opt/keycloak/bin/kcadm.sh create authentication/flows -r "lagoon" -s alias="Browser-Webauthn" -s providerId=basic-flow -s topLevel=true -s builtIn=false --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn/executions/execution -i -b '{"provider" : "auth-cookie"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' -r "lagoon" --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn/executions/execution -i -b '{"provider" : "auth-spnego"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"DISABLED"}' -r "lagoon" --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn/executions/execution -i -b '{"provider" : "identity-provider-redirector"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' -r "lagoon" --config $CONFIG_PATH
+
+    FLOW_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn/executions/flow -i -r "lagoon" -b '{"alias" : "Browser-Webauthn-Forms" , "type" : "basic-flow"}' --config $CONFIG_PATH)
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh get authentication/flows/Browser-Webauthn/executions -r "lagoon" --fields id,flowId,alias --config $CONFIG_PATH | jq -r '.[] | select(.flowId==("'"$FLOW_ID"'")) | .id')
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn/executions -r "lagoon" -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Forms/executions/execution -i -b '{"provider" : "auth-username-password-form"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Forms/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"REQUIRED"}' -r "lagoon" --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Forms/executions/execution -i -b '{"provider" : "webauthn-authenticator"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Forms/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' -r "lagoon" --config $CONFIG_PATH
+
+    FLOW_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Forms/executions/flow -i -r "lagoon" -b '{"alias" : "Browser-Webauthn-Conditional2FA" , "type" : "basic-flow"}' --config $CONFIG_PATH)
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh get authentication/flows/Browser-Webauthn-Forms/executions -r "lagoon" --fields id,flowId,alias --config $CONFIG_PATH | jq -r '.[] | select(.flowId==("'"$FLOW_ID"'")) | .id')
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Forms/executions -r "lagoon" -b '{"id":"'"$EXECUTION_ID"'","requirement":"CONDITIONAL"}' --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Conditional2FA/executions/execution -i -b '{"provider" : "conditional-user-configured"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Conditional2FA/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"REQUIRED"}' -r "lagoon" --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Conditional2FA/executions/execution -i -b '{"provider" : "webauthn-authenticator"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Conditional2FA/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' -r "lagoon" --config $CONFIG_PATH
+
+    EXECUTION_ID=$(/opt/keycloak/bin/kcadm.sh create authentication/flows/Browser-Webauthn-Conditional2FA/executions/execution -i -b '{"provider" : "auth-otp-form"}' -r "lagoon" --config $CONFIG_PATH)
+    /opt/keycloak/bin/kcadm.sh update authentication/flows/Browser-Webauthn-Conditional2FA/executions -b '{"id":"'"$EXECUTION_ID"'","requirement":"ALTERNATIVE"}' -r "lagoon" --config $CONFIG_PATH
+
+    echo "Set the realm to use the new webauthn browserflow"
+    /opt/keycloak/bin/kcadm.sh update realms/lagoon -s browserFlow=Browser-Webauthn --config $CONFIG_PATH
+
+    echo "Delete webauthn-register required action, this may report resource not found which is fine to ignore"
+    /opt/keycloak/bin/kcadm.sh delete authentication/required-actions/webauthn-register -r lagoon --config $CONFIG_PATH
+
+    echo "Register webauthn-register required action"
+    /opt/keycloak/bin/kcadm.sh create authentication/register-required-action -r lagoon \
+        -s providerId=webauthn-register \
+        -s name="Webauthn Register" \
+        --config $CONFIG_PATH
+else
+    echo "Browser flow for webauthn already created"
+fi

--- a/local-dev/k3d-seed-data/seed-example-sso.sh
+++ b/local-dev/k3d-seed-data/seed-example-sso.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+CONFIG_PATH=/tmp/kcadm.config
+
+# login to keycloak
+/opt/keycloak/bin/kcadm.sh config credentials \
+  --config $CONFIG_PATH --server http://localhost:8080/auth \
+  --user $KEYCLOAK_ADMIN_USER --password $KEYCLOAK_ADMIN_PASSWORD \
+  --realm master
+
+if /opt/keycloak/bin/kcadm.sh get realms/sso --config $CONFIG_PATH > /dev/null; then
+    echo "Realm sso is already created, skipping"
+    exit 0
+fi
+
+# create the SSO realm
+echo "Creating new sso realm"
+/opt/keycloak/bin/kcadm.sh create realms --config $CONFIG_PATH -s realm=sso -s enabled=true
+
+# Create a user in the SSO realm
+
+echo "Creating user and configuring password for user@sso.example.com"
+/opt/keycloak/bin/kcadm.sh create users -r sso \
+   -s email=user@sso.example.com \
+   -s firstName=sso \
+   -s lastName=user \
+   -s username=sso-user \
+   -s enabled=true \
+   -o --fields id,username \
+   --config $CONFIG_PATH
+
+# Set the password for the SSO user
+/opt/keycloak/bin/kcadm.sh set-password \
+   --config $CONFIG_PATH \
+   --username sso-user \
+   -p user@sso.example.com \
+   --target-realm sso
+
+# create the SSO realm OIDC client
+echo "Creating example client in sso realm"
+echo '{"clientId": "sso-oidc-client", "publicClient": false, "webOrigins": ["*"], "redirectUris": ["*"]}' | /opt/keycloak/bin/kcadm.sh create clients --config $CONFIG_PATH -r sso -f -
+CLIENT_ID=$(/opt/keycloak/bin/kcadm.sh get  -r sso clients?clientId=sso-oidc-client --config $CONFIG_PATH | jq -r '.[0]["id"]')
+echo '{"protocol":"openid-connect","config":{"id.token.claim":"true","access.token.claim":"true","userinfo.token.claim":"true","user.attribute":"lagoon-uid","claim.name":"lagoon.user_id","jsonType.label":"int","multivalued":""},"name":"Lagoon User ID","protocolMapper":"oidc-usermodel-attribute-mapper"}' | /opt/keycloak/bin/kcadm.sh create -r sso clients/$CLIENT_ID/protocol-mappers/models --config $CONFIG_PATH -f -
+/opt/keycloak/bin/kcadm.sh update clients/$CLIENT_ID -s secret=123456789 --config $CONFIG_PATH -r sso
+
+
+# create the IDP in the Lagoon realm linking to the SSO OIDC client
+echo "Creating ssorealm identity provider in lagoon realm"
+/opt/keycloak/bin/kcadm.sh create identity-provider/instances -s enabled=true \
+  -s displayName=ssorealm \
+  -s alias=ssorealm \
+  -s providerId=oidc \
+  -s config.authorizationUrl=${KEYCLOAK_FRONTEND_URL%/}/realms/sso/protocol/openid-connect/auth \
+  -s config.tokenUrl=http://localhost:8080/auth/realms/sso/protocol/openid-connect/token \
+  -s config.logoutUrl=${KEYCLOAK_FRONTEND_URL%/}/realms/sso/protocol/openid-connect/logout \
+  -s config.userInfoUrl=http://localhost:8080/auth/realms/sso/protocol/openid-connect/userinfo \
+  -s config.issuer=${KEYCLOAK_FRONTEND_URL%/}/realms/sso \
+  -s config.validateSignature=true \
+  -s config.pkceEnabled=false \
+  -s config.clientAuthMethod=client_secret_post \
+  -s config.clientId=sso-oidc-client \
+  -s config.clientSecret=123456789 \
+  -s config.metadataDescriptorUrl=http://localhost:8080/auth/realms/sso/.well-known/openid-configuration \
+  -s config.jwksUrl=http://localhost:8080/auth/realms/sso/protocol/openid-connect/certs \
+  -s config.useJwksUrl=true --config $CONFIG_PATH -r lagoon
+
+# create a role mapper that grants any users from the SSO realm as platform-owner
+echo "Configuring ssorealm identity provider with platform-owner role mapping"
+/opt/keycloak/bin/kcadm.sh create identity-provider/instances/ssorealm/mappers \
+   -s name=platform-owner \
+   -s identityProviderMapper=oidc-hardcoded-role-idp-mapper  \
+   -s identityProviderAlias=ssorealm \
+   -s config.syncMode=FORCE \
+   -s config.role=platform-owner \
+    --config $CONFIG_PATH -r lagoon

--- a/local-dev/k3d-seed-data/seed-users.sh
+++ b/local-dev/k3d-seed-data/seed-users.sh
@@ -15,24 +15,24 @@ function configure_user_passwords {
   for i in ${LAGOON_DEMO_USERS[@]}
   do
     echo Configuring password for $i
-    /opt/keycloak/bin/kcadm.sh set-password --config $CONFIG_PATH --username $i -p $i --target-realm Lagoon
+    /opt/keycloak/bin/kcadm.sh set-password --config $CONFIG_PATH --username $i -p $i --target-realm lagoon
   done
 
   for i in ${LAGOON_DEMO_ORG_USERS[@]}
   do
     echo Configuring password for $i
-    /opt/keycloak/bin/kcadm.sh set-password --config $CONFIG_PATH --username $i -p $i --target-realm Lagoon
+    /opt/keycloak/bin/kcadm.sh set-password --config $CONFIG_PATH --username $i -p $i --target-realm lagoon
   done
 }
 
 function configure_platformowner {
   echo Configuring platform owner role
-    /opt/keycloak/bin/kcadm.sh add-roles --uusername platformowner@example.com --rolename platform-owner --config $CONFIG_PATH --target-realm Lagoon
+    /opt/keycloak/bin/kcadm.sh add-roles --uusername platformowner@example.com --rolename platform-owner --config $CONFIG_PATH --target-realm lagoon
 }
 
 function configure_platformviewer {
   echo Configuring platform viewer role
-    /opt/keycloak/bin/kcadm.sh add-roles --uusername platformviewer@example.com --rolename platform-viewer --config $CONFIG_PATH --target-realm Lagoon
+    /opt/keycloak/bin/kcadm.sh add-roles --uusername platformviewer@example.com --rolename platform-viewer --config $CONFIG_PATH --target-realm lagoon
 }
 
 function configure_keycloak {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Adds some helper scripts that can be used by the docker-compse stack and also `make k3d/local-stack` for seeding keycloak with a second realm for SSO/IDP and also configuring a browserflow for webauthn support.

These can be useful for testing settings changes with SSO/IDP users and webauthn security keys. 

It is possible to configure a local stack to work with other auth providers than this example one if you wanted to too, this just provides a simple starting point for a basic SSO/IDP implementation.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
