### PR TITLE
Upgrade keycloak to 26.2.5

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@lagoon/commons": "4.0.0",
-    "@s3pweb/keycloak-admin-client-cjs": "26.1.4",
+    "@s3pweb/keycloak-admin-client-cjs": "26.2.4",
     "@supercharge/request-ip": "^1.1.2",
     "apollo-server-express": "^2.14.2",
     "aws-sdk": "^2.378.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -44,7 +44,7 @@
     "graphql-type-json": "^0.3.0",
     "graphql-upload": "^12.0.0",
     "jsonwebtoken": "^8.0.1",
-    "keycloak-connect": "^5.0.0",
+    "keycloak-connect": "^26.1.1",
     "knex": "^3.0.1",
     "mariadb": "^2.5.2",
     "moment": "^2.24.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -51,7 +51,6 @@
     "morgan": "^1.9.0",
     "mysql": "^2.18.1",
     "newrelic": "^12.5.0",
-    "node-cache": "^5.1.0",
     "ramda": "0.25.0",
     "redis": "^3.0.2",
     "snakecase-keys": "^1.2.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@lagoon/commons": "4.0.0",
-    "@s3pweb/keycloak-admin-client-cjs": "^26.0.0",
+    "@s3pweb/keycloak-admin-client-cjs": "26.1.4",
     "@supercharge/request-ip": "^1.1.2",
     "apollo-server-express": "^2.14.2",
     "aws-sdk": "^2.378.0",

--- a/services/api/src/lib/keycloak-grant-manager.js
+++ b/services/api/src/lib/keycloak-grant-manager.js
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+'use strict'
 
