### PR TITLE
fix: api-sidecar-handler returns newlines in ssh key data

### DIFF
--- a/services/api-sidecar-handler/internal/server/validate.go
+++ b/services/api-sidecar-handler/internal/server/validate.go
@@ -85,7 +85,7 @@ func validatePrivateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sshPubKey := ssh.MarshalAuthorizedKey(signer.PublicKey())
-	resp.PublicKey = string(sshPubKey)
+	resp.PublicKey = strings.TrimSpace(string(sshPubKey))
 	pub, _, _, _, err := ssh.ParseAuthorizedKey(sshPubKey)
 	if err != nil {
 		resp.Error = err.Error()
@@ -96,7 +96,7 @@ func validatePrivateKey(w http.ResponseWriter, r *http.Request) {
 	resp.SHA256Fingerprint = ssh.FingerprintSHA256(pub)
 	resp.MD5Fingerprint = ssh.FingerprintLegacyMD5(pub)
 	resp.Type = pub.Type()
-	resp.Value = strings.Split(string(sshPubKey), " ")[1]
+	resp.Value = strings.TrimSpace(strings.Split(string(sshPubKey), " ")[1])
 	log.Printf("validated private key with public fingerprint %s", resp.SHA256Fingerprint)
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, resp.String())

--- a/services/api-sidecar-handler/internal/server/validate_test.go
+++ b/services/api-sidecar-handler/internal/server/validate_test.go
@@ -108,7 +108,7 @@ func Test_validatePrivateKey(t *testing.T) {
 			name:       "with private ed25519",
 			method:     http.MethodPost,
 			input:      fmt.Sprintf("key=%s", ed25519Key),
-			want:       `{"publickey":"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAD8E5wfvLg8vvfO9mmHVsZQK8dNgdKM5FrTxL4ORDq66Z50O8zUzBwF1VTO5Zx+qwB7najMdWsnW00BC6PMysSNJQD5HI4CokyKqmGdeSXcROYwvYOjlDQ+jD5qOSmkllRZZnkEYXE5FVBXaZWToyfGUGIoECvKGUQZxkBDHsbK13JdfA==\n","sha256fingerprint":"SHA256:RBRWA2mJFPK/8DtsxVoVzoSShFiuRAzlUBws7cXkwG0","md5fingerprint":"72:86:48:50:59:1b:97:81:21:27:e7:55:98:fa:35:95","type":"ecdsa-sha2-nistp521","value":"AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAD8E5wfvLg8vvfO9mmHVsZQK8dNgdKM5FrTxL4ORDq66Z50O8zUzBwF1VTO5Zx+qwB7najMdWsnW00BC6PMysSNJQD5HI4CokyKqmGdeSXcROYwvYOjlDQ+jD5qOSmkllRZZnkEYXE5FVBXaZWToyfGUGIoECvKGUQZxkBDHsbK13JdfA==\n"}`,
+			want:       `{"publickey":"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAD8E5wfvLg8vvfO9mmHVsZQK8dNgdKM5FrTxL4ORDq66Z50O8zUzBwF1VTO5Zx+qwB7najMdWsnW00BC6PMysSNJQD5HI4CokyKqmGdeSXcROYwvYOjlDQ+jD5qOSmkllRZZnkEYXE5FVBXaZWToyfGUGIoECvKGUQZxkBDHsbK13JdfA==","sha256fingerprint":"SHA256:RBRWA2mJFPK/8DtsxVoVzoSShFiuRAzlUBws7cXkwG0","md5fingerprint":"72:86:48:50:59:1b:97:81:21:27:e7:55:98:fa:35:95","type":"ecdsa-sha2-nistp521","value":"AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAD8E5wfvLg8vvfO9mmHVsZQK8dNgdKM5FrTxL4ORDq66Z50O8zUzBwF1VTO5Zx+qwB7najMdWsnW00BC6PMysSNJQD5HI4CokyKqmGdeSXcROYwvYOjlDQ+jD5qOSmkllRZZnkEYXE5FVBXaZWToyfGUGIoECvKGUQZxkBDHsbK13JdfA=="}`,
 			statusCode: http.StatusOK,
 		},
 		{

--- a/services/api/database/migrations/20241119031013_trim_sshkeys.js
+++ b/services/api/database/migrations/20241119031013_trim_sshkeys.js
@@ -1,0 +1,18 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex('ssh_key').update({
+    key_value: knex.raw("REPLACE(key_value, '\n', '')")
+  })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  // Nothing to do
+  return knex.schema
+};


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

A new API was added in https://github.com/uselagoon/lagoon/pull/3662 that handles public/private key pair cryptography. This API returns newlines in key values, which break parts of Lagoon that does key matching.

This PR removes the newlines from the API response and runs a database migration to clean up any existing newlines.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
