### PR TITLE
fix: capture branch name when branch is deleted via git

### DIFF
--- a/services/logs2notifications/internal/handler/email_events.go
+++ b/services/logs2notifications/internal/handler/email_events.go
@@ -53,6 +53,10 @@ func (h *Messaging) processEmailTemplates(notification *Notification) (string, s
 	case "deleteEnvironment":
 		mainHTMLTpl = `Deleted environment <code>{{.EnvironmentName}}</code>`
 		plainTextTpl = `[{{.ProjectName}}] deleted environment {{.EnvironmentName}}`
+		if notification.Meta.BranchName != "" { // git branch deletion
+			mainHTMLTpl = `Deleted environment <code>{{.BranchName}}</code> triggered by git`
+			plainTextTpl = `[{{.ProjectName}}] deleted environment {{.BranchName}} triggered by git`
+		}
 	case "repoPushHandled":
 		mainHTMLTpl = `<a href="{{.RepoURL}}/tree/{{.BranchName}}">{{.BranchName}}</a>{{ if ne .ShortSha "" }} <a href="{{.CommitURL}}">{{.ShortSha}}</a>{{end}} pushed in <a href="{{.RepoURL}}">{{.RepoFullName}}</a>`
 		plainTextTpl = `[{{.ProjectName}}] {{.BranchName}}{{ if ne .ShortSha "" }} ({{.ShortSha}}){{end}} pushed in {{.RepoFullName}}`
@@ -169,7 +173,6 @@ func (h *Messaging) prepareAndSendEmail(emoji, color, subject, event, project, e
 	if err != nil {
 		log.Printf("error sending email for %s event %s: %v", emailAddress, event, err)
 	}
-	return
 }
 
 func getEmailEvent(msgEvent string) (string, string, string, error) {

--- a/services/logs2notifications/internal/handler/microsoftteams_events.go
+++ b/services/logs2notifications/internal/handler/microsoftteams_events.go
@@ -59,6 +59,9 @@ func (h *Messaging) processMicrosoftTeamsTemplate(notification *Notification) (s
 		teamsTpl = `PR [#{{.PullrequestNumber}} ({{.PullrequestTitle}})]({{.PullrequestURL}}) closed in [{{.RepoName}}]({{.RepoURL}})`
 	case "deleteEnvironment":
 		teamsTpl = `Deleting environment ` + "`{{.EnvironmentName}}`"
+		if notification.Meta.BranchName != "" { // git branch deletion
+			teamsTpl = `Deleting environment ` + "`{{.BranchName}}` triggered by git"
+		}
 	case "repoPushHandled":
 		teamsTpl = `[{{.BranchName}}]({{.RepoURL}}/tree/{{.BranchName}}){{ if ne .ShortSha "" }} ([{{.ShortSha}}]({{.CommitURL}})){{end}} pushed in [{{.RepoFullName}}]({{.RepoURL}})`
 	case "repoPushSkipped":

--- a/services/logs2notifications/internal/handler/rocketchat_events.go
+++ b/services/logs2notifications/internal/handler/rocketchat_events.go
@@ -63,6 +63,9 @@ func (h *Messaging) processRocketChatTemplate(notification *Notification) (strin
 		rcTpl = `*[{{.ProjectName}}]* PR [#{{.PullrequestNumber}} ({{.PullrequestTitle}})]({{.PullrequestURL}}) closed in [{{.RepoName}}]({{.RepoURL}})`
 	case "deleteEnvironment":
 		rcTpl = `*[{{.ProjectName}}]* Deleting environment ` + "`{{.EnvironmentName}}`"
+		if notification.Meta.BranchName != "" { // git branch deletion
+			rcTpl = `*[{{.ProjectName}}]* Deleting environment ` + "`{{.BranchName}}` triggered by git"
+		}
 	case "repoPushHandled":
 		rcTpl = `*[{{.ProjectName}}]* [{{.BranchName}}]({{.RepoURL}}/tree/{{.BranchName}}){{ if ne .ShortSha "" }} ([{{.ShortSha}}]({{.CommitURL}})){{end}} pushed in [{{.RepoFullName}}]({{.RepoURL}})`
 	case "repoPushSkipped":

--- a/services/logs2notifications/internal/handler/slack_events.go
+++ b/services/logs2notifications/internal/handler/slack_events.go
@@ -43,6 +43,9 @@ func (h *Messaging) processSlackTemplate(notification *Notification) (string, st
 		slackTpl = `*[{{.ProjectName}}]* PR <{{.PullrequestURL}}|#{{.PullrequestNumber}} ({{.PullrequestTitle}})> closed in <{{.RepoURL}}|{{.RepoName}}>`
 	case "deleteEnvironment":
 		slackTpl = `*[{{.ProjectName}}]* Deleting environment ` + "`{{.EnvironmentName}}`"
+		if notification.Meta.BranchName != "" { // git branch deletion
+			slackTpl = `*[{{.ProjectName}}]* Deleting environment ` + "`{{.BranchName}}` triggered by git"
+		}
 	case "repoPushHandled":
 		slackTpl = `*[{{.ProjectName}}]* <{{.RepoURL}}/tree/{{.BranchName}}|{{.BranchName}}>{{ if ne .ShortSha "" }} (<{{.CommitURL}}|{{.ShortSha}}>){{end}} pushed in <{{.RepoURL}}|{{.RepoFullName}}>`
 	case "repoPushSkipped":

--- a/services/logs2notifications/internal/handler/useraction_events.go
+++ b/services/logs2notifications/internal/handler/useraction_events.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 )
@@ -11,11 +10,6 @@ type handleUserActionUser struct {
 	Email        string `json:"email"`
 	Organization int    `json:"organization"`
 	Role         string `json:"role"`
-}
-
-type handleUserActionResource struct {
-	Type    string `json:"type"`
-	Details string `json:"details"` // stores the org name
 }
 
 // There is also a third payload struct called "linkedResource" which we could use, but it seems redundant
@@ -76,7 +70,7 @@ func (h *Messaging) handleUserActionToEmail(notification *Notification, rawPaylo
 	case "api:removeUserFromGroup":
 		return h.groupRemoveEmailMessage(useractionEmailDetails, notification.Meta.Event)
 	}
-	return errors.New(fmt.Sprintf("Unable to match incoming notification: %v", notification))
+	return fmt.Errorf("unable to match incoming notification: %v", notification)
 }
 
 func (h *Messaging) groupAddEmailMessage(valuesStruct UseractionEmailDetails, event string) error {
@@ -105,13 +99,10 @@ func (h *Messaging) groupAddEmailMessage(valuesStruct UseractionEmailDetails, ev
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error generating email template for %s event %s: %v", valuesStruct.Email, event, err)
 	}
 	plainText := fmt.Sprintf("%v added to group %v with the role %v", valuesStruct.Name, valuesStruct.Groupname, valuesStruct.Role)
 	subject := fmt.Sprintf("User %s has been added to a group", valuesStruct.Name)
-	if err != nil {
-		return fmt.Errorf("error generating email template for %s event %s: %v", valuesStruct.Email, event, err)
-	}
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -144,13 +135,10 @@ func (h *Messaging) groupRemoveEmailMessage(valuesStruct UseractionEmailDetails,
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error generating email template for %s event %s: %v", valuesStruct.Email, event, err)
 	}
 	plainText := fmt.Sprintf("%v removed from group %v", valuesStruct.Name, valuesStruct.Groupname)
 	subject := fmt.Sprintf("User %s has been removed from a group", valuesStruct.Name)
-	if err != nil {
-		return fmt.Errorf("error generating email template for %s event %s: %v", valuesStruct.Email, event, err)
-	}
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -181,13 +169,10 @@ func (h *Messaging) addEditRemoveSshKeyEmailMessage(valuesStruct UseractionEmail
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error generating email template for %s event %s and project %s: %v", event, valuesStruct.Email, valuesStruct.Role, err)
 	}
 	plainText := fmt.Sprintf("%v %v ssh key", valuesStruct.Name, action)
 	subject := fmt.Sprintf("User %s has %v an ssh key", valuesStruct.Name, action)
-	if err != nil {
-		return fmt.Errorf("error generating email template for %s event %s and project %s: %v", event, valuesStruct.Email, valuesStruct.Role, err)
-	}
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -208,14 +193,12 @@ func (h *Messaging) addPlatformRoleToUser(valuesStruct UseractionEmailDetails) e
 
 	templateGenerator := NewTemplateDataGenerator(content, h.EmailTemplate, h.EmailBase64Logo)
 	mainHTML, err := templateGenerator.Generate(valuesStruct)
-	if err != nil {
-		return err
-	}
-	plainText := fmt.Sprintf("%v granted platform role %v", valuesStruct.Name, valuesStruct.Role)
-	subject := fmt.Sprintf("User %s Lagoon platform role was updated", valuesStruct.Name)
+
 	if err != nil {
 		return fmt.Errorf("error generating email template for addPlatformRoleToUser event %s and project %s: %v", valuesStruct.Email, valuesStruct.Role, err)
 	}
+	plainText := fmt.Sprintf("%v granted platform role %v", valuesStruct.Name, valuesStruct.Role)
+	subject := fmt.Sprintf("User %s Lagoon platform role was updated", valuesStruct.Name)
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -236,14 +219,12 @@ func (h *Messaging) removePlatformRoleFromUser(valuesStruct UseractionEmailDetai
 
 	templateGenerator := NewTemplateDataGenerator(content, h.EmailTemplate, h.EmailBase64Logo)
 	mainHTML, err := templateGenerator.Generate(valuesStruct)
-	if err != nil {
-		return err
-	}
-	plainText := fmt.Sprintf("%v removed from platform role %v", valuesStruct.Name, valuesStruct.Role)
-	subject := fmt.Sprintf("User %s Lagoon platform role was updated", valuesStruct.Name)
+
 	if err != nil {
 		return fmt.Errorf("error generating email template for addPlatformRoleToUser event %s and project %s: %v", valuesStruct.Email, valuesStruct.Role, err)
 	}
+	plainText := fmt.Sprintf("%v removed from platform role %v", valuesStruct.Name, valuesStruct.Role)
+	subject := fmt.Sprintf("User %s Lagoon platform role was updated", valuesStruct.Name)
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -266,14 +247,12 @@ func (h *Messaging) addAdminToOrganization(valuesStruct UseractionEmailDetails) 
 `
 	templateGenerator := NewTemplateDataGenerator(content, h.EmailTemplate, h.EmailBase64Logo)
 	mainHTML, err := templateGenerator.Generate(valuesStruct)
-	if err != nil {
-		return err
-	}
-	plainText := fmt.Sprintf("%v granted role %v on organization %v", valuesStruct.Name, valuesStruct.Role, valuesStruct.OrganizationName)
-	subject := fmt.Sprintf("User %s role updated for Organization: %v", valuesStruct.Name, valuesStruct.OrganizationName)
+
 	if err != nil {
 		return fmt.Errorf("error generating email template for addAdminToOrganization event %s and project %s: %v", valuesStruct.Email, valuesStruct.Role, err)
 	}
+	plainText := fmt.Sprintf("%v granted role %v on organization %v", valuesStruct.Name, valuesStruct.Role, valuesStruct.OrganizationName)
+	subject := fmt.Sprintf("User %s role updated for Organization: %v", valuesStruct.Name, valuesStruct.OrganizationName)
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {
@@ -297,14 +276,12 @@ func (h *Messaging) removeAdminFromOrganization(valuesStruct UseractionEmailDeta
 
 	templateGenerator := NewTemplateDataGenerator(content, h.EmailTemplate, h.EmailBase64Logo)
 	mainHTML, err := templateGenerator.Generate(valuesStruct)
-	if err != nil {
-		return err
-	}
-	plainText := fmt.Sprintf("%v removed from organization %v", valuesStruct.Name, valuesStruct.OrganizationName)
-	subject := fmt.Sprintf("User %s removed from Organization: %v", valuesStruct.Name, valuesStruct.OrganizationName)
+
 	if err != nil {
 		return fmt.Errorf("error generating email template for removing user %s and from organization %s: %v", valuesStruct.Email, valuesStruct.OrganizationName, err)
 	}
+	plainText := fmt.Sprintf("%v removed from organization %v", valuesStruct.Name, valuesStruct.OrganizationName)
+	subject := fmt.Sprintf("User %s removed from Organization: %v", valuesStruct.Name, valuesStruct.OrganizationName)
 
 	err = h.simpleMail(valuesStruct.Email, subject, mainHTML, plainText)
 	if err != nil {

--- a/services/logs2notifications/internal/handler/useraction_events_template.go
+++ b/services/logs2notifications/internal/handler/useraction_events_template.go
@@ -61,7 +61,7 @@ func templateGenerator(mailTemplate, contentTemplate string, contentValues inter
 
 	// now let's fill in the content
 	var completeMail strings.Builder
-	t, err = template.New("emailWithContent").Parse(body.String())
+	t, _ = template.New("emailWithContent").Parse(body.String())
 	err = t.Execute(&completeMail, contentValues)
 	if err != nil {
 		return "", fmt.Errorf("error generating email template: %v", err)

--- a/services/logs2notifications/internal/handler/useraction_events_test.go
+++ b/services/logs2notifications/internal/handler/useraction_events_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestMessaging_handleUserActionToEmail(t *testing.T) {
-	type fields struct {
-	}
 	type args struct {
 		notification *Notification
 		event        string
@@ -94,8 +92,7 @@ func TestMessaging_handleUserActionToEmail1(t *testing.T) {
 
 		// let's create a mock EmailDeliveryFunction
 		var subjectSent, plaintextSent, htmlSent string
-		var emailDeliveryFunction DeliverEmailType
-		emailDeliveryFunction = func(h *Messaging, emailAddress string, subject string, plainText string, htmlMessage bytes.Buffer) error {
+		emailDeliveryFunction := func(h *Messaging, emailAddress string, subject string, plainText string, htmlMessage bytes.Buffer) error {
 			subjectSent = subject
 			plaintextSent = plainText
 			htmlSent = htmlMessage.String()


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

When a webhook for branch deletions are received, only the `branchName` is set, when the slack notifications are checking for `environmentName`.

This fixes it so that if `branchName` is detected, the message will reflect it was deleted by a triggered webhook from git.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3955 
