### PR TITLE
build: correct path in local-git for entrypoint

### DIFF
--- a/local-dev/git/entrypoint.sh
+++ b/local-dev/git/entrypoint.sh
@@ -6,4 +6,4 @@ fi
 
 ls -d -- git/*
 
-exec /sbin/runsvdir /etc/service
+exec /usr/sbin/runsvdir /etc/service


### PR DESCRIPTION
Alpine 3.21 changed the path for some utility packages previously under /sbin to /usr/sbin - and the one we use is in the local-git image entrypoint