### PR TITLE
Change title of docker compose to be without a dot

### DIFF
--- a/docs/concepts-basics/lagoon-yml.md
+++ b/docs/concepts-basics/lagoon-yml.md
@@ -787,7 +787,7 @@ container-registries:
 
 To consume a custom or private container registry image, you need to update the service inside your `docker-compose.yml` file to use a build context instead of defining an image:
 
-```yaml title=".docker-compose.yml"
+```yaml title="docker-compose.yml"
 services:
   mariadb:
     build:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

I assume the title of this section should in fact be `docker-compose.yml` and not `.docker-compose.yml`

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
