### PR TITLE
fix: speed up lagoon details make target and prevent container clutter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ local-dev/k3d
 local-dev/kind
 local-dev/kubectl
 local-dev/jq
+local-dev/jwt
 local-dev/stern
 local-dev/go
 local-dev/certificates


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Motivation

The `make k3d/get-lagoon-details` and `make k3d/get-lagoon-cli-details` targets are very important to local development of Lagoon, but suffer from two issues:

- They are slower than they need to be
- They create and leave a docker container _per execution_ just to complete a JWT encoding, leading to these leftover containers littering my local machine, requiring manual clean up

# Solution

This PR does two main things.

First, it replaces the `docker run uselagoon/tests python3 /ansible/tasks/api/admin_token.py` command with a command-line tool `jwt-cli`, (repo: https://github.com/mike-engel/jwt-cli). Note due to implementation differences, the exact token returned is different, but I have confirmed the payloads are identical and the new tokens are indeed accepted (for example by the Lagoon API).

Second, in the `k3d/get-lagoon-details` target, it extracts the six or so calls to `$(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`. By saving the result in a variable, the execution time of the target on my machine drops from ~2.5s to ~1.5s.



