### PR TITLE
fix: get environment details for auditlog

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -483,16 +483,6 @@ export const updateDeployment: ResolverFn = async (
     project: R.path(['0', 'pid'], permsDeployment)
   });
 
-  if (environment) {
-    const permsEnv = await environmentHelpers(sqlClientPool).getEnvironmentById(
-      environment
-    );
-    // Check access to modify deployment as it will be updated
-    await hasPermission('environment', 'view', {
-      project: permsEnv.project
-    });
-  }
-
   await query(
     sqlClientPool,
     Sql.updateDeployment({
@@ -518,11 +508,15 @@ export const updateDeployment: ResolverFn = async (
 
   pubSub.publish(EVENTS.DEPLOYMENT, deployment);
 
+  const env = await environmentHelpers(sqlClientPool).getEnvironmentById(
+    deployment.environment
+  );
+
   const auditLog: AuditLog = {
     resource: {
-      id: environment.id,
+      id: env.id,
       type: AuditType.ENVIRONMENT,
-      details: environment.name,
+      details: env.name,
     },
     linkedResource: {
       id: id,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The `updateDeployment` mutation audit log incorrectly used an `environment` check which would be an `int` to check for its `id` and `name` which results in a graphql error. Also it removes what seems to be an unnecessary permission check, if you can deploy, you can view.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

