### PR TITLE
fix: purge group cache when removing project from organization

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -140,6 +140,7 @@ export interface GroupModel {
   addGroup: (groupInput: Group, projectId?: number, organizationId?: number) => Promise<Group>
   updateGroup: (groupInput: GroupEdit) => Promise<Group>
   deleteGroup: (id: string) => Promise<void>
+  removeGroupFromOrganization: (id: string) => Promise<void>
   addUserToGroup: (user: User, groupInput: GroupInput, roleName: string) => Promise<Group>
   removeUserFromGroup: (user: User, group: Group ) => Promise<Group>
   removeUserFromGroups: (user: User,groups: Group[]) => Promise<void>
@@ -799,6 +800,32 @@ export const Group = (clients: {
     }
   };
 
+  const removeGroupFromOrganization = async (id: string): Promise<void> => {
+    try {
+      // loadSparseGroupByIdOrName doesn't load the attributes, should it?
+      const group = await loadGroupById(id);
+      await updateGroup({
+        id: group.id,
+        name: group.name,
+        attributes: {
+          ...group.attributes,
+          // lagoon-organization attribute is removed for legacy reasons only, theses values are stored in the api-db now
+          "lagoon-organization": [""]
+        }
+      });
+      await groupHelpers(sqlClientPool).removeGroupFromOrganization(id);
+      await purgeGroupCache(group);
+    } catch (err: unknown) {
+      if (err instanceof GroupNotFoundError) {
+        throw err;
+      } else if (err instanceof Error) {
+        throw new Error(`Error removing group ${id} from organization: ${err.message}`);
+      } else {
+        throw err;
+      }
+    }
+  };
+
   const addUserToGroup = async (
     user: User,
     groupInput: GroupInput,
@@ -1149,6 +1176,7 @@ export const Group = (clients: {
     addGroup,
     updateGroup,
     deleteGroup,
+    removeGroupFromOrganization,
     addUserToGroup,
     removeUserFromGroup,
     removeUserFromGroups,

--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -642,19 +642,9 @@ export const removeProjectFromOrganization: ResolverFn = async (
       if (projectGroups[g].attributes["type"] == "project-default-group") {
         // remove all users from the project default group except the `default-user@project`
         await models.GroupModel.removeNonProjectDefaultUsersFromGroup(projectGroups[g], project.name)
-        // update group
-        await models.GroupModel.updateGroup({
-          id: projectGroups[g].id,
-          name: projectGroups[g].name,
-          attributes: {
-            ...projectGroups[g].attributes,
-            // lagoon-organization attribute is removed for legacy reasons only, theses values are stored in the api-db now
-            "lagoon-organization": [""]
-          }
-        });
         // remove the default project group from the group_organization association table
         // when the project is removed from the organization
-        await groupHelpers(sqlClientPool).removeGroupFromOrganization(projectGroups[g].id)
+        await models.GroupModel.removeGroupFromOrganization(projectGroups[g].id);
       } else {
         removeGroups.push(projectGroups[g])
       }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Fixes a bug where when a project is removed from an organization, the cache reference remains for the project default group.