-const URL = require('url');
-const http = require('http');
-const https = require('https');
-const crypto = require('crypto');
-const querystring = require('querystring');
-const Grant = require('keycloak-connect/middleware/auth-utils/grant');
-const Token = require('keycloak-connect/middleware/auth-utils/token');
-var Rotation = require('keycloak-connect/middleware/auth-utils/rotation');
+const URL = require('url')
+const http = require('http')
+const https = require('https')
+const crypto = require('crypto')
+const querystring = require('querystring')
+
+const Grant = require('keycloak-connect/middleware/auth-utils/grant')
+const Token = require('keycloak-connect/middleware/auth-utils/token')
+const Rotation = require('keycloak-connect/middleware/auth-utils/rotation')
 
 /**
  * Construct a grant manager.
@@ -32,14 +33,15 @@ var Rotation = require('keycloak-connect/middleware/auth-utils/rotation');
  * @constructor
  */
 function GrantManager (config) {
-  this.realmUrl = config.realmUrl;
-  this.clientId = config.clientId;
-  this.secret = config.secret;
-  this.publicKey = config.publicKey;
-  this.public = config.public;
-  this.bearerOnly = config.bearerOnly;
-  this.notBefore = 0;
-  this.rotation = new Rotation(config);
+  this.realmUrl = config.realmUrl
+  this.clientId = config.clientId
+  this.secret = config.secret
+  this.publicKey = config.publicKey
+  this.public = config.public
+  this.bearerOnly = config.bearerOnly
+  this.notBefore = 0
+  this.rotation = new Rotation(config)
+  this.verifyTokenAudience = config.verifyTokenAudience
 }
 
 /**
@@ -60,15 +62,15 @@ GrantManager.prototype.obtainDirectly = function obtainDirectly (username, passw
   callback, scopeParam) {
   const params = {
     client_id: this.clientId,
-    username: username,
-    password: password,
+    username,
+    password,
     grant_type: 'password',
     scope: scopeParam || 'openid'
-  };
-  const handler = createHandler(this);
-  const options = postOptions(this);
-  return nodeify(fetch(this, handler, options, params), callback);
-};
+  }
+  const handler = createHandler(this)
+  const options = postOptions(this)
+  return nodeify(fetch(this, handler, options, params), callback)
+}
 
 /**
  * Obtain a grant from a previous interactive login which results in a code.
@@ -92,107 +94,107 @@ GrantManager.prototype.obtainFromCode = function obtainFromCode (request, code, 
   const params = {
     client_session_state: sessionId,
     client_session_host: sessionHost,
-    code: code,
+    code,
     grant_type: 'authorization_code',
     client_id: this.clientId,
     redirect_uri: request.session ? request.session.auth_redirect_uri : {}
-  };
-  const handler = createHandler(this);
-  const options = postOptions(this);
+  }
+  const handler = createHandler(this)
+  const options = postOptions(this)
 
-  return nodeify(fetch(this, handler, options, params), callback);
-};
+  return nodeify(fetch(this, handler, options, params), callback)
+}
 
 GrantManager.prototype.checkPermissions = function obtainPermissions (authzRequest, request, callback) {
   const params = {
     grant_type: 'urn:ietf:params:oauth:grant-type:uma-ticket'
-  };
+  }
 
   if (authzRequest.audience) {
-    params.audience = authzRequest.audience;
+    params.audience = authzRequest.audience
   } else {
-    params.audience = this.clientId;
+    params.audience = this.clientId
   }
 
   if (authzRequest.response_mode) {
-    params.response_mode = authzRequest.response_mode;
+    params.response_mode = authzRequest.response_mode
   }
 
   if (authzRequest.claim_token) {
-    params.claim_token = authzRequest.claim_token;
-    params.claim_token_format = authzRequest.claim_token_format;
+    params.claim_token = authzRequest.claim_token
+    params.claim_token_format = authzRequest.claim_token_format
   }
 
-  const options = postOptions(this);
+  const options = postOptions(this)
 
   if (this.public) {
     if (request.kauth && request.kauth.grant && request.kauth.grant.access_token) {
-      options.headers.Authorization = 'Bearer ' + request.kauth.grant.access_token.token;
+      options.headers.Authorization = 'Bearer ' + request.kauth.grant.access_token.token
     }
   } else {
-    let header = request.headers.authorization;
-    let bearerToken;
+    const header = request.headers.authorization
+    let bearerToken
 
     if (header && (header.indexOf('bearer ') === 0 || header.indexOf('Bearer ') === 0)) {
-      bearerToken = header.substring(7);
+      bearerToken = header.substring(7)
     }
 
     if (!bearerToken) {
       if (request.kauth && request.kauth.grant && request.kauth.grant.access_token) {
-        bearerToken = request.kauth.grant.access_token.token;
+        bearerToken = request.kauth.grant.access_token.token
       } else {
-        return Promise.reject(new Error('No bearer in header'));
+        return Promise.reject(new Error('No bearer in header'))
       }
     }
 
-    params.subject_token = bearerToken;
+    params.subject_token = bearerToken
   }
 
-  let permissions = authzRequest.permissions;
+  let permissions = authzRequest.permissions
 
   if (!permissions) {
-    permissions = [];
+    permissions = []
   }
 
   for (let i = 0; i < permissions.length; i++) {
-    var resource = permissions[i];
-    var permission = resource.id;
+    const resource = permissions[i]
+    let permission = resource.id
 
     if (resource.scopes && resource.scopes.length > 0) {
-      permission += '#';
+      permission += '#'
 
       for (let j = 0; j < resource.scopes.length; j++) {
-        var scope = resource.scopes[j];
+        const scope = resource.scopes[j]
         if (permission.indexOf('#') !== permission.length - 1) {
-          permission += ',';
+          permission += ','
         }
-        permission += scope;
+        permission += scope
       }
     }
 
     if (!params.permission) {
-      params.permission = [];
+      params.permission = []
     }
 
-    params.permission.push(permission);
+    params.permission.push(permission)
   }
 
-  let manager = this;
+  const manager = this
 
-  var handler = (resolve, reject, json) => {
+  const handler = (resolve, reject, json) => {
     try {
       if (authzRequest.response_mode === 'decision' || authzRequest.response_mode === 'permissions') {
-        callback(JSON.parse(json));
+        callback(JSON.parse(json))
       } else {
-        resolve(manager.createGrant(json));
+        resolve(manager.createGrant(json))
       }
     } catch (err) {
-      reject(err);
+      reject(err)
     }
-  };
+  }
 
-  return nodeify(fetch(this, handler, options, params));
-};
+  return nodeify(fetch(this, handler, options, params))
+}
 
 /**
  * Obtain a service account grant.
@@ -200,20 +202,19 @@ GrantManager.prototype.checkPermissions = function obtainPermissions (authzReque
  *
  * This method returns or promise or may optionally take a callback function.
  *
- * @param {Function} [callback] Optional callback, if not using promises.
- * @param {String} [scopeParam]
+ * @param {Function} callback Optional callback, if not using promises.
  */
 GrantManager.prototype.obtainFromClientCredentials = function obtainFromlientCredentials (callback, scopeParam) {
   const params = {
     grant_type: 'client_credentials',
     scope: scopeParam || 'openid',
     client_id: this.clientId
-  };
-  const handler = createHandler(this);
-  const options = postOptions(this);
+  }
+  const handler = createHandler(this)
+  const options = postOptions(this)
 
-  return nodeify(fetch(this, handler, options, params), callback);
-};
+  return nodeify(fetch(this, handler, options, params), callback)
+}
 
 /**
  * Ensure that a grant is *fresh*, refreshing if required & possible.
@@ -234,27 +235,27 @@ GrantManager.prototype.obtainFromClientCredentials = function obtainFromlientCre
  */
 GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callback) {
   if (!grant.isExpired()) {
-    return nodeify(Promise.resolve(grant), callback);
+    return nodeify(Promise.resolve(grant), callback)
   }
 
   if (!grant.refresh_token) {
-    return nodeify(Promise.reject(new Error('Unable to refresh without a refresh token')), callback);
+    return nodeify(Promise.reject(new Error('Unable to refresh without a refresh token')), callback)
   }
 
   if (grant.refresh_token.isExpired()) {
-    return nodeify(Promise.reject(new Error('Unable to refresh with expired refresh token')), callback);
+    return nodeify(Promise.reject(new Error('Unable to refresh with expired refresh token')), callback)
   }
 
   const params = {
     grant_type: 'refresh_token',
     refresh_token: grant.refresh_token.token,
     client_id: this.clientId
-  };
-  const handler = refreshHandler(this, grant);
-  const options = postOptions(this);
+  }
+  const handler = refreshHandler(this, grant)
+  const options = postOptions(this)
 
