### PR TITLE
feat: built-in audit logging

### DIFF
--- a/node-packages/commons/src/types.ts
+++ b/node-packages/commons/src/types.ts
@@ -34,6 +34,30 @@ export enum TaskSourceType {
   API = 'api'
 }
 
+export enum AuditSourceType {
+  API = 'api',
+  CLI = 'cli',
+  UI = 'ui'
+}
+
+export enum AuditType {
+  BACKUP = 'backup',
+  BULKDEPLOYMENT = 'bulkdeployment',
+  DEPLOYMENT = 'deployment',
+  DEPLOYTARGET = 'deploytarget',
+  DEPLOYTARGETCONFIG = 'deploytargetconfig',
+  ENVIRONMENT = 'environment',
+  GROUP = 'group',
+  NOTIFICATION = 'notification',
+  ORGANIZATION = 'organization',
+  PROJECT = 'project',
+  SSHKEY = 'sshkey',
+  TASK = 'task',
+  USER = 'user',
+  VARIABLE = 'variable',
+  WORKFLOW = 'workflow',
+}
+
 export interface DeployData {
   baseBranchName?: string,
   baseSha?: string,

--- a/services/api/database/migrations/20250218000000_audit_log.js
+++ b/services/api/database/migrations/20250218000000_audit_log.js
@@ -1,0 +1,38 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+    organizations = await knex.schema.hasTable('audit_log');
+    if (!organizations) {
+        return knex.schema
+        .createTable('audit_log', function (table) {
+            table.increments('id').notNullable().primary();
+            table.specificType('usid', 'CHAR(36)'); // will be uuid from keycloak
+            table.string('email_address', 300);
+            table.specificType('resource_id', 'CHAR(36)'); // could be uuid (group/user) or int (project/env/org)
+            table.enu('resource_type', ['backup', 'bulkdeployment', 'deployment', 'deploytarget', 'deploytargetconfig', 'environment', 'group', 'notification', 'organization', 'project', 'sshkey', 'task', 'user', 'variable','workflow']);
+            table.string('resource_details', 300);
+            table.specificType('linked_resource_id', 'CHAR(36)'); // could be uuid (group/user) or int (project/env/org)
+            table.enu('linked_resource_type', ['backup', 'bulkdeployment', 'deployment', 'deploytarget', 'deploytargetconfig', 'environment', 'group', 'notification', 'organization', 'project', 'sshkey', 'task', 'user', 'variable','workflow']);
+            table.string('linked_resource_details', 300);
+            table.string('audit_event', 300);
+            table.specificType('impersonator_id', 'CHAR(36)'); // will be uuid from keycloak
+            table.string('impersonator_username', 300);
+            table.string('ip_address', 300);
+            table.enu('source', ['api','cli','ui']);
+            table.datetime('created').notNullable().defaultTo(knex.fn.now());
+        })
+    }
+    else {
+        return knex.schema
+    }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    return knex.schema
+};

--- a/services/api/src/loggers/lagoonLogsTransport.ts
+++ b/services/api/src/loggers/lagoonLogsTransport.ts
@@ -1,6 +1,11 @@
 import Transport = require('winston-transport');
 import { sendToLagoonLogs } from '@lagoon/commons/dist/logs/lagoon-logger';
 import { parseAndCleanMeta } from './userActivityLogger';
