### PR TITLE
Update RabbitMQ to 3.13 on broker

### DIFF
--- a/services/broker/Dockerfile
+++ b/services/broker/Dockerfile
@@ -1,7 +1,7 @@
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest} AS commons
-FROM rabbitmq:3.12.14-management-alpine
+FROM rabbitmq:3.13.7-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
       gojq \
       curl
 
-RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez \
+RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez \
     && chown rabbitmq:rabbitmq /plugins/rabbitmq_delayed_message_exchange-*
 
 # override sticky bit set in upstream whilst we still ep the files in /etc/rabbitmq

--- a/services/broker/enable-feature-flags.sh
+++ b/services/broker/enable-feature-flags.sh
@@ -19,9 +19,9 @@ until is_broker_running; do
 done
 
 echo enabling any disabled feature flags
-for feature in $(curl -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" "http://${SERVICE_NAME}:15672/api/feature-flags/" | gojq -r '.[] | select(.state=="disabled") | .name'); do
+for feature in $(curl -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" "http://${SERVICE_NAME}:15672/api/feature-flags/" | gojq -r '.[] | select(.state=="disabled" and .stability!="experimental") | .name'); do
   echo " - enabling ${feature}"
-  curl -X PUT --header "Content-Type: application/json" -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" -d '{"name":"'${feature}'"}' http://${SERVICE_NAME}:15672/api/feature-flags/${feature}/enable
+  curl -X PUT --header "Content-Type: application/json" -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" -d '{"name":"'${feature}'"}' "http://${SERVICE_NAME}:15672/api/feature-flags/${feature}/enable"
 done
 
 echo all feature flags enabled


### PR DESCRIPTION
Note that 3.13 includes an experimental feature flag for Khepri, which is not compatible with the management plugin, or upgradeable to Rabbit 4.x - so I've added logic to the feature flag enabler to ignore experimental FFs.