### PR TITLE
Change: Deprecate `internal_container_registry`

### DIFF
--- a/docs/concepts-advanced/environment-variables.md
+++ b/docs/concepts-advanced/environment-variables.md
@@ -119,7 +119,7 @@ An example of setting an `environment` env var:
 
 ### Scopes
 
-Scopes are used to set an env var for a specific context. An env var can have a scope of `build`, `runtime`, `global`, `container_registry` or `internal_container_registry`.
+Scopes are used to set an env var for a specific context. An env var can have a scope of `build`, `runtime`, `global` or `container_registry`.
 
 #### Buildtime
 
@@ -226,9 +226,6 @@ An example of setting a `global` scoped env var:
 #### Container Registry
 
 Container registry scoped env vars can be used to authenticate to a private container registry so that Lagoon can pull custom and/or private images at buildtime. Check the full documentation on [container registries](../concepts-basics/lagoon-yml.md#container-registries) for more information.
-
-!!! warning
-    The scope `internal_container_registry` is not for general use, and shouldn't be used unless explicitly required.
 
 An example of setting a `container_registry` scoped env var:
 

--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -142,7 +142,6 @@ export enum EnvVariableScope {
   RUNTIME = 'runtime',
   GLOBAL = 'global',
   CONTAINER_REGISTRY = 'container_registry',
-  INTERNAL_CONTAINER_REGISTRY = 'internal_container_registry'
 }
 
 let transportOptions: {

--- a/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
+++ b/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
@@ -3,9 +3,10 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  return knex('env_vars')
-    .where('scope', 'internal_container_registry')
-    .del()
+  return knex.schema
+      .raw(`DELETE FROM env_vars WHERE scope = 'internal_container_registry'`)
+      .raw(`ALTER TABLE env_vars
+        MODIFY scope ENUM('global', 'build', 'runtime', 'container_registry') NOT NULL DEFAULT 'global';`);
 };
 
 /**
@@ -13,5 +14,7 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  return knex.schema;
+  return knex.schema
+      .raw(`ALTER TABLE env_vars
+        MODIFY scope ENUM('global', 'build', 'runtime', 'container_registry', 'internal_container_registry') NOT NULL DEFAULT 'global';`);
 };

--- a/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
+++ b/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
@@ -13,5 +13,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  return Promise.reject(new Error('Unable to rollback data deletion'));
+  return knex.schema;
 };

--- a/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
+++ b/services/api/database/migrations/20250822070204_delete_internal_container_registry_scoped_env_vars.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex('env_vars')
+    .where('scope', 'internal_container_registry')
+    .del()
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return Promise.reject(new Error('Unable to rollback data deletion'));
+};

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -313,8 +313,7 @@ export const addOrUpdateEnvVariableByName: ResolverFn = async (
   }
 
   if (scope === 'internal_container_registry') {
-    logger.warn('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
-    return;
+    throw new Error('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
   }
 
   const envVarType = getEnvVarType({
@@ -539,8 +538,7 @@ export const addEnvVariable: ResolverFn = async (obj, args, context) => {
   } = args;
 
   if (args.input.scope === 'internal_container_registry') {
-    logger.warn('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
-    return;
+    throw new Error('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
   }
 
   if (type === 'project') {

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -7,6 +7,7 @@ import { Helpers as projectHelpers } from '../project/helpers';
 import { Helpers as orgHelpers } from '../organization/helpers';
 import { AuditType } from '@lagoon/commons/dist/types';
 import { AuditLog, AuditResource } from '../audit/types';
+import {logger} from "../../loggers/logger";
 
 export enum EnvVarType {
   ORGANIZATION = 'organization',
@@ -311,6 +312,11 @@ export const addOrUpdateEnvVariableByName: ResolverFn = async (
     throw new Error('A variable name must be provided.');
   }
 
+  if (scope === 'internal_container_registry') {
+    logger.warn('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
+    return;
+  }
+
   const envVarType = getEnvVarType({
     organization: orgName,
     project: projectName,
@@ -531,6 +537,11 @@ export const addEnvVariable: ResolverFn = async (obj, args, context) => {
   const {
     input: { type }
   } = args;
+
+  if (args.input.scope === 'internal_container_registry') {
+    logger.warn('Variable scope "internal_container_registry" is deprecated & can no longer be set.');
+    return;
+  }
 
   if (type === 'project') {
     return addEnvVariableToProject(obj, args, context);


### PR DESCRIPTION
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Adds a migration to remove `internal_container_registry` scoped variables & no-ops relevant resolver interactions.

closes https://github.com/uselagoon/lagoon/issues/3878