### PR TITLE
docs: fix indent in MySQL docker-compose.yml example

### DIFF
--- a/docs/docker-images/mysql.md
+++ b/docs/docker-images/mysql.md
@@ -49,11 +49,11 @@ This image is prepared to be used on Lagoon. There are therefore some things alr
 		ports:
 			# exposes the port 3306 with a random local port, find it with `docker compose port mariadb 3306`
 			- "3306"
-    environment:
+		environment:
 			# These override the default credentials to match what Drupal is hardwired to expect in Lagoon
-      - MYSQL_DATABASE=drupal
-      - MYSQL_USER=drupal
-      - MYSQL_PASSWORD=drupal
+			- MYSQL_DATABASE=drupal
+			- MYSQL_USER=drupal
+			- MYSQL_PASSWORD=drupal
 		volumes:
 			# mounts a named volume at the default path for MariaDB
 			- db:/var/lib/mysql


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

N/A

# Description

Fixes incorrect indent in docs for MySQL at https://docs.lagoon.sh/docker-images/mysql/

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

N/A