### PR TITLE
chore: add old queue cleanup to broker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - broker:/var/lib/rabbitmq
   broker-ff-enable:
     image: ${IMAGE_REPO:-lagoon}/broker:${IMAGE_REPO_BROKER_TAG:-${IMAGE_REPO_TAG:-latest}}
-    entrypoint: /enable-feature-flags.sh
+    entrypoint: /broker-job.sh
     environment:
       - SERVICE_NAME=broker
     depends_on:

--- a/services/broker/Dockerfile
+++ b/services/broker/Dockerfile
@@ -29,8 +29,10 @@ RUN chmod 0777 /var/lib/rabbitmq /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitm
 COPY definitions.json enabled_plugins rabbitmq.conf /etc/rabbitmq/
 RUN fix-permissions /etc/rabbitmq
 
-COPY start-rabbit.sh enable-feature-flags.sh /
-RUN fix-permissions start-rabbit.sh enable-feature-flags.sh && chmod +x /start-rabbit.sh /enable-feature-flags.sh
+COPY start-rabbit.sh broker-job.sh /
+RUN fix-permissions start-rabbit.sh broker-job.sh && chmod +x /start-rabbit.sh  /broker-job.sh
+# backwards compatible copy to old filename
+RUN cp /broker-job.sh /enable-feature-flags.sh
 
 # Copy the new entrypoint for b/c reasons
 COPY /start-rabbit.sh /cluster-rabbit.sh

--- a/services/broker/broker-job.sh
+++ b/services/broker/broker-job.sh
@@ -2,6 +2,7 @@
 
 # This script needs to be run after a minor version update (or prior to one)
 # to ensure that any disabled feature_flags are correctly enabled.
+# it is run within a helm job when installed via helm
 
 function is_broker_running {
   local http_code=$(curl -s -o /dev/null -w "%{http_code}" -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" "http://${SERVICE_NAME}:15672/api/health/checks/virtual-hosts/")

--- a/services/broker/enable-feature-flags.sh
+++ b/services/broker/enable-feature-flags.sh
@@ -33,3 +33,14 @@ then
 else
   echo " - lagoon-ha policy already removed"
 fi
+
+echo removing unused lagoon-logs queues
+for queue in "workflows" "slack" "rocketchat" "microsoftTeams" "email" "webhook" "s3"; do
+if [[ ! "$(curl -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" "http://${SERVICE_NAME}:15672/api/queues/%2F/lagoon-logs%3A${queue}")" =~ "Object Not Found" ]]
+  then
+    echo " - removing lagoon-logs:${queue} queue"
+    curl -X DELETE -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" "http://${SERVICE_NAME}:15672/api/queues/%2F/lagoon-logs%3A${queue}"
+  else
+    echo " - lagoon-logs:${queue} queue already removed"
+  fi
+done


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Cleans up old queues from the broker. Mostly this is to follow up with the removal of `workflows` but has included all the previously removed service queues.