### PR TITLE
tests: pin ansible version to 2.18.6

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core >= 2.17.5
+ansible-core == 2.18.6
 kubernetes >= 31.0.0
 jmespath == 1.0.1
 PyJWT == 2.9.0


### PR DESCRIPTION
Ansible 2.19.0 has a lot of breaking changes that requires considerable refactoring of our test suite to work - https://github.com/ansible/ansible/blob/v2.19.0/changelogs/CHANGELOG-v2.19.rst

This pins it to 2.18.6 which was the last working version for the test suite.

We should investigate whether we continue to use ansible and do the necessary refactoring, or re-write them with go