-  return nodeify(fetch(this, handler, options, params), callback);
-};
+  return nodeify(fetch(this, handler, options, params), callback)
+}
 
 /**
  * Perform live validation of an `access_token` against the Keycloak server.
@@ -265,63 +266,64 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
  * @return {boolean} `false` if the token is invalid, or the same token if valid.
  */
 GrantManager.prototype.validateAccessToken = function validateAccessToken (token, callback) {
-  let t = token;
+  let t = token
   if (typeof token === 'object') {
-    t = token.token;
+    t = token.token
   }
   const params = {
     token: t,
     client_secret: this.secret,
     client_id: this.clientId
-  };
-  const options = postOptions(this, '/protocol/openid-connect/token/introspect');
-  const handler = validationHandler(this, token);
+  }
+  const options = postOptions(this, '/protocol/openid-connect/token/introspect')
+  const handler = validationHandler(this, token)
 
-  return nodeify(fetch(this, handler, options, params), callback);
-};
+  return nodeify(fetch(this, handler, options, params), callback)
+}
 
 GrantManager.prototype.userInfo = function userInfo (token, callback) {
-  const url = this.realmUrl + '/protocol/openid-connect/userinfo';
-  const options = URL.parse(url);
-  options.method = 'GET';
+  const url = this.realmUrl + '/protocol/openid-connect/userinfo'
+  const options = URL.parse(url); // eslint-disable-line
+  options.method = 'GET'
 
-  let t = token;
-  if (typeof token === 'object') t = token.token;
+  let t = token
+  if (typeof token === 'object') t = token.token
 
   options.headers = {
-    'Authorization': 'Bearer ' + t,
-    'Accept': 'application/json',
+    Authorization: 'Bearer ' + t,
+    Accept: 'application/json',
     'X-Client': 'keycloak-nodejs-connect'
-  };
+  }
 
   const promise = new Promise((resolve, reject) => {
     const req = getProtocol(options).request(options, (response) => {
       if (response.statusCode < 200 || response.statusCode >= 300) {
-        return reject(new Error('Error fetching account'));
+        response.destroy()
+        return reject(new Error('Error fetching account'))
       }
-      let json = '';
-      response.on('data', (d) => (json += d.toString()));
+      let json = ''
+      response.on('data', (d) => (json += d.toString()))
       response.on('end', () => {
-        const data = JSON.parse(json);
-        if (data.error) reject(data);
-        else resolve(data);
-      });
-    });
-    req.on('error', reject);
-    req.end();
-  });
+        const data = JSON.parse(json)
+        if (data.error) reject(data)
+        else resolve(data)
+      })
+    })
+    req.on('error', reject)
+    req.end()
+  })
 
-  return nodeify(promise, callback);
-};
+  return nodeify(promise, callback)
+}
 
 GrantManager.prototype.getAccount = function getAccount () {
-  console.error('GrantManager#getAccount is deprecated. See GrantManager#userInfo');
-  return this.userInfo.apply(this, arguments);
-};
+  console.error('GrantManager#getAccount is deprecated. See GrantManager#userInfo')
+  return this.userInfo.apply(this, arguments)
+}
 
 GrantManager.prototype.isGrantRefreshable = function isGrantRefreshable (grant) {
-  return !this.bearerOnly && (grant && grant.refresh_token);
-};
+  return !this.bearerOnly && (grant && grant.refresh_token)
+}
 
 /**
  * Create a `Grant` object from a string of JSON data.
@@ -335,8 +337,8 @@ GrantManager.prototype.isGrantRefreshable = function isGrantRefreshable (grant) 
  * @return {Promise} A promise reoslving a grant.
  */
 GrantManager.prototype.createGrant = function createGrant (rawData) {
-  let grantData = rawData;
-  if (typeof rawData !== 'object') grantData = JSON.parse(grantData);
+  let grantData = rawData
+  if (typeof rawData !== 'object') grantData = JSON.parse(grantData)
 
   const grant = new Grant({
     access_token: (grantData.access_token ? new Token(grantData.access_token, this.clientId) : undefined),
@@ -345,19 +347,19 @@ GrantManager.prototype.createGrant = function createGrant (rawData) {
     expires_in: grantData.expires_in,
     token_type: grantData.token_type,
     __raw: rawData
-  });
+  })
 
   if (this.isGrantRefreshable(grant)) {
     return new Promise((resolve, reject) => {
       this.ensureFreshness(grant)
         .then(g => this.validateGrant(g))
         .then(g => resolve(g))
-        .catch(err => reject(err));
-    });
+        .catch(err => reject(err))
+    })
   } else {
-    return this.validateGrant(grant);
+    return this.validateGrant(grant)
   }
