### PR TITLE
feat: show if user has 2fa or is federated user in api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ BUILD_DEPLOY_IMAGE_TAG ?= edge
 # UI_IMAGE_REPO and UI_IMAGE_TAG are an easy way to override the UI image used
 # only works for installations where INSTALL_STABLE_CORE=false
 UI_IMAGE_REPO = uselagoon/ui
-UI_IMAGE_TAG = pr-340
+UI_IMAGE_TAG = main
 
 # The two variables below are an easy way to override the insights-handler image used in the local stack lagoon-core
 # only works for installations where ENABLE_INSIGHTS=true and INSTALL_STABLE_CORE=false

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ BUILD_DEPLOY_IMAGE_TAG ?= edge
 # UI_IMAGE_REPO and UI_IMAGE_TAG are an easy way to override the UI image used
 # only works for installations where INSTALL_STABLE_CORE=false
 UI_IMAGE_REPO = uselagoon/ui
-UI_IMAGE_TAG = main
+UI_IMAGE_TAG = pr-340
 
 # The two variables below are an easy way to override the insights-handler image used in the local stack lagoon-core
 # only works for installations where ENABLE_INSIGHTS=true and INSTALL_STABLE_CORE=false

--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -362,13 +362,32 @@ export const Group = (clients: {
     }
   };
 
