### PR TITLE
docs: move historical releases into archive

### DIFF
--- a/docs/releases/.pages
+++ b/docs/releases/.pages
@@ -2,4 +2,6 @@ title: Releases
 order: desc
 nav:
   - Policy: policy.md
-  - ...
+  - ... | regex=2.(?:1[8-9]|[2-9]\d|[1-9]\d{2,}).*.md
+  - Archived Releases:
+    - ... | **/*.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ nav:
   - Lagoon CLI: https://uselagoon.github.io/lagoon-cli/
   - Lagoon Sync: https://github.com/uselagoon/lagoon-sync
   - Client Libraries: other-tools/client-libraries.md
-- ... | releases/*
+- ... | releases/**
 
 theme:
   name: 'material'


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

I get sick of the releases menu being so large. This moves old releases under an `Archived Releases` menu under releases to make the list a bit easier to look at.