-};
+}
 
 /**
  * Validate the grant and all tokens contained therein.
@@ -373,33 +375,33 @@ GrantManager.prototype.createGrant = function createGrant (rawData) {
  * rejects with an error if any of the tokens are invalid.
  */
 GrantManager.prototype.validateGrant = function validateGrant (grant) {
-  var self = this;
+  const self = this
   const validateGrantToken = (grant, tokenName, expectedType) => {
     return new Promise((resolve, reject) => {
     // check the access token
       this.validateToken(grant[tokenName], expectedType).then(token => {
-        grant[tokenName] = token;
-        resolve();
+        grant[tokenName] = token
+        resolve()
       }).catch((err) => {
-        reject(new Error('Grant validation failed. Reason: ' + err.message));
-      });
-    });
-  };
+        reject(new Error('Grant validation failed. Reason: ' + err.message))
+      })
+    })
+  }
   return new Promise((resolve, reject) => {
-    var promises = [];
-    promises.push(validateGrantToken(grant, 'access_token', 'Bearer'));
+    const promises = []
+    promises.push(validateGrantToken(grant, 'access_token', 'Bearer'))
     if (!self.bearerOnly) {
       if (grant.id_token) {
-        promises.push(validateGrantToken(grant, 'id_token', 'ID'));
+        promises.push(validateGrantToken(grant, 'id_token', 'ID'))
       }
     }
     Promise.all(promises).then(() => {
-      resolve(grant);
+      resolve(grant)
     }).catch((err) => {
-      reject(new Error(err.message));
-    });
-  });
-};
+      reject(new Error(err.message))
+    })
+  })
+}
 
 /**
  * Validate a token.
@@ -408,123 +410,132 @@ GrantManager.prototype.validateGrant = function validateGrant (grant) {
  *
  * If the token is valid the promise will be resolved with the token
  *
- * If any of the following errors are seen the promise will resolve with undefined:
- *
- * - The token was undefined in the first place.
- * - The token is expired.
- * - The token is not expired, but issued before the current *not before* timestamp.
- * - The token signature does not verify against the known realm public-key.
+ * If the token is undefined or fails validation an applicable error is returned
  *
  * @return {Promise} That resolve a token
  */
 GrantManager.prototype.validateToken = function validateToken (token, expectedType) {
   return new Promise((resolve, reject) => {
     if (!token) {
-      reject(new Error('invalid token (missing)'));
+      reject(new Error('invalid token (missing)'))
     } else if (token.isExpired()) {
-      reject(new Error('invalid token (expired)'));
+      reject(new Error('invalid token (expired)'))
     } else if (!token.signed) {
-      reject(new Error('invalid token (not signed)'));
+      reject(new Error('invalid token (not signed)'))
     } else if (token.content.typ !== expectedType) {
-      reject(new Error('invalid token (wrong type)'));
+      reject(new Error('invalid token (wrong type)'))
     } else if (token.content.iat < this.notBefore) {
-      reject(new Error('invalid token (stale token)'));
+      reject(new Error('invalid token (stale token)'))
     } else if (token.content.iss !== this.realmUrl) {
-      reject(new Error('invalid token (wrong ISS)'));
+      reject(new Error('invalid token (wrong ISS)'))
     } else {
-      const verify = crypto.createVerify('RSA-SHA256');
+      const audienceData = Array.isArray(token.content.aud) ? token.content.aud : [token.content.aud]
+      if (expectedType === 'ID') {
+        if (!audienceData.includes(this.clientId)) {
+          reject(new Error('invalid token (wrong audience)'))
+        }
+        if (token.content.azp && token.content.azp !== this.clientId) {
+          reject(new Error('invalid token (authorized party should match client id)'))
+        }
+      } else if (this.verifyTokenAudience) {
+        if (!audienceData.includes(this.clientId)) {
+          reject(new Error('invalid token (wrong audience)'))
+        }
+      }
+      const verify = crypto.createVerify('RSA-SHA256')
       // if public key has been supplied use it to validate token
       if (this.publicKey) {
         try {
-          verify.update(token.signed);
+          verify.update(token.signed)
           if (!verify.verify(this.publicKey, token.signature, 'base64')) {
-            reject(new Error('invalid token (signature)'));
+            reject(new Error('invalid token (signature)'))
           } else {
-            resolve(token);
+            resolve(token)
           }
         } catch (err) {
-          reject(new Error('Misconfigured parameters while validating token. Check your keycloak.json file!'));
+          reject(new Error('Misconfigured parameters while validating token. Check your keycloak.json file!'))
         }
       } else {
         // retrieve public KEY and use it to validate token
         this.rotation.getJWK(token.header.kid).then(key => {
-          verify.update(token.signed);
+          verify.update(token.signed)
           if (!verify.verify(key, token.signature)) {
-            reject(new Error('invalid token (public key signature)'));
+            reject(new Error('invalid token (public key signature)'))
           } else {
-            resolve(token);
+            resolve(token)
           }
         }).catch((err) => {
-          reject(new Error('failed to load public key to verify token. Reason: ' + err.message));
-        });
+          reject(new Error('failed to load public key to verify token. Reason: ' + err.message))
+        })
       }
     }
-  });
-};
+  })
+}
 
 const getProtocol = (opts) => {
-  return opts.protocol === 'https:' ? https : http;
-};
+  return opts.protocol === 'https:' ? https : http
+}
 
 const nodeify = (promise, cb) => {
-  if (typeof cb !== 'function') return promise;
-  return promise.then((res) => cb(null, res)).catch((err) => cb(err));
-};
+  if (typeof cb !== 'function') return promise
+  return promise.then((res) => cb(null, res)).catch((err) => cb(err))
+}
 
 const createHandler = (manager) => (resolve, reject, json) => {
   try {
-    resolve(manager.createGrant(json));
+    resolve(manager.createGrant(json))
   } catch (err) {
-    reject(err);
+    reject(err)
   }
-};
+}
 
 const refreshHandler = (manager, grant) => (resolve, reject, json) => {
   manager.createGrant(json)
     .then((grant) => resolve(grant))
-    .catch((err) => reject(err));
-};
+    .catch((err) => reject(err))
+}
 
 const validationHandler = (manager, token) => (resolve, reject, json) => {
-  const data = JSON.parse(json);
-  if (!data.active) resolve(false);
-  else resolve(token);
-};
+  const data = JSON.parse(json)
+  if (!data.active) resolve(false)
+  else resolve(token)
+}
 
 const postOptions = (manager, path) => {
-  const realPath = path || '/protocol/openid-connect/token';
-  const opts = URL.parse(manager.realmUrl + realPath);
+  const realPath = path || '/protocol/openid-connect/token'
+  const opts = URL.parse(manager.realmUrl + realPath); // eslint-disable-line
   opts.headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
     'X-Client': 'keycloak-nodejs-connect'
-  };
-  if (!manager.public) {
-    opts.headers.Authorization = 'Basic ' + Buffer.from(manager.clientId + ':' + manager.secret).toString('base64');
   }