+import { Sql } from '../resources/audit/sql';
+import { sqlClientPool } from '../clients/sqlClient';
+import { query } from '../util/db';
+import { logger } from './logger';
+import { AuditSourceType } from '@lagoon/commons/dist/types';
 
 export class LagoonLogsTransport extends Transport {
     constructor(options) {
@@ -34,6 +39,41 @@ export class LagoonLogsTransport extends Transport {
       const lagoonLogsPayload = this.parseLagoonLogsPayload(info);
       setImmediate(() => this.emit('logged', lagoonLogsPayload));
 
+      // USER ACTIVITY AUDIT LOGGING
+      // only authenticated access_token requests, not internal tokens (aka legacy tokens)
+      // saving internal tokens to the event log would result in massive amounts of logged data
+      // ideally LEGACY_EXPIRY_MAX and LEGACY_EXPIRY_REJECT are tuned to ensure use of legacy tokens is useless outside
+      // of internal systems
+      if (info.event && info.event != "api:unknownEvent" && info.payload.resource && info.user.access_token) {
+        // try and determine the user request from headers, fall back to api
+        const requestSource = info.headers['referer'] ? AuditSourceType.UI : info.headers['user-agent'].includes("lagoon-client") ? AuditSourceType.CLI : AuditSourceType.API
+        const aLog = {
+          usid: info.user.access_token.content.sub,
+          emailAddress: info.user.access_token ? info.user.access_token.content.email : info.user.iss,
+          resourceId: info.payload.resource?.id || null,
+          resourceType: info.payload.resource.type,
+          resourceDetails: info.payload.resource.details,
+          ipAddress: info.headers?.ipAddress || "null",
+          linkedResourceId: info.payload.linkedResource?.id || null,
+          linkedResourceType: info.payload.linkedResource?.type || null,
+          linkedResourceDetails: info.payload.linkedResource?.details || null,
+          impersonatorId: info.user.access_token.content.impersonator ? info.user.access_token.content.impersonator.id : null,
+          impersonatorUsername: info.user.access_token.content.impersonator ? info.user.access_token.content.impersonator.username : null,
+          source: requestSource,
+          auditEvent: `${info.event}`,
+        }
+        try {
+          // save the log
+          query(
+            sqlClientPool,
+            Sql.insertAuditLog(aLog)
+          );
+        } catch (err) {
+          logger.warn(`unable to save auditlog ${JSON.stringify(aLog)}`)
+        }
+      }
+
+      // all user activity logs including legacy tokens are still shipped to the lagoon-logs queue
       sendToLagoonLogs(
         lagoonLogsPayload.severity,
         lagoonLogsPayload.project,

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -27,6 +27,10 @@ const {
   getEnvironmentsByFactSearch,
 } = require('./resources/fact/resolvers');
 
+const {
+  getAuditLogs,
+} = require('./resources/audit/resolvers');
+
 const { SeverityScoreType } = require('./resources/problem/types');
 
 const { getLagoonVersion } = require('./resources/lagoon/resolvers');
@@ -300,6 +304,28 @@ const {
 
 const resolvers = {
   Upload: GraphQLUpload,
+  AuditType: {
+    BACKUP: 'backup',
+    BULKDEPLOYMENT: 'bulkdeployment',
+    DEPLOYMENT: 'deployment',
+    DEPLOYTARGET: 'deploytarget',
+    DEPLOYTARGETCONFIG: 'deploytargetconfig',
+    ENVIRONMENT: 'environment',
+    GROUP: 'group',
+    NOTIFICATION: 'notification',
+    ORGANIZATION: 'organization',
+    PROJECT: 'project',
+    SSHKEY: 'sshkey',
+    TASK: 'task',
+    USER: 'user',
+    VARIABLE: 'variable',
+    WORKFLOW: 'workflow',
+  },
+  AuditSource: {
+    API: 'api',
+    CLI: 'cli',
+    UI: 'ui',
+  },
   GroupRole: {
     GUEST: 'guest',
     REPORTER: 'reporter',
@@ -593,6 +619,7 @@ const resolvers = {
     getEnvVariablesByProjectEnvironmentName,
     checkBulkImportProjectsAndGroupsToOrganization,
     allPlatformUsers: getAllPlatformUsers,
+    getAuditLogs,
   },
   Mutation: {
     addProblem,

--- a/services/api/src/resources/audit/resolvers.ts
+++ b/services/api/src/resources/audit/resolvers.ts
@@ -1,0 +1,82 @@
+import * as R from 'ramda';
+import { ResolverFn } from '../';
+import { knex, query } from '../../util/db';
+
+
+export const getAuditLogs: ResolverFn = async (
+  root,
+  { input },
+  { sqlClientPool, hasPermission }
+) => {
+  await hasPermission('project', 'viewAll');
+
+  let queryBuilder = knex('audit_log');
+
+  if (input && input.userId) {
+    queryBuilder = queryBuilder.where('usid', input.userId);
+  }
+
+  if (input && input.emailAddress) {
+    queryBuilder = queryBuilder.where('email_address', input.emailAddress);
+  }
+
+  if (input && input.resourceId) {
+    queryBuilder = queryBuilder.where('resource_id', input.resourceId);
+  }
+
+  if (input && input.resourceType) {
+    queryBuilder = queryBuilder.where('resource_type', input.resourceType);
+  }
+
+  if (input && input.resourceDetails) {
+    queryBuilder = queryBuilder.where('resource_details','LIKE',`%${input.resourceDetails}%`);
+  }
+
+  if (input && input.linkedResourceId) {
+    queryBuilder = queryBuilder.where('linked_resource_id', input.linkedResourceId);
+  }
+
+  if (input && input.linkedResourceType) {
+    queryBuilder = queryBuilder.where('linked_resource_type', input.linkedResourceType);
+  }
+
+  if (input && input.linkedResourceDetails) {
+    const l =
+    queryBuilder = queryBuilder.where('linked_resource_details','LIKE',`%${input.linkedResourceDetails}%`);
+  }
+
+  if (input && input.auditEvent) {
+    queryBuilder = queryBuilder.where('audit_event', input.auditEvent);
+  }
+
+  if (input && input.impersonatorId) {
+    queryBuilder = queryBuilder.where('impersonator_id', input.impersonatorId);
+  }
+
+  if (input && input.impersonatorUsername) {
+    queryBuilder = queryBuilder.where('impersonator_username', input.impersonatorUsername);
+  }
+
+  if (input && input.ipAddress) {
+    queryBuilder = queryBuilder.where('ip_address', input.ipAddress);
+  }
+
+  if (input && input.source) {
+    queryBuilder = queryBuilder.where('source', input.source);
+  }
+
+  if (input && input.startDate) {
+    queryBuilder = queryBuilder.where('created', '>=', input.startDate);
+  }
+
+  if (input && input.endDate) {
+    queryBuilder = queryBuilder.where('created', '<=', input.endDate);
+  }
+
+  if (input && input.order) {
+    queryBuilder = queryBuilder.orderBy(input.order);
+  }
+
+  const rows = await query(sqlClientPool, queryBuilder.toString());
+  return rows
+};

--- a/services/api/src/resources/audit/resolvers.ts
+++ b/services/api/src/resources/audit/resolvers.ts
@@ -12,69 +12,88 @@ export const getAuditLogs: ResolverFn = async (
 
   let queryBuilder = knex('audit_log');
 
-  if (input && input.userId) {
-    queryBuilder = queryBuilder.where('usid', input.userId);
+  // default results limit to 100
+  let limit = 100;
+
+  if (input) {
+    if (input.startDate) {
+      queryBuilder = queryBuilder.where('created', '>=', input.startDate);
+    }
+
+    if (input.endDate) {
+      queryBuilder = queryBuilder.where('created', '<=', input.endDate);
+    }
+
+    if (input.startDate && input.endDate) {
+      // if a date range is requested, don't limit the results
+      limit = 0;
+    }
+
+    // limit could be 0
+    if (input.limit != undefined) {
+      limit = input.limit;
+    }
+
+    if (input.userId) {
+      queryBuilder = queryBuilder.where('usid', input.userId);
+    }
+
+    if (input.emailAddress) {
+      queryBuilder = queryBuilder.where('email_address', input.emailAddress);
+    }
+
+    if (input.resourceId) {
+      queryBuilder = queryBuilder.where('resource_id', input.resourceId);
+    }
+
+    if (input.resourceType) {
+      queryBuilder = queryBuilder.where('resource_type', input.resourceType);
+    }
+
+    if (input.resourceDetails) {
+      queryBuilder = queryBuilder.where('resource_details','LIKE',`%${input.resourceDetails}%`);
+    }
+
+    if (input.linkedResourceId) {
+      queryBuilder = queryBuilder.where('linked_resource_id', input.linkedResourceId);
+    }
+
+    if (input.linkedResourceType) {
+      queryBuilder = queryBuilder.where('linked_resource_type', input.linkedResourceType);
+    }
+
+    if (input.linkedResourceDetails) {
+      queryBuilder = queryBuilder.where('linked_resource_details','LIKE',`%${input.linkedResourceDetails}%`);
+    }
+
+    if (input.auditEvent) {
+      queryBuilder = queryBuilder.where('audit_event', input.auditEvent);
+    }
+
+    if (input.impersonatorId) {
+      queryBuilder = queryBuilder.where('impersonator_id', input.impersonatorId);
+    }
+
+    if (input.impersonatorUsername) {
+      queryBuilder = queryBuilder.where('impersonator_username', input.impersonatorUsername);
+    }
+
+    if (input.ipAddress) {
+      queryBuilder = queryBuilder.where('ip_address', input.ipAddress);
+    }
+
+    if (input.source) {
+      queryBuilder = queryBuilder.where('source', input.source);
+    }
+
+    if (input.order) {
+      queryBuilder = queryBuilder.orderBy(input.order);
+    }
   }
 
-  if (input && input.emailAddress) {
-    queryBuilder = queryBuilder.where('email_address', input.emailAddress);
-  }
-
-  if (input && input.resourceId) {
-    queryBuilder = queryBuilder.where('resource_id', input.resourceId);
-  }
-
-  if (input && input.resourceType) {
-    queryBuilder = queryBuilder.where('resource_type', input.resourceType);
-  }
-
-  if (input && input.resourceDetails) {
-    queryBuilder = queryBuilder.where('resource_details','LIKE',`%${input.resourceDetails}%`);
-  }
-
-  if (input && input.linkedResourceId) {
-    queryBuilder = queryBuilder.where('linked_resource_id', input.linkedResourceId);
-  }
-
-  if (input && input.linkedResourceType) {
-    queryBuilder = queryBuilder.where('linked_resource_type', input.linkedResourceType);
-  }
-
-  if (input && input.linkedResourceDetails) {
-    const l =
-    queryBuilder = queryBuilder.where('linked_resource_details','LIKE',`%${input.linkedResourceDetails}%`);
-  }
-
-  if (input && input.auditEvent) {
-    queryBuilder = queryBuilder.where('audit_event', input.auditEvent);
-  }
-
-  if (input && input.impersonatorId) {
-    queryBuilder = queryBuilder.where('impersonator_id', input.impersonatorId);
-  }
-
-  if (input && input.impersonatorUsername) {
-    queryBuilder = queryBuilder.where('impersonator_username', input.impersonatorUsername);
-  }
-
-  if (input && input.ipAddress) {
-    queryBuilder = queryBuilder.where('ip_address', input.ipAddress);
-  }
-
-  if (input && input.source) {
-    queryBuilder = queryBuilder.where('source', input.source);
-  }
-
-  if (input && input.startDate) {
-    queryBuilder = queryBuilder.where('created', '>=', input.startDate);
-  }
-
-  if (input && input.endDate) {
-    queryBuilder = queryBuilder.where('created', '<=', input.endDate);
-  }
-
-  if (input && input.order) {
-    queryBuilder = queryBuilder.orderBy(input.order);
+  // apply the limit if required
+  if (limit > 0) {
+    queryBuilder = queryBuilder.limit(limit);
   }
 
   const rows = await query(sqlClientPool, queryBuilder.toString());

--- a/services/api/src/resources/audit/sql.ts
+++ b/services/api/src/resources/audit/sql.ts
@@ -1,0 +1,33 @@
+import { knex } from '../../util/db';
+
+export interface AuditLog {
+    id?: number;
+    usid: string;
+    emailAddress: string;
+    resourceId?: number;
+    resourceType: string;
+    resourceDetails: string;
+    linkedResourceId?: number;
+    linkedResourceType?: string;
+    linkedResourceDetails?: string;
+    auditEvent: string;
+    ipAddress: string;
+    impersonatorId?: string;
+    impersonatorUsername?: string;
+    created?: string;
+  }
+
+  export const Sql = {
+    insertAuditLog: (auditLog: AuditLog) =>
+      knex('audit_log')
+        .insert(auditLog)
+        .toString(),
+    selectAuditLog: () =>
+      knex('audit_log')
+        .toString(),
+    deleteAuditLog: (id: string) =>
+      knex('audit_log')
+        .where('id', id)
+        .delete()
+        .toString(),
+  };

--- a/services/api/src/resources/audit/types.ts
+++ b/services/api/src/resources/audit/types.ts
@@ -1,0 +1,12 @@
+import { AuditType } from "@lagoon/commons/src/types"
+
+export interface AuditLog {
+    resource: AuditResource
+    linkedResource?: AuditResource
+}
+
+export interface AuditResource {
+    id?: string
+    type: AuditType
+    details?: string
+}

--- a/services/api/src/resources/deploytargetconfig/sql.ts
+++ b/services/api/src/resources/deploytargetconfig/sql.ts
@@ -35,6 +35,11 @@ export const Sql = {
       .select('d.*')
       .where('deploy_target', '=', id)
       .toString(),
+  deleteDeployTargetConfigById: (id: number) =>
+    knex('deploy_target_config')
+      .where('id', id)
+      .del()
+      .toString(),
   insertDeployTargetConfig: ({
     id,
     project,

--- a/services/api/src/resources/env-variables/sql.ts
+++ b/services/api/src/resources/env-variables/sql.ts
@@ -90,6 +90,10 @@ export const Sql = {
         .where('env_vars.environment', '=', environmentId)
         .orderBy('env_vars.name', 'asc')
         .toString(),
+  selectEnvVarById: (id: number) =>
+      knex('env_vars')
+        .where('id', '=', id)
+        .toString(),
   selectPermsForEnvVariable: (id: number) =>
     knex('env_vars')
       .select({ pid: 'project.id' })

--- a/services/api/src/resources/organization/helpers.ts
+++ b/services/api/src/resources/organization/helpers.ts
@@ -10,6 +10,10 @@ export const Helpers = (sqlClientPool: Pool) => {
     const rows = await query(sqlClientPool, Sql.selectOrganization(id));
     return R.prop(0, rows);
   };
+  const getOrganizationByName = async (name: string) => {
+    const rows = await query(sqlClientPool, Sql.selectOrganizationByName(name));
+    return R.prop(0, rows);
+  };
   const getProjectsByOrganizationId = async (id: number) => {
     const rows = await query(sqlClientPool, Sql.selectOrganizationProjects(id));
     return rows;
@@ -67,6 +71,7 @@ export const Helpers = (sqlClientPool: Pool) => {
     getNotificationsForOrganizationId,
     getNotificationsByTypeForOrganizationId,
     getEnvironmentsByOrganizationId,
+    getOrganizationByName,
     getOrganizationByOrganizationInput: async (organizationInput, scope: string, resource: string) => {
       const notEmpty = R.complement(R.anyPass([R.isNil, R.isEmpty]));
       const hasId = R.both(R.has('id'), R.propSatisfies(notEmpty, 'id'));

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -14,7 +14,9 @@ import { Helpers as organizationHelpers } from '../organization/helpers';
 import { Helpers as notificationHelpers } from '../notification/helpers';
 import { Helpers as groupHelpers } from '../group/helpers';
 import { getUserProjectIdsFromRoleProjectIds } from '../../util/auth';
+import { AuditType } from '@lagoon/commons/dist/types';
 import GitUrlParse from 'git-url-parse';
+import { AuditLog, AuditResource } from '../audit/types';
 
 const DISABLE_NON_ORGANIZATION_PROJECT_CREATION = process.env.DISABLE_NON_ORGANIZATION_PROJECT_CREATION || "false"
 
@@ -483,12 +485,20 @@ export const addProject = async (
     }
   }
 
+  const auditLog: AuditLog = {
+    resource: {
+      id: project.id,
+      type: AuditType.PROJECT,
+      details: project.name,
+    },
+  };
   userActivityLogger(`User added a project '${project.name}'`, {
     project: '',
     event: 'api:addProject',
     payload: {
       input,
-      data: project
+      data: project,
+      ...auditLog,
     }
   });
 
@@ -591,13 +601,21 @@ export const deleteProject: ResolverFn = async (
     );
   }
 
+  const auditLog: AuditLog = {
+    resource: {
+      id: project.id,
+      type: AuditType.PROJECT,
+      details: project.name,
+    },
+  };
   userActivityLogger(`User deleted a project '${project.name}'`, {
     project: '',
     event: 'api:deleteProject',
     payload: {
       input: {
         project
-      }
+      },
+      ...auditLog,
     }
   });
 
@@ -900,6 +918,13 @@ export const updateProject: ResolverFn = async (
   //   );
   // }
 
+  const auditLog: AuditLog = {
+    resource: {
+      id: oldProject.id,
+      type: AuditType.PROJECT,
+      details: oldProject.name,
+    },
+  };
   userActivityLogger(`User updated project '${oldProject.name}'`, {
     project: '',
     event: 'api:updateProject',
@@ -931,7 +956,8 @@ export const updateProject: ResolverFn = async (
         organization,
         buildImage,
         sharedBaasBucket
-      }
+      },
+      ...auditLog,
     }
   });
 
@@ -959,6 +985,8 @@ export const removeProjectMetadataByKey: ResolverFn = async (
     }
   }
 
+  const project = await Helpers(sqlClientPool).getProjectById(id);
+
   await query(
     sqlClientPool,
     `UPDATE project
@@ -967,6 +995,13 @@ export const removeProjectMetadataByKey: ResolverFn = async (
     { id, meta_key: `$.${key}` }
   );
 
+  const auditLog: AuditLog = {
+    resource: {
+      id: project.id,
+      type: AuditType.PROJECT,
+      details: project.name,
+    },
+  };
   userActivityLogger(`User removed project metadata key '${key}'`, {
     project: '',
     event: 'api:removeProjectMetadataByKey',
@@ -974,7 +1009,8 @@ export const removeProjectMetadataByKey: ResolverFn = async (
       input: {
         id,
         key
-      }
+      },
+      ...auditLog,
     }
   });
 
@@ -1012,6 +1048,8 @@ export const updateProjectMetadata: ResolverFn = async (
     }
   }
 
+  const project = await Helpers(sqlClientPool).getProjectById(id);
+
   await query(
     sqlClientPool,
     `UPDATE project
@@ -1024,6 +1062,13 @@ export const updateProjectMetadata: ResolverFn = async (
     }
   );
 
+  const auditLog: AuditLog = {
+    resource: {
+      id: project.id,
+      type: AuditType.PROJECT,
+      details: project.name,
+    },
+  };
   userActivityLogger(`User updated project metadata`, {
     project: '',
     event: 'api:updateProjectMetadata',
@@ -1032,7 +1077,8 @@ export const updateProjectMetadata: ResolverFn = async (
         project: id,
         key,
         value
-      }
+      },
+      ...auditLog,
     }
   });
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1250,6 +1250,10 @@ const typeDefs = gql`
     auditEvent: String
     ipAddress: String
     source: AuditSource
+    """
+    Limit number of events returned. Defaults to 100 unless start and end date are defined
+    """
+    limit: Int
   }
 
   input AddDeployTargetConfigInput {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1192,6 +1192,66 @@ const typeDefs = gql`
     deployTargetProjectPattern: String
   }
 
+  type AuditLog {
+    id: Int
+    usid: String
+    emailAddress: String
+    resourceId: String
+    resourceType: AuditType
+    resourceDetails: String
+    linkedResourceId: String
+    linkedResourceType: AuditType
+    linkedResourceDetails: String
+    auditEvent: String
+    impersonatorId: String
+    impersonatorUsername: String
+    ipAddress: String
+    source: AuditSource
+    created: String
+  }
+
+  enum AuditSource {
+    API
+    CLI
+    UI
+  }
+
+  enum AuditType {
+    BACKUP
+    BULKDEPLOYMENT
+    DEPLOYMENT
+    DEPLOYTARGET
+    DEPLOYTARGETCONFIG
+    ENVIRONMENT
+    GROUP
+    NOTIFICATION
+    ORGANIZATION
+    PROJECT
+    SSHKEY
+    TASK
+    USER
+    VARIABLE
+    WORKFLOW
+  }
+
+  input AuditLogInput {
+    startDate: String
+    endDate: String
+    userId: String
+    emailAddress: String
+    impersonatorId: String
+    impersonatorUsername: String
+    resourceType: AuditType
+    resourceDetails: String
+    resourceId: String
+    linkedResourceType: AuditType
+    linkedResourceId: String
+    linkedResourceDetails: String
+    auditEvent: String
+    ipAddress: String
+    source: AuditSource
+  }
+
   input AddDeployTargetConfigInput {
     id: Int
     project: Int!
@@ -1449,6 +1509,7 @@ const typeDefs = gql`
     getEnvVariablesByProjectEnvironmentName(input: EnvVariableByProjectEnvironmentNameInput!): [EnvKeyValue]
     checkBulkImportProjectsAndGroupsToOrganization(input: AddProjectToOrganizationInput!): ProjectGroupsToOrganization
     allPlatformUsers(id: String, email: String, gitlabId: Int, role: PlatformRole): [User]
+    getAuditLogs(input: AuditLogInput): [AuditLog]
   }
 
   type ProjectGroupsToOrganization {

--- a/services/keycloak/lagoon-realm-base-import.json
+++ b/services/keycloak/lagoon-realm-base-import.json
@@ -3226,6 +3226,34 @@
             "claim.name": "lagoon.user_id",
             "jsonType.label": "int"
           }
+        },
+        {
+            "name": "Impersonator User ID",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usersessionmodel-note-mapper",
+            "consentRequired": false,
+            "config": {
+                "user.session.note": "IMPERSONATOR_ID",
+                "introspection.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "impersonator.id",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "Impersonator Username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usersessionmodel-note-mapper",
+            "consentRequired": false,
+            "config": {
+                "user.session.note": "IMPERSONATOR_USERNAME",
+                "introspection.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "impersonator.username",
+                "jsonType.label": "String"
+            }
         }
       ],
       "defaultClientScopes": [
@@ -3281,6 +3309,34 @@
             "claim.name": "lagoon.user_id",
             "jsonType.label": "int"
           }
+        },
+        {
+            "name": "Impersonator User ID",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usersessionmodel-note-mapper",
+            "consentRequired": false,
+            "config": {
+                "user.session.note": "IMPERSONATOR_ID",
+                "introspection.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "impersonator.id",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "Impersonator Username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usersessionmodel-note-mapper",
+            "consentRequired": false,
+            "config": {
+                "user.session.note": "IMPERSONATOR_USERNAME",
+                "introspection.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "impersonator.username",
+                "jsonType.label": "String"
+            }
         }
       ],
       "defaultClientScopes": [

--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -924,6 +924,48 @@ EOF
 EOF
 }
 
+function add_lagoon-ui_impersonator_mappers {
+    local lagoon_ui_client=$(/opt/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=lagoon-ui --config $CONFIG_PATH | jq -r '.[0]["protocolMappers"] | map(select(.name=="Impersonator User ID")) // false')
+    if [ "$lagoon_ui_client" != "[]" ]; then
+        echo "lagoon-ui impersonator mappers already exist"
+        return 0
+    fi
+    local lagoon_ui_clientid=$( /opt/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=lagoon-ui --config $CONFIG_PATH | jq -r '.[0]["id"] // false')
+    /opt/keycloak/bin/kcadm.sh create clients/${lagoon_ui_clientid}/protocol-mappers/models -r lagoon \
+      -s name="Impersonator User ID" \
+      -s protocol="openid-connect" \
+      -s protocolMapper="oidc-usersessionmodel-note-mapper" \
+      -s config='{"user.session.note":"IMPERSONATOR_ID","introspection.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"impersonator.id","jsonType.label":"String"}' \
+       --config $CONFIG_PATH
+    /opt/keycloak/bin/kcadm.sh create clients/${lagoon_ui_clientid}/protocol-mappers/models -r lagoon \
+      -s name="Impersonator Username" \
+      -s protocol="openid-connect" \
+      -s protocolMapper="oidc-usersessionmodel-note-mapper" \
+      -s config='{"user.session.note":"IMPERSONATOR_USERNAME","introspection.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"impersonator.username","jsonType.label":"String"}' \
+       --config $CONFIG_PATH
+}
+
+function add_lagoon-ui-oidc_impersonator_mappers {
+    local lagoon_ui_oidc_client=$(/opt/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=lagoon-ui-oidc --config $CONFIG_PATH | jq -r '.[0]["protocolMappers"] | map(select(.name=="Impersonator User ID")) // false')
+    if [ "$lagoon_ui_oidc_client" != "[]" ]; then
+        echo "lagoon-ui-oidc impersonator mappers already exist"
+        return 0
+    fi
+    local lagoon_ui_oidc_clientid=$( /opt/keycloak/bin/kcadm.sh get -r lagoon clients?clientId=lagoon-ui-oidc --config $CONFIG_PATH | jq -r '.[0]["id"] // false')
+    /opt/keycloak/bin/kcadm.sh create clients/${lagoon_ui_oidc_clientid}/protocol-mappers/models -r lagoon \
+      -s name="Impersonator User ID" \
+      -s protocol="openid-connect" \
+      -s protocolMapper="oidc-usersessionmodel-note-mapper" \
+      -s config='{"user.session.note":"IMPERSONATOR_ID","introspection.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"impersonator.id","jsonType.label":"String"}' \
+       --config $CONFIG_PATH
+    /opt/keycloak/bin/kcadm.sh create clients/${lagoon_ui_oidc_clientid}/protocol-mappers/models -r lagoon \
+      -s name="Impersonator Username" \
+      -s protocol="openid-connect" \
+      -s protocolMapper="oidc-usersessionmodel-note-mapper" \
+      -s config='{"user.session.note":"IMPERSONATOR_USERNAME","introspection.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"impersonator.username","jsonType.label":"String"}' \
+       --config $CONFIG_PATH
+}
+
 ##################
 # Initialization #
 ##################
@@ -978,6 +1020,8 @@ function configure_keycloak {
     add_update_platform_organization_permissions
     lagoon-opensearch-sync_add_view-users_permission
     add_org_env_vars
+    add_lagoon-ui_impersonator_mappers
+    add_lagoon-ui-oidc_impersonator_mappers
 
     # always run last
     sync_client_secrets


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Introduce audit logging that saves events in the API instead of relying on the events being stored in an external logging tool (like opensearch) as they currently are.

They are searchable by date range and other fields (email, user id, event type, resource type, etc..)

Things to consider
* Truncating or ageing out events over time to prevent the table from becoming too large
  * Maybe periodically export to s3 for historical purposes? It could be possible to just dump events from the API, and then manually truncate the table to retain certain date range
  * Maybe #3709 could have some role here in the future to handle configuring the audit log retention policy?