### PR TITLE
chore: fix the reference to the ui in docker-compose stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -115,7 +115,7 @@ services:
   ui:
     # no reason to have this UI run in development mode, so just consume the upstream built image and runtime
     # can now override just the image for the UI and its tag using envvars
-    image: ${UI_IMAGE_REPO:-uselagoon}/ui:${UI_IMAGE_TAG:-main}
+    image: ${UI_IMAGE_REPO:-uselagoon/ui}:${UI_IMAGE_TAG:-main}
     # always pull the image to prevent stale images locally
     pull_policy: always
     environment:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Small fix to the way the `ui` image reference is defined in docker-compose.yml after #3875 went in with a change to the `UI_IMAGE_REPO` variable

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