-  opts.method = 'POST';
-  return opts;
-};
+  if (!manager.public) {
+    opts.headers.Authorization = 'Basic ' + Buffer.from(manager.clientId + ':' + manager.secret).toString('base64')
+  }
+  opts.method = 'POST'
+  return opts
+}
 
 const fetch = (manager, handler, options, params) => {
   return new Promise((resolve, reject) => {
-    const data = (typeof params === 'string' ? params : querystring.stringify(params));
-    options.headers['Content-Length'] = data.length;
+    const data = (typeof params === 'string' ? params : querystring.stringify(params))
+    options.headers['Content-Length'] = data.length
 
     const req = getProtocol(options).request(options, (response) => {
-      let json = '';
-      response.on('data', (d) => (json += d.toString()));
+      let json = ''
+      response.on('data', (d) => (json += d.toString()))
       response.on('end', () => {
         if (response.statusCode < 200 || response.statusCode > 299) {
-          return reject(new Error(response.statusCode + ':' + http.STATUS_CODES[ response.statusCode ] + ':' + json));
+          response.destroy()
+          return reject(new Error(response.statusCode + ':' + http.STATUS_CODES[response.statusCode] + ':' + json))
         }
-        handler(resolve, reject, json);
-      });
-    });
+        handler(resolve, reject, json)
+      })
+    })
 
-    req.write(data);
-    req.on('error', reject);
-    req.end();
-  });
-};
+    req.write(data)
+    req.on('error', reject)
+    req.end()
+  })
+}
 
-module.exports = GrantManager;
+module.exports = GrantManager

