### PR TITLE
fix: invalidate group membership cache on user update

### DIFF
--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -164,6 +164,7 @@ export interface GroupModel {
   getGroupMembership: (group: Group) => Promise<GroupMembership[]>
   getGroupMemberCount: (group: Group) => Promise<number>
   removeNonProjectDefaultUsersFromGroup: (group: Group, project: String) => Promise<Group>
+  purgeGroupCache: (group: Pick<Group, 'name' | 'id'>, membersOnly: Boolean) => Promise<void>
 }
 
 export const Group = (clients: {
@@ -1126,6 +1127,7 @@ export const Group = (clients: {
     transformKeycloakGroups,
     getGroupMembership,
     getGroupMemberCount,
-    removeNonProjectDefaultUsersFromGroup
+    removeNonProjectDefaultUsersFromGroup,
+    purgeGroupCache
   };
 };

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -794,6 +794,14 @@ export const User = (clients: {
         }
       }
 
+      // Purge the Group cache for all groups the user belongs to, 
+      // so it does not have out of date information.
+      const GroupModel = Group(clients);
+      const userGroups = await getAllGroupsForUser(userInput.id);
+      await Promise.all(
+          userGroups.map((userGroup) => GroupModel.purgeGroupCache(userGroup, true) )
+      );
+
       await keycloakAdminClient.users.update(
         {
           id: userInput.id


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Description

Addresses #3939.

When user information is updating via `updateUser` mutation, the redis caches that contain the user's information are not invalidated, and therefore contain out of date information.

This PR ensures that whenever user information is updated via this mutation, the correct caches are invalidated (i.e deleted).