+  // load all keycloak groups using pagination
+  const loadAllKeycloakGroups = async (): Promise<KeycloakLagoonGroup[]> => {
+    let groups = [];
+    let first = 0;
+    let pageSize = 200;
+    let fetchedGroups;
+    while (true) {
+      fetchedGroups = await keycloakAdminClient.groups.find({
+        briefRepresentation: false,
+        first: first,
+        max: pageSize
+      });
+      groups = groups.concat(fetchedGroups)
+      first += pageSize;
+      if (fetchedGroups.length < pageSize) {
+        break;
+      }
+    }
+    return groups;
+  };
+
   const loadAllGroups = async (): Promise<KeycloakLagoonGroup[]> => {
     // briefRepresentation pulls all the group information from keycloak
     // including the attributes this means we don't need to iterate over all the
     // groups one by one anymore to get the full group information
-    const keycloakGroups = await keycloakAdminClient.groups.find({
-      briefRepresentation: false,
-    });
+    const keycloakGroups = await loadAllKeycloakGroups();
 
     let fullGroups: KeycloakLagoonGroup[] = [];
     for (const group of keycloakGroups) {

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -85,6 +85,7 @@ export interface UserModel {
   userLastAccessed: (userInput: User) => Promise<Boolean>;
   transformKeycloakUsers: (keycloakUsers: UserRepresentation[]) => Promise<User[]>;
   getFullUserDetails: (userInput: User) => Promise<Object>;
+  fetchUserTwoFactor: (user: User) => Promise<boolean>;
 }
 
 // these match the names of the roles created in keycloak
@@ -243,16 +244,8 @@ export const User = (clients: {
       if (userdate.length) {
         user.lastAccessed = userdate[0].lastAccessed
       }
-      user.has2faEnabled = await fetchUserTwoFactor(user)
       let userFed = await fetchFederatedIdentities(user);
       if (userFed.hasIdentities) {
-        // if a federated user sets up 2fa or passkeys in their account after they have logged in
-        // it will never be used unless the user unlinks themselves from the identity provider
-        // if that happens, then the user will have no federated user and their 2fa status will show correctly
-        // if a user is federated though, then their 2fa status is managed/enforced in the external provider
-        // and lagoon has no way to verify if 2fa is enabled or enforced in that provider so just set that the user
-        // is a federated user
-        user.has2faEnabled = false
         user.isFederatedUser = userFed.hasIdentities
       }
       usersWithGitlabIdFetch.push({
@@ -1033,6 +1026,7 @@ const getAllProjectsIdsForUser = async (
     deleteUser,
     resetUserPassword,
     transformKeycloakUsers,
-    getFullUserDetails
+    getFullUserDetails,
+    fetchUserTwoFactor,
   };
 };

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -37,6 +37,15 @@ export interface User {
   organizationRole?: string;
   platformRoles?: [string];
   emailNotifications?: IEmailNotifications;
+  totp?: boolean;
+  has2faEnabled?: boolean;
+  isFederatedUser?: boolean;
+}
+
+
+interface FederatedIdentity {
+  hasIdentities?: boolean;
+  gitlabId?: string;
 }
 
 interface UserEdit {
@@ -166,18 +175,46 @@ export const User = (clients: {
       )(user.attributes)
     )(users);
 
-  const fetchGitlabId = async (user: User): Promise<string> => {
+
+  const fetchUserTwoFactor = async (user: User): Promise<boolean> => {
+    const credTypes = await keycloakAdminClient.users.getCredentials({
+      id: user.id
+    });
+    let hasTwoFactor = false
+    for(const cred of credTypes) {
+      switch (cred.type.replace(/"/g, "")) {
+        case "webauthn":
+        case "otp":
+          hasTwoFactor = true
+          break;
+        default:
+          break;
+      }
+    }
+    return hasTwoFactor;
+  };
+
+
+  const fetchFederatedIdentities = async (user: User): Promise<FederatedIdentity> => {
+    let userFed: FederatedIdentity = {
+      hasIdentities: false,
+      gitlabId: null,
+    };
     const identities = await keycloakAdminClient.users.listFederatedIdentities({
       id: user.id
     });
+
+    if (identities.length > 0) {
+      userFed.hasIdentities = true;
+    }
 
     const gitlabIdentity = R.find(
       R.propEq('identityProvider', 'gitlab'),
       identities
     );
-
     // @ts-ignore
-    return R.defaultTo(undefined, R.prop('userId', gitlabIdentity));
+    userFed.gitlabId = R.defaultTo(undefined, R.prop('userId', gitlabIdentity))
+    return userFed;
   };
 
   const transformKeycloakUsers = async (
@@ -206,9 +243,21 @@ export const User = (clients: {
       if (userdate.length) {
         user.lastAccessed = userdate[0].lastAccessed
       }
+      user.has2faEnabled = await fetchUserTwoFactor(user)
+      let userFed = await fetchFederatedIdentities(user);
+      if (userFed.hasIdentities) {
+        // if a federated user sets up 2fa or passkeys in their account after they have logged in
+        // it will never be used unless the user unlinks themselves from the identity provider
+        // if that happens, then the user will have no federated user and their 2fa status will show correctly
+        // if a user is federated though, then their 2fa status is managed/enforced in the external provider
+        // and lagoon has no way to verify if 2fa is enabled or enforced in that provider so just set that the user
+        // is a federated user
+        user.has2faEnabled = false
+        user.isFederatedUser = userFed.hasIdentities
+      }
       usersWithGitlabIdFetch.push({
         ...user,
-        gitlabId: await fetchGitlabId(user)
+        gitlabId: userFed.gitlabId
       });
     }
 
@@ -300,6 +349,7 @@ export const User = (clients: {
     // from various people with issues with this
     email = email.toLocaleLowerCase();
     const keycloakUsers = await keycloakAdminClient.users.find({
+      briefRepresentation: false,
       email
     });
 
@@ -330,6 +380,27 @@ export const User = (clients: {
     }
 
     throw new Error('You must provide a user id or email');
+  };
+
+  // load all keycloak users using pagination
+  const loadAllKeycloakUsers = async (): Promise<User[]> => {
+    let users = [];
+    let first = 0;
+    let pageSize = 200;
+    let fetchedUsers;
+    while (true) {
+      fetchedUsers = await keycloakAdminClient.users.find({
+        briefRepresentation: false,
+        first: first,
+        max: pageSize
+      });
+      users = users.concat(fetchedUsers)
+      first += pageSize;
+      if (fetchedUsers.length < pageSize) {
+        break;
+      }
+    }
+    return users;
   };
 
   // used to list onwers of organizations
@@ -365,7 +436,7 @@ export const User = (clients: {
       return false;
     };
 
-    const keycloakUsers = await keycloakAdminClient.users.find({briefRepresentation: false, max: -1});
+    let keycloakUsers = await loadAllKeycloakUsers()
 
     let filteredOwners = filterUsersByAttribute(keycloakUsers, ownerFilter);
     let filteredAdmins = filterUsersByAttribute(keycloakUsers, adminFilter);
@@ -389,13 +460,9 @@ export const User = (clients: {
   };
 
   const loadAllUsers = async (): Promise<User[]> => {
-    const keycloakUsers = await keycloakAdminClient.users.find({
-      max: -1
-    });
-
-    const users = await transformKeycloakUsers(keycloakUsers);
-
-    return users;
+    let users = await loadAllKeycloakUsers()
+    const keycloakUsers = await transformKeycloakUsers(users)
+    return keycloakUsers;
   };
 
   const loadAllPlatformUsers = async (): Promise<User[]> => {
@@ -804,7 +871,7 @@ const getAllProjectsIdsForUser = async (
         }
       }
 
-      // Purge the Group cache for all groups the user belongs to, 
+      // Purge the Group cache for all groups the user belongs to,
       // so it does not have out of date information.
       const GroupModel = Group(clients);
       const userGroups = await getAllGroupsForUser(userInput.id);

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -218,6 +218,7 @@ const {
   getAllPlatformUsers,
   addPlatformRoleToUser,
   removePlatformRoleFromUser,
+  getUser2fa,
 } = require('./resources/user/resolvers');
 
 const {
@@ -609,11 +610,13 @@ async function getResolvers() {
     }
   },
   User: {
+    has2faEnabled: getUser2fa,
     sshKeys: getUserSshKeys,
     groups: getGroupsByUserId,
     groupRoles: getGroupRolesByUserId,
   },
   OrgUser: {
+    has2faEnabled: getUser2fa,
     groupRoles: getGroupRolesByUserIdAndOrganization,
   },
   Backup: {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -436,6 +436,8 @@ const typeDefs = gql`
     created: String
     lastAccessed: String
     emailNotifications: UserEmailNotification
+    has2faEnabled: Boolean
+    isFederatedUser: Boolean
   }
 
   enum PlatformRole {
@@ -1066,6 +1068,8 @@ const typeDefs = gql`
     admin: Boolean @deprecated(reason: "use organizationRole")
     owner: Boolean @deprecated(reason: "use organizationRole")
     comment: String
+    has2faEnabled: Boolean
+    isFederatedUser: Boolean
     groupRoles: [GroupRoleInterface]
     organizationRole: OrganizationRole
   }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Currently the only way to check if a user has 2fa enabled is to log in to keycloak as admin to check users individually. This is not ideal, as it can be time consuming and requires users to log in to keycloak directly, which we want to limit.

Another is detecting if a user is using an identity provider instead of direct user access.

This feature will now show if a user has 1 or more 2fa features enabled by setting a `has2faEnabled` flag on their account in the API. It currently can detect if a user is using totp or webauthn, but the flag is just a `true|false`

The federated user check will also only detect if the user has any federated identities, and if so will flag the user as a federated user. This appears as `isFederatedUser` which is also a `true|false`

The [UI could also be extended](https://github.com/uselagoon/lagoon-ui/pull/340) to display this status so organization owners can see which of their users have 2fa enabled, or which are federated users (SSO).

Example in organization users page: 
<img width="1229" height="222" alt="image" src="https://github.com/user-attachments/assets/f757b834-66ba-4d4e-a743-246c1f4b93a6" />


<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->