--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -91,10 +91,21 @@ const getHighestRole = (roles) => {
 export const isLegacyToken = R.pathSatisfies(isNotNil, ['payload', 'role']);
 export const isKeycloakToken = R.pathSatisfies(isNotNil, ['payload', 'typ']);
 
-export const getGrantForKeycloakToken = async (token: string) =>
-  keycloakGrantManager.createGrant({
+export const getGrantForKeycloakToken = async (token: string) => {
+  // Create grant, validating token is signed/fresh.
+  const grant = await keycloakGrantManager.createGrant({
     access_token: token
   });
+
+  // Validates token has a live session.
+  const valid = await keycloakGrantManager.validateAccessToken(grant.access_token, undefined);
+
+  if (!valid) {
+    throw new Error('session signed out')
+  }
+
+  return grant
+}
 
 export const getCredentialsForLegacyToken = async (token: string): Promise<LegacyToken> => {
   const decoded = verify(token, getConfigFromEnv('JWTSECRET'));

--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -178,7 +178,7 @@ export class KeycloakUnauthorizedError extends Error {
   }
 }
 
-export const keycloakHasPermission = (grant, requestCache, modelClients, serviceAccount, currentUser, groupRoleProjectIds) => {
+export const keycloakHasPermission = (grant, modelClients, serviceAccount, currentUser, groupRoleProjectIds) => {
   const GroupModel = Group(modelClients);
   const UserModel = User(modelClients);
 

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,12 +1,14 @@
+# Stage: Build the custom token mapper
 FROM maven:3.9.9-eclipse-temurin-21-alpine as builder
-# build the custom token mapper in builder
 COPY custom-mapper/. .
 RUN mvn clean compile package
 
+# Stage: Install package dependencies
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 RUN mkdir -p /mnt/rootfs
 RUN dnf install --installroot /mnt/rootfs nc jq openssl curl unzip --releasever 9 --setopt install_weak_deps=false --nodocs -y; dnf --installroot /mnt/rootfs clean all
 
+# Stage: Package custom script providers
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest} AS commons
@@ -17,7 +19,8 @@ COPY javascript /tmp/lagoon-scripts
 
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
-FROM quay.io/keycloak/keycloak:26.0.7
+# Stage: Build the keycloak image
+FROM quay.io/keycloak/keycloak:26.1.5
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION
@@ -82,7 +85,7 @@ ENV TMPDIR=/tmp \
 
 VOLUME /opt/keycloak/data
 
-RUN curl -sSLo /opt/keycloak/providers/keycloak-home-idp-discovery.jar https://github.com/sventorben/keycloak-home-idp-discovery/releases/download/v26.0.1/keycloak-home-idp-discovery.jar
+RUN curl -sSLo /opt/keycloak/providers/keycloak-home-idp-discovery.jar https://github.com/sventorben/keycloak-home-idp-discovery/releases/download/v26.1.1/keycloak-home-idp-discovery.jar
 
 COPY entrypoints/kc-startup.sh /lagoon/kc-startup.sh
 COPY entrypoints/wait-for-mariadb.sh /lagoon/entrypoints/98-wait-for-mariadb.sh

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -20,7 +20,7 @@ COPY javascript /tmp/lagoon-scripts
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
 # Stage: Build the keycloak image
-FROM quay.io/keycloak/keycloak:26.1.5
+FROM quay.io/keycloak/keycloak:26.2.5
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION

--- a/services/keycloak/entrypoints/kc-startup.sh
+++ b/services/keycloak/entrypoints/kc-startup.sh
@@ -18,7 +18,7 @@ shopt -s failglob
 
 # it is also possible to expose the admin console on a different hostname using the `--hostname-admin` flag, which could support in the future with a different
 # variable than `KEYCLOAK_FRONTEND_URL` perhaps `KEYCLOAK_ADMIN_URL`
-/opt/keycloak/bin/kc.sh "$@" --features="scripts,token-exchange,admin-fine-grained-authz" \
+/opt/keycloak/bin/kc.sh "$@" --features="scripts,token-exchange:v1,admin-fine-grained-authz:v1" \
     --proxy-headers xforwarded \
     --http-enabled true \
     --http-relative-path ${KC_HTTP_RELATIVE_PATH:-/auth} \

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,10 +685,10 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
-"@keycloak/keycloak-admin-client@26.1.2":
-  version "26.1.2"
-  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.1.2.tgz#ff4961d4fc46f872c5daf103f620ebdad27289bc"
-  integrity sha512-WiYrPQ+M4o7SF8pD0mxSfazCpUOA28rJFWwVjyijJPPSvLxAeZxHjIFNm5q/FzPxsN8+7VdjFsWg/U/UYZ5uHg==
+"@keycloak/keycloak-admin-client@26.1.4":
+  version "26.1.4"
+  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.1.4.tgz#069497043e9cc6509c2b0b51d931830853f65540"
+  integrity sha512-zJJM7uhtzUUD0Uf6Q2xhFrUqT+qvfj5WhBqTwKtO8k4jbxu4uNmk5qRDa8fnkk0sHyPzlD+d875H2Jora/W2gw==
   dependencies:
     camelize-ts "^3.0.0"
     url-join "^5.0.0"
@@ -944,12 +944,12 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@s3pweb/keycloak-admin-client-cjs@^26.0.0":
-  version "26.1.2"
-  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.1.2.tgz#6488e1bc86ec881a84e9c686233a3baf32e13e28"
-  integrity sha512-8l9PA1NC9xxOTqQXyuzLyDb1eeOZx/JVqcvWcs0stBB/OQgiOZkh1C5D66h5hkfEW5GGsw6iMgpRFltL39+JMw==
+"@s3pweb/keycloak-admin-client-cjs@26.1.4":
+  version "26.1.4"
+  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.1.4.tgz#680cb17a4bc40dffd4650b8573b695976d725669"
+  integrity sha512-KZ+YYV5VcrFpkyHsVCPF/qRg40+Fu3ibIoISi9S1pZ1GytS+8cQW8oqrGm7biI7tSosiheWz1v6quRcViNAkCA==
   dependencies:
-    "@keycloak/keycloak-admin-client" "26.1.2"
+    "@keycloak/keycloak-admin-client" "26.1.4"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,10 +685,10 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
-"@keycloak/keycloak-admin-client@26.1.4":
-  version "26.1.4"
-  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.1.4.tgz#069497043e9cc6509c2b0b51d931830853f65540"
-  integrity sha512-zJJM7uhtzUUD0Uf6Q2xhFrUqT+qvfj5WhBqTwKtO8k4jbxu4uNmk5qRDa8fnkk0sHyPzlD+d875H2Jora/W2gw==
+"@keycloak/keycloak-admin-client@26.2.4":
+  version "26.2.4"
+  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.2.4.tgz#9484ad8e7fb1bcc5fbd540211b77d16ade3792a2"
+  integrity sha512-2N56jps2HEGJoslxT2LQudUNEKmVwXyfZushR77hkoQF05YQ2USFOvqeM0kxxFb/3S38ZwS4wZv0NiZKnAwhUw==
   dependencies:
     camelize-ts "^3.0.0"
     url-join "^5.0.0"
@@ -944,12 +944,12 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@s3pweb/keycloak-admin-client-cjs@26.1.4":
-  version "26.1.4"
-  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.1.4.tgz#680cb17a4bc40dffd4650b8573b695976d725669"
-  integrity sha512-KZ+YYV5VcrFpkyHsVCPF/qRg40+Fu3ibIoISi9S1pZ1GytS+8cQW8oqrGm7biI7tSosiheWz1v6quRcViNAkCA==
+"@s3pweb/keycloak-admin-client-cjs@26.2.4":
+  version "26.2.4"
+  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.2.4.tgz#6a5a0c272cac17767abda167bc83a4ebf7c73b77"
+  integrity sha512-NbYC6HlAZuUIVI8L6xYDrpSzzCppqGwddPUY+L0ePYNY2rlPZKHWmnyvFYAPvQRXodgSxD/wLpio3/2acP8Ekw==
   dependencies:
-    "@keycloak/keycloak-admin-client" "26.1.4"
+    "@keycloak/keycloak-admin-client" "26.2.4"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,11 +2559,6 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6081,13 +6076,6 @@ node-abi@^3.3.0:
   integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
   dependencies:
     semver "^7.3.5"
-
-node-cache@^5.1.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
-  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
-  dependencies:
-    clone "2.x"
 
 node-cleanup@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,16 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testim/chrome-version@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"
+  integrity sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==
+
+"@tootallnate/quickjs-emscripten@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
+  integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.7.tgz#3b98b1889d2b2386604c2bbbe62e4fb51e95b265"
@@ -1416,6 +1426,13 @@
   resolved "https://registry.yarnpkg.com/@types/yarnpkg__lockfile/-/yarnpkg__lockfile-1.1.9.tgz#b3c8e8d66dc8ce79827f422a660a557cda9ded14"
   integrity sha512-GD4Fk15UoP5NLCNor51YdfL9MSdldKCqOC9EssrRw3HVfar9wUZ5y8Lfnp+qVD6hIinLr8ygklDYnmlnlQo12Q==
 
+"@types/yauzl@^2.9.1":
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
+  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/parser@^6.7.5":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.21.0.tgz#af8fcf66feee2edc86bc5d1cf45e33b0630bf35b"
@@ -1507,7 +1524,7 @@ acorn@^8.14.0, acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
-agent-base@^7.1.2:
+agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
   integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
@@ -1897,6 +1914,13 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
+ast-types@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+  dependencies:
+    tslib "^2.0.1"
+
 async-function@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
@@ -1982,6 +2006,15 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^1.7.4:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^1.7.9:
   version "1.8.1"
@@ -2096,6 +2129,11 @@ basic-auth@~2.0.1:
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
   dependencies:
     safe-buffer "5.1.2"
+
+basic-ftp@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.5.tgz#14a474f5fffecca1f4f406f1c26b18f800225ac0"
+  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -2240,6 +2278,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -2452,6 +2495,19 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chromedriver@latest:
+  version "137.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-137.0.1.tgz#a7c1eeb0c0b091a1e2505b384b4df8aaceb133fb"
+  integrity sha512-H4amLfsU3zubwD9X7me9Ajd8z3+MARfJ90gLV6PEKdad0Jgmh3fAGnCuz8Ew8yeuoSJ5ycb/vGEvyqgGVFAjJQ==
+  dependencies:
+    "@testim/chrome-version" "^1.1.4"
+    axios "^1.7.4"
+    compare-versions "^6.1.0"
+    extract-zip "^2.0.1"
+    proxy-agent "^6.4.0"
+    proxy-from-env "^1.1.0"
+    tcp-port-used "^1.0.2"
+
 ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
@@ -2618,6 +2674,11 @@ common-tags@^1.4.0, common-tags@^1.8.2:
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
+compare-versions@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 compressible@~2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -2780,6 +2841,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
+  integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
+
 data-view-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz#211a03ba95ecaf7798a8c7198d79536211f88570"
@@ -2825,6 +2891,13 @@ debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
+
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@4.3.4:
   version "4.3.4"
@@ -2889,6 +2962,15 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+degenerator@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-5.0.1.tgz#9403bf297c6dad9a1ece409b37db27954f91f2f5"
+  integrity sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==
+  dependencies:
+    ast-types "^0.13.4"
+    escodegen "^2.1.0"
+    esprima "^4.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3265,6 +3347,17 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-airbnb-base@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
@@ -3392,7 +3485,7 @@ espree@^9.3.1, espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3529,6 +3622,17 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+extract-zip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -3583,6 +3687,13 @@ fb-watchman@^2.0.0:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 fecha@^4.2.0:
   version "4.2.3"
@@ -3896,6 +4007,15 @@ get-symbol-description@^1.1.0:
     call-bound "^1.0.3"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
+
+get-uri@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-6.0.4.tgz#6daaee9e12f9759e19e55ba313956883ef50e0a7"
+  integrity sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==
+  dependencies:
+    basic-ftp "^5.0.2"
+    data-uri-to-buffer "^6.0.2"
+    debug "^4.3.4"
 
 getopts@2.3.0:
   version "2.3.0"
@@ -4251,6 +4371,14 @@ http-errors@^1.7.3, http-errors@^1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-reasons@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/http-reasons/-/http-reasons-0.1.0.tgz#a953ca670078669dde142ce899401b9d6e85d3b4"
@@ -4296,7 +4424,7 @@ httpreq@>=0.4.22:
   resolved "https://registry.yarnpkg.com/httpreq/-/httpreq-1.1.1.tgz#b8818316cdfd6b1bfb0f68b822fa1306cd24be68"
   integrity sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==
 
-https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.4:
+https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.4, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -4412,6 +4540,19 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
+
+ip-regex@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -4647,6 +4788,11 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-weakmap@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
@@ -4666,6 +4812,15 @@ is-weakset@^2.0.3:
   dependencies:
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
+
+is2@^2.0.6:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.9.tgz#ff63b441f90de343fa8fac2125ee170da8e8240d"
+  integrity sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^4.1.0"
+    is-url "^1.2.4"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -5172,6 +5327,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5319,12 +5479,14 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-keycloak-connect@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/keycloak-connect/-/keycloak-connect-5.0.0.tgz#fa0ebfe1e1236381d0e1b94bfb1594dab5a21497"
-  integrity sha512-9SDZc6bbNzWY1di1qEQAW4RY94t/z6hWvkj6RNro3sWV3PSuT/DNXsCyfZpEJlj5Vz60w8p496HuNdMyqsV7AQ==
+keycloak-connect@^26.1.1:
+  version "26.1.1"
+  resolved "https://registry.yarnpkg.com/keycloak-connect/-/keycloak-connect-26.1.1.tgz#27fb15a21ce7e63ea0d9842be019b65517a11eda"
+  integrity sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==
   dependencies:
     jwk-to-pem "^2.0.0"
+  optionalDependencies:
+    chromedriver latest
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -5565,6 +5727,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 luxon@~3.5.0:
   version "3.5.0"
@@ -5840,6 +6007,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+netmask@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
+  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 newman@^6.1.1:
   version "6.2.1"
@@ -6199,6 +6371,28 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pac-proxy-agent@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz#9cfaf33ff25da36f6147a20844230ec92c06e5df"
+  integrity sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==
+  dependencies:
+    "@tootallnate/quickjs-emscripten" "^0.23.0"
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    get-uri "^6.0.1"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.6"
+    pac-resolver "^7.0.1"
+    socks-proxy-agent "^8.0.5"
+
+pac-resolver@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.1.tgz#54675558ea368b64d210fd9c92a640b5f3b8abb6"
+  integrity sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==
+  dependencies:
+    degenerator "^5.0.0"
+    netmask "^2.0.2"
+
 package-json-from-dist@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
@@ -6294,6 +6488,11 @@ pause-stream@0.0.11:
   integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
   dependencies:
     through "~2.3"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 performance-now@2.1.0, performance-now@^2.1.0:
   version "2.1.0"
@@ -6564,6 +6763,20 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-agent@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.5.0.tgz#9e49acba8e4ee234aacb539f89ed9c23d02f232d"
+  integrity sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    http-proxy-agent "^7.0.1"
+    https-proxy-agent "^7.0.6"
+    lru-cache "^7.14.1"
+    pac-proxy-agent "^7.1.0"
+    proxy-from-env "^1.1.0"
+    socks-proxy-agent "^8.0.5"
 
 proxy-from-env@^1.1.0:
   version "1.1.0"
@@ -7222,6 +7435,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 snakecase-keys@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/snakecase-keys/-/snakecase-keys-1.2.0.tgz#6c5d8f7a4dfda41afa86a26b6780c6daebb7e3b5"
@@ -7229,6 +7447,23 @@ snakecase-keys@^1.2.0:
   dependencies:
     map-obj "~2.0.0"
     to-snake-case "~0.1.2"
+
+socks-proxy-agent@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
+  integrity sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    socks "^2.8.3"
+
+socks@^2.8.3:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.4.tgz#07109755cdd4da03269bda4725baa061ab56d5cc"
+  integrity sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==
+  dependencies:
+    ip-address "^9.0.5"
+    smart-buffer "^4.2.0"
 
 sort-object-keys@^1.1.3:
   version "1.1.3"
@@ -7243,7 +7478,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -7254,6 +7489,11 @@ split@0.3:
   integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
   dependencies:
     through "2"
+
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -7348,16 +7588,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7431,7 +7662,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7444,13 +7675,6 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -7582,6 +7806,14 @@ tarn@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
+
+tcp-port-used@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
+  integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==
+  dependencies:
+    debug "4.3.1"
+    is2 "^2.0.6"
 
 teleport-javascript@1.0.0:
   version "1.0.0"
@@ -7758,7 +7990,7 @@ tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.1.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -8239,7 +8471,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8252,15 +8484,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -8405,6 +8628,14 @@ yarn-audit-fix@^10.1.0:
     lodash-es "^4.17.21"
     semver "^7.6.3"
     synp "^1.9.14"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

- Upgrades keycloak to the most recent version 26.2.5
- Upgrades keycloak related libraries in the api to most recent versions
- Validates api tokens against keycloak session database
- Removes some dead code

Keycloak has still not recommended a replacement for keycloak-connect libarary and it appears to still get updated, so didn't take care of this issue yet https://github.com/uselagoon/lagoon/issues/3029