### PR TITLE
refactor: lowercase email address search to match keycloak

### DIFF
--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -532,7 +532,7 @@ export const addUserToGroup: ResolverFn = async (
   let createUserErr;
   try {
     // check if user already exists
-    user = await models.UserModel.loadUserByIdOrUsername({
+    user = await models.UserModel.loadUserByIdOrEmail({
       id: R.prop('id', userInput),
       email: R.prop('email', userInput)
     });
@@ -568,7 +568,7 @@ export const addUserToGroup: ResolverFn = async (
           return e
         }
       } else if (createUserErr) {
-        // otherwise return whatever error loadUserByIdOrUsername returned
+        // otherwise return whatever error loadUserByIdOrEmail returned
         return createUserErr
       }
     }
@@ -580,7 +580,7 @@ export const addUserToGroup: ResolverFn = async (
       // otherwise return the error
       throw new Error('Cannot invite user to group that is not in an organization');
     } else if (createUserErr) {
-      // otherwise return whatever error loadUserByIdOrUsername returned
+      // otherwise return whatever error loadUserByIdOrEmail returned
       return createUserErr
     }
   }
@@ -615,7 +615,7 @@ export const removeUserFromGroup: ResolverFn = async (
     throw new Error('You must provide a user id or email');
   }
 
-  const user = await models.UserModel.loadUserByIdOrUsername({
+  const user = await models.UserModel.loadUserByIdOrEmail({
     id: R.prop('id', userInput),
     email: R.prop('email', userInput)
   });

--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -429,7 +429,7 @@ export const getUserByEmailAndOrganizationId: ResolverFn = async (
   });
 
   try {
-    const user = await models.UserModel.loadUserByUsername(email);
+    const user = await models.UserModel.loadUserByEmail(email);
     const queryUserGroups = await models.UserModel.getAllGroupsForUser(user.id, organization);
 
     user.owner = false
@@ -945,7 +945,7 @@ export const removeUserFromOrganizationGroups: ResolverFn = async (
     throw new Error('You must provide a user id or email');
   }
 
-  const user = await models.UserModel.loadUserByIdOrUsername({
+  const user = await models.UserModel.loadUserByIdOrEmail({
     id: R.prop('id', userInput),
     email: R.prop('email', userInput)
   });

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -583,7 +583,7 @@ export const deleteProject: ResolverFn = async (
 
   // Remove the default user
   try {
-    const user = await models.UserModel.loadUserByUsername(
+    const user = await models.UserModel.loadUserByEmail(
       `default-user@${project.name}`
     );
     await models.UserModel.deleteUser(user.id);
@@ -740,7 +740,7 @@ export const updateProject: ResolverFn = async (
             keyFingerprint: keyPair.fingerprint
           })
         );
-        const user = await models.UserModel.loadUserByUsername(
+        const user = await models.UserModel.loadUserByEmail(
           `default-user@${oldProject.name}`
         );
         await query(
@@ -857,7 +857,7 @@ export const updateProject: ResolverFn = async (
     }
 
     try {
-      const user = await models.UserModel.loadUserByUsername(
+      const user = await models.UserModel.loadUserByEmail(
         `default-user@${oldProject.name}`
       );
       await models.UserModel.updateUser({

--- a/services/api/src/resources/sshKey/resolvers.ts
+++ b/services/api/src/resources/sshKey/resolvers.ts
@@ -44,7 +44,7 @@ export const addSshKey: ResolverFn = async (
     throw new Error('Invalid SSH key format! Please verify keyType + keyValue');
   }
 
-  const user = await models.UserModel.loadUserByIdOrUsername({
+  const user = await models.UserModel.loadUserByIdOrEmail({
     id: R.prop('id', userInput),
     email: R.prop('email', userInput)
   });


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

Creating a user in Lagoon with an uppercase email address ends up with Keycloak saving/storing it as lowercase. If a user then tries to query Lagoon for this user using the uppercase email, the Keycloak lookup fails because it does not match the lowercase saved email.

Keycloak saves all email addresses and usernames as lowercase when users are created, even if the provided email address contains uppercase. Confusingly though, it still respects case sensitivity in the API query params when doing lookups. It appears Keycloak have chosen to do this for some reason, probably for consistency, and there isn't any feature or parameter to change this behaviour.

There are numerous github issues and stack overflow posts where people have encountered issues with needing uppercase usernames or email address in Keycloak with no real clear indication if it can be changed. 

While the mailbox local part of an email address should be case sensitive per RFC 5321 2.3.11 and 2.4, however, the majority of email service providers will ignore this to reduce confusion. For example, `User@example.com` and `user@example.com` according to RFC should be treated as different mailboxes.

The simplest solution for us is to just make sure we lowercase email addresses when we're performing user lookups against Keycloak, which is what this pull request does.

Additionally, I've renamed some of the user lookup functions to better suit their use, and also updated the `allUser` query to be more efficient when filtering on an email address or user ID by only looking up the requested filter query.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

