### PR TITLE
feat: allow enabling of insights handler in local stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ BUILD_DEPLOY_IMAGE_TAG ?= edge
 UI_IMAGE_REPO = uselagoon/ui
 UI_IMAGE_TAG = main
 
+# The two variables below are an easy way to override the insights-handler image used in the local stack lagoon-core 
+# only works for installations where ENABLE_INSIGHTS=true and INSTALL_STABLE_CORE=false
+#INSIGHTS_HANDLER_IMAGE_REPO = 
+#INSIGHTS_HANDLER_IMAGE_TAG = 
+
 # SSHPORTALAPI_IMAGE_REPO and SSHPORTALAPI_IMAGE_TAG are an easy way to override the ssh portal api image used in the local stack lagoon-core
 # only works for installations where INSTALL_STABLE_CORE=false
 # SSHPORTALAPI_IMAGE_REPO =
@@ -497,6 +502,9 @@ INSTALL_PROMETHEUS = true
 # install aergia in local development
 INSTALL_AERGIA = true
 
+# enable insights in local development
+ENABLE_INSIGHTS = false
+
 # optionally install k8up for lagoon local development testing
 INSTALL_K8UP = false
 REMOTE_CONTROLLER_K8UP_VERSION = v2
@@ -793,6 +801,7 @@ endif
 		SSHPORTALAPI_IMAGE_REPO=$(SSHPORTALAPI_IMAGE_REPO) SSHPORTALAPI_IMAGE_TAG=$(SSHPORTALAPI_IMAGE_TAG) \
 		SSHTOKEN_IMAGE_REPO=$(SSHTOKEN_IMAGE_REPO) SSHTOKEN_IMAGE_TAG=$(SSHTOKEN_IMAGE_TAG) \
 		SSHPORTAL_IMAGE_REPO=$(SSHPORTAL_IMAGE_REPO) SSHPORTAL_IMAGE_TAG=$(SSHPORTAL_IMAGE_TAG) \
+		INSIGHTS_HANDLER_IMAGE_REPO=$(INSIGHTS_HANDLER_IMAGE_REPO) INSIGHTS_HANDLER_IMAGE_TAG=$(INSIGHTS_HANDLER_IMAGE_TAG) \
 		OVERRIDE_BUILD_DEPLOY_DIND_IMAGE="registry.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io/library/build-deploy-image:$(BUILD_DEPLOY_IMAGE_TAG)" \
 		$$([ $(OVERRIDE_REMOTE_CONTROLLER_IMAGETAG) ] && echo 'OVERRIDE_REMOTE_CONTROLLER_IMAGETAG=$(OVERRIDE_REMOTE_CONTROLLER_IMAGETAG)') \
 		$$([ $(OVERRIDE_REMOTE_CONTROLLER_IMAGE_REPOSITORY) ] && echo 'OVERRIDE_REMOTE_CONTROLLER_IMAGE_REPOSITORY=$(OVERRIDE_REMOTE_CONTROLLER_IMAGE_REPOSITORY)') \
@@ -820,7 +829,8 @@ endif
 		$$([ $(INSTALL_MARIADB_PROVIDER) ] && echo 'INSTALL_MARIADB_PROVIDER=$(INSTALL_MARIADB_PROVIDER)') \
 		$$([ $(INSTALL_POSTGRES_PROVIDER) ] && echo 'INSTALL_POSTGRES_PROVIDER=$(INSTALL_POSTGRES_PROVIDER)') \
 		$$([ $(INSTALL_MONGODB_PROVIDER) ] && echo 'INSTALL_MONGODB_PROVIDER=$(INSTALL_MONGODB_PROVIDER)') \
-		$$([ $(INSTALL_AERGIA) ] && echo 'INSTALL_AERGIA=$(INSTALL_AERGIA)')
+		$$([ $(INSTALL_AERGIA) ] && echo 'INSTALL_AERGIA=$(INSTALL_AERGIA)') \
+		$$([ $(ENABLE_INSIGHTS) ] && echo 'ENABLE_INSIGHTS=$(ENABLE_INSIGHTS)')
 	$(MAKE) k3d/push-stable-build-image
 ifneq ($(SKIP_DETAILS),true)
 	$(MAKE) k3d/get-lagoon-details

--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -160,6 +160,23 @@ To change back to the default image you can use `make k3d/push-stable-build-imag
 make k3d/push-stable-build-image BUILD_DEPLOY_IMAGE_TAG=pr-123
 ```
 
+#### Lagoon Insights
+
+Lagoon provides an optional feature called 'Insights'.
+By default, this feature is disabled in the local-stack.
+You can enable it with
+
+```bash title="Enable insights with stable image"
+make k3d/local-stack ENABLE_INSIGHTS=true
+```
+
+By default, the local-stack uses the stable `uselagoon/insights-handler` image.
+To use a custom image, you can pass in the `INSIGHTS_HANDLER_IMAGE_REPO` and `INSIGHTS_HANDLER_IMAGE_TAG` variables:
+
+```bash title="Enable insights with a custom image"
+make k3d/local-stack ENABLE_INSIGHTS=true INSIGHTS_HANDLER_IMAGE_REPO=uselagoon/insights-handler INSIGHTS_HANDLER_IMAGE_TAG=local
+```
+
 #### Stable chart installation and upgrading chart versions
 
 It is possible to run the local-stack as it would be directly from a stable chart version.


### PR DESCRIPTION
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

Requires https://github.com/uselagoon/lagoon-charts/pull/825

This PR adds support for enabling the Lagoon Insights Handler in the local-stack, as well as setting a custom image to use, i.e when developing `uselagoon/insights-handler` locally.