### PR TITLE
chore: bump keycloak version to 26.3.1

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -20,7 +20,7 @@ COPY javascript /tmp/lagoon-scripts
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
 # Stage: Build the keycloak image
-FROM quay.io/keycloak/keycloak:26.2.5
+FROM quay.io/keycloak/keycloak:26.3.1
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION

--- a/services/keycloak/custom-mapper/pom.xml
+++ b/services/keycloak/custom-mapper/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <keycloak.version>26.0.7</keycloak.version>
+        <keycloak.version>26.3.1</keycloak.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

There are a few performance related issues with groups queries in keycloak 26.2.x that 26.3.x appear to have fixed. 

* https://www.keycloak.org/docs/latest/upgrading/#subgroup-counts-are-no-longer-cached

I've spun this up locally in `k3d/local-stack` and installed the `k3d/example-sso` and run [this](https://gist.github.com/shreddedbacon/b717cdd4646cb7ea86abf3886fbdf3c9) in the keycloak pod to setup the home-idp plugin browser flow. Everything appears to work fine, even though the home-idp plugin is still on an older version.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

