### PR TITLE
fix: actually set containers for services

### DIFF
--- a/services/actions-handler/handler/controller_builds.go
+++ b/services/actions-handler/handler/controller_builds.go
@@ -206,7 +206,10 @@ func (m *Messenger) handleBuild(ctx context.Context, messageQueue *mq.MessageQue
 			}
 			// then update all the existing services
 			for _, mService := range message.Meta.EnvironmentServices {
-				var containers []schema.ServiceContainerInput
+				containers := []schema.ServiceContainerInput{}
+				for _, sCon := range mService.Containers {
+					containers = append(containers, schema.ServiceContainerInput(sCon))
+				}
 				s2add := schema.AddEnvironmentServiceInput{EnvironmentID: environmentID, Name: mService.Name, Type: mService.Type, Containers: containers}
 				// add or update it
 				setServices, err := lagoon.AddOrUpdateEnvironmentService(ctx, s2add, l)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Small fix for the environment services when the v1beta2 version of remote controller sends the newer environment services data. This actually sets the containers in the input when updating the services.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->