### PR TITLE
chore: add a timeout to the arm build retry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,9 @@ pipeline {
         sh script: "make -j$NPROC -O build", label: "Building images"
         sh script: 'make go/test'
         retry(3) {
-          sh script: "make -j$NPROC -O build PLATFORM_ARCH=linux/arm64", label: "Building arm images"
+          timeout(time: 15, unit: 'MINUTES') {
+            sh script: "make -j$NPROC -O build PLATFORM_ARCH=linux/arm64", label: "Building arm images"
+          }
         }
         retry(3) {
           sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Just add a timeout wrapper around the arm build logic to prevent blocking

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
