### PR TITLE
test: simulate an upgrade in ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,9 @@ pipeline {
           steps {
             sh script: "make local-dev-tools", label: "Configure k3d"
             sh script: "./local-dev/k3d cluster delete --all", label: "Delete any remnant clusters"
-            sh script: "make k3d/test TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Setup cluster and run nginx smoketest"
+            sh script: "make k3d/stable-local-stack INSTALL_SEED_DATA=false BRANCH_NAME=${SAFEBRANCH_NAME} LAGOON_CORE_USE_HTTPS=false", label: "Setup stable cluster"
+            sh script: "make k3d/retest TESTS=[nginx] BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Run nginx smoketest"
+            sh script: "make k3d/install-lagoon BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Run lagoon upgrade"
             sh script: "pkill -f './local-dev/stern'", label: "Closing off test-suite-0 log after test completion"
             // script {
             //   skipRemainingStages = true

--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -131,6 +131,26 @@ make k3d/local-stack INSTALL_POSTGRES_PROVIDER=false  INSTALL_MONGODB_PROVIDER=f
 !!! info
     If you're using an arm64 based operating system (MacOS M* for example), then `INSTALL_MONGODB_PROVIDER` will always be set to `false`, this is because there are some issues due to MongoDB not working properly.
 
+#### Build-deploy-image version
+
+By default, the image used will be `uselagoon/build-deploy-image:edge`. This image will be pulled, and then re-tagged and pushed into the registry that is deployed as part of the local-stack.
+
+If you want to run a custom version of the [build-deploy-tool](https://github.com/uselagoon/build-deploy-tool) in a local-stack, you can checkout the build-deploy-tool repo, work on your changes and use `make docker-build` in that repository to build the image. Then in the local-stack repository use `make k3d/push-local-build-image` to push it to the local-stack registry.
+
+```bash title="Change build-deploy-image to a working local version"
+# in `uselagoon/build-deploy-tool` branch
+make docker-build
+
+# in `uselagoon/lagoon` branch
+make k3d/push-local-build-image
+```
+
+To change back to the default image you can use `make k3d/push-stable-build-image`. This target also supports using `BUILD_DEPLOY_IMAGE_REPO` and `BUILD_DEPLOY_IMAGE_TAG` variables, allowing you to push any other image from other repositories and tags.
+
+```bash title="Change build-deploy-image to a specific tag"
+make k3d/push-stable-build-image BUILD_DEPLOY_IMAGE_TAG=pr-123
+```
+
 #### Stable chart installation and upgrading chart versions
 
 It is possible to run the local-stack as it would be directly from a stable chart version.

--- a/local-dev/k3d-seed-data/00-populate-kubernetes.gql
+++ b/local-dev/k3d-seed-data/00-populate-kubernetes.gql
@@ -5,7 +5,7 @@ mutation PopulateApi {
     input: {
       id: 2001
       name: "ci-local-control-k8s"
-      consoleUrl: "https://localhost:8443/"
+      consoleUrl: "${CONSOLE_URL}"
       routerPattern: "${ROUTER_PATTERN}.nip.io"
       sshHost: "${SSH_PORTAL_HOST}"
       sshPort: "${SSH_PORTAL_PORT}"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The purpose of this is to install the latest stable release, and then perform an upgrade to the version in branch. This helps to validate if changes to Lagoon in either core, or the charts will cause a failure of an upgrade.

The process is to firstly install the latest stable release using the following (some extra options which may change with #3860)
```
make k3d/stable-local-stack
```
This will set up the k3d cluster, install the prerequisite components (ingress, harbor, etc) and then install the latest lagoon charts release versions (core, remote, build-deploy)

Once that is running, perform the upgrade using the following
```
make k3d/install-lagoon
```
This will just re-install, or upgrade, the core, remote, and build-deploy charts from the source repositories.

Also updated to allow for overriding the build-deploy-image without having to set the `buildImage` in the API. The `build-deploy-image` is now pulled and then pushed into the registry that is deployed as part of the local-stack and there are new make commands that can be used to push a different image into the registry to override it as required. This will hopefully allow for easier development and testing of build-deploy-images locally.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
