### PR TITLE
feat: allow org management to view certain audit logs

### DIFF
--- a/services/api/database/migrations/20250826000000_org_audit_log.js
+++ b/services/api/database/migrations/20250826000000_org_audit_log.js
@@ -6,6 +6,7 @@ exports.up = async function(knex) {
   return knex.schema
   .alterTable('audit_log', (table) => {
     table.integer('organization_id');
+    table.index('organization_id', 'organization_index');
   })
 };
 

--- a/services/api/database/migrations/20250826000000_org_audit_log.js
+++ b/services/api/database/migrations/20250826000000_org_audit_log.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  return knex.schema
+  .alterTable('audit_log', (table) => {
+    table.integer('organization_id');
+  })
+};
+
+/**
+* @param { import("knex").Knex } knex
+* @returns { Promise<void> }
+*/
+exports.down = async function(knex) {
+  return knex.schema
+  .alterTable('audit_log', (table) => {
+    table.dropColumn('organization_id');
+  })
+};

--- a/services/api/src/loggers/lagoonLogsTransport.ts
+++ b/services/api/src/loggers/lagoonLogsTransport.ts
@@ -61,6 +61,7 @@ export class LagoonLogsTransport extends Transport {
           impersonatorUsername: info.user.access_token.content.impersonator ? info.user.access_token.content.impersonator.username : null,
           source: requestSource,
           auditEvent: `${info.event}`,
+          organizationId: info.payload?.organizationId || null,
         }
         try {
           // save the log

--- a/services/api/src/resources/audit/sql.ts
+++ b/services/api/src/resources/audit/sql.ts
@@ -15,6 +15,7 @@ export interface AuditLog {
     impersonatorId?: string;
     impersonatorUsername?: string;
     created?: string;
+    organizationId?: number;
   }
 
   export const Sql = {

--- a/services/api/src/resources/audit/types.ts
+++ b/services/api/src/resources/audit/types.ts
@@ -1,6 +1,7 @@
 import { AuditType } from "@lagoon/commons/src/types"
 
 export interface AuditLog {
+    organizationId?: number
     resource: AuditResource
     linkedResource?: AuditResource
 }

--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -119,6 +119,9 @@ const getRestoreLocation = async (backupId, restoreLocation, sqlClientPool, user
             details: R.prop(3, s3Parts),
           },
         };
+        if (project.organization) {
+          auditLog.organizationId = project.organization;
+        }
         userActivityLogger(`User requested a download link`, {
           event: 'api:getSignedBackupUrl',
           payload: {
@@ -209,20 +212,25 @@ export const addBackup: ResolverFn = async (
   const rows = await query(sqlClientPool, Sql.selectBackup(insertId));
   const backup = R.prop(0, rows);
 
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
+
   pubSub.publish(EVENTS.BACKUP, backup);
 
   const auditLog: AuditLog = {
     resource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
     linkedResource: {
-      id: backup.id,
+      id: backup.id.toString(),
       type: AuditType.BACKUP,
       details: `${source} - ${backupId}`,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deployed backup '${backupId}' to '${environment.name}' on project '${environment.project}'`, {
     project: '',
     event: 'api:addBackup',
@@ -252,22 +260,26 @@ export const deleteBackup: ResolverFn = async (
   });
 
   const environment = await environmentSql.selectEnvironmentByBackupId(backupId)
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
   const rows = await query(sqlClientPool, Sql.selectBackupByBackupId(backupId));
   const backup = R.prop(0, rows);
   await query(sqlClientPool, Sql.deleteBackup(backupId));
 
   const auditLog: AuditLog = {
     resource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
     linkedResource: {
-      id: backup.id,
+      id: backup.id.toString(),
       type: AuditType.BACKUP,
       details: `${backup.source} - ${backupId}`,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted backup '${backupId}'`, {
     project: '',
     event: 'api:deleteBackup',
@@ -360,16 +372,19 @@ export const addRestore: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: environmentData.id,
+      id: environmentData.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environmentData.name,
     },
     linkedResource: {
-      id: backupData.id,
+      id: backupData.id.toString(),
       type: AuditType.BACKUP,
       details: `${backupData.source} - ${backupId}`,
     },
   };
+  if (projectData.organization) {
+    auditLog.organizationId = projectData.organization;
+  }
   userActivityLogger(`User restored a backup '${backupId}' for project ${projectData.name}`, {
     project: '',
     event: 'api:addRestore',
@@ -448,21 +463,25 @@ export const updateRestore: ResolverFn = async (
   const backupData = R.prop(0, rows);
 
   const environmentData = await environmentSql.selectEnvironmentByBackupId(backupId)
+  const project = await projectHelpers(sqlClientPool).getProjectById(environmentData.project);
 
   pubSub.publish(EVENTS.BACKUP, backupData);
 
   const auditLog: AuditLog = {
     resource: {
-      id: environmentData.id,
+      id: environmentData.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environmentData.name,
     },
     linkedResource: {
-      id: backupData.id,
+      id: backupData.id.toString(),
       type: AuditType.BACKUP,
       details: `${backupData.source} - ${backupId}`,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   if (userActivityLogger != undefined) {
     userActivityLogger(`User updated restore '${backupId}'`, {
     project: '',

--- a/services/api/src/resources/backup/resolvers.ts
+++ b/services/api/src/resources/backup/resolvers.ts
@@ -231,7 +231,7 @@ export const addBackup: ResolverFn = async (
   if (project.organization) {
     auditLog.organizationId = project.organization;
   }
-  userActivityLogger(`User deployed backup '${backupId}' to '${environment.name}' on project '${environment.project}'`, {
+  userActivityLogger(`User added backup '${backupId}' to '${environment.name}' on project '${environment.project}'`, {
     project: '',
     event: 'api:addBackup',
     payload: {

--- a/services/api/src/resources/deploytargetconfig/resolvers.ts
+++ b/services/api/src/resources/deploytargetconfig/resolvers.ts
@@ -152,20 +152,19 @@ export const updateEnvironmentDeployTarget: ResolverFn = async (
     })
   );
 
-  const projectObj = await projectHelpers(
-    sqlClientPool
-  ).getProjectByEnvironmentId(environment);
-
   const auditLog: AuditLog = {
     resource: {
-      id: environmentObj.id,
+      id: environmentObj.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environmentObj.name,
     },
     linkedResource: {
-      id: deployTarget,
+      id: deployTarget.toString(),
       type: AuditType.DEPLOYTARGET,
     },
+  }
+  if (projectData.organization) {
+    auditLog.organizationId = projectData.organization;
   }
   userActivityLogger(`User changed DeployTarget for environment`, {
     project: '',
@@ -228,12 +227,12 @@ export const addDeployTargetConfig: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: projectData.id,
+      id: projectData.id.toString(),
       type: AuditType.PROJECT,
       details: projectData.name,
     },
     linkedResource: {
-      id: insertId,
+      id: insertId.toString(),
       type: AuditType.DEPLOYTARGETCONFIG,
       details: `${JSON.stringify({
         weight,
@@ -242,6 +241,9 @@ export const addDeployTargetConfig: ResolverFn = async (
         deployTarget,
       })}`
     },
+  }
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
   }
   userActivityLogger(`User added DeployTargetConfig`, {
     project: '',
@@ -280,14 +282,17 @@ export const deleteDeployTargetConfig: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: projectData.id,
+      id: projectData.id.toString(),
       type: AuditType.PROJECT,
       details: projectData.name,
     },
     linkedResource: {
-      id: id,
+      id: id.toString(),
       type: AuditType.DEPLOYTARGETCONFIG,
     },
+  }
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
   }
   userActivityLogger(`User deleted DeployTargetConfig'`, {
     project: '',
@@ -371,7 +376,7 @@ export const updateDeployTargetConfig: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: projectData.id,
+      id: projectData.id.toString(),
       type: AuditType.PROJECT,
       details: projectData.name,
     },
@@ -385,6 +390,9 @@ export const updateDeployTargetConfig: ResolverFn = async (
         deployTarget,
       })}`
     },
+  }
+  if (projectData.organization) {
+    auditLog.organizationId = projectData.organization;
   }
   userActivityLogger(`User updated DeployTargetConfig`, {
     event: 'api:updateDeployTargetConfig',

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -728,7 +728,7 @@ export const deleteEnvVariable: ResolverFn = async (
     const environment =
       await environmentHelpers(sqlClientPool).getEnvironmentById(envVar.environment);
     const project =
-      await projectHelpers(sqlClientPool).getProjectById(environment.id);
+      await projectHelpers(sqlClientPool).getProjectById(environment.project);
     resource = {
       id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -1008,7 +1008,7 @@ export const deleteEnvironmentService: ResolverFn = async (
 
   await query(sqlClientPool, Sql.deleteEnvironmentServiceById(service.id));
 
-  const project = await projectHelpers(sqlClientPool).getProjectById(environment.id)
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.project)
 
   const auditLog: AuditLog = {
     resource: {

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -442,16 +442,19 @@ export const addOrUpdateEnvironment: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User updated environment`, {
     project: '',
     event: 'api:addOrUpdateEnvironment',
@@ -516,12 +519,12 @@ export const addOrUpdateEnvironmentStorage: ResolverFn = async (
   const curEnv = await Helpers(sqlClientPool).getEnvironmentById(environment['environment']);
   const auditLog: AuditLog = {
     resource: {
-      id: curEnv.project,
+      id: curEnv.project.toString(),
       type: AuditType.PROJECT,
       details: projectName,
     },
     linkedResource: {
-      id: curEnv.id,
+      id: curEnv.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: curEnv.name,
     },
@@ -654,16 +657,19 @@ export const deleteEnvironment: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: environment.project,
+      id: environment.project.toString(),
       type: AuditType.PROJECT,
       details: projectName,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted environment '${environment.name}' on project '${projectName}'`, {
     project: '',
     event: 'api:deleteEnvironment',
@@ -753,23 +759,23 @@ export const updateEnvironment: ResolverFn = async (
   const rows = await query(sqlClientPool, Sql.selectEnvironmentById(id));
   const withK8s = Helpers(sqlClientPool).aliasOpenshiftToK8s(rows);
 
-  const project = await query(
-    sqlClientPool,
-    projectSql.selectProjectById(curEnv.project)
-  );
+  const project = await projectHelpers(sqlClientPool).getProjectById(curEnv.project);
 
   const auditLog: AuditLog = {
     resource: {
-      id: curEnv.project,
+      id: curEnv.project.toString(),
       type: AuditType.PROJECT,
       details: project.name
     },
     linkedResource: {
-      id: curEnv.id,
+      id: curEnv.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: curEnv.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User updated environment '${curEnv.name}' on project '${curEnv.project}'`, {
     project: '',
     event: 'api:updateEnvironment',
@@ -846,19 +852,16 @@ export const setEnvironmentServices: ResolverFn = async (
     await query(sqlClientPool, Sql.insertService(environmentId, service));
   }
 
-  const project = await query(
-    sqlClientPool,
-    projectSql.selectProjectById(environment.project)
-  );
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.project)
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
@@ -950,19 +953,16 @@ export const addOrUpdateEnvironmentService: ResolverFn = async (
 
   const rows = await query(sqlClientPool, Sql.selectEnvironmentServiceById(insertId));
 
-  const project = await query(
-    sqlClientPool,
-    projectSql.selectProjectById(environment.project)
-  );
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.project)
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
@@ -1008,19 +1008,16 @@ export const deleteEnvironmentService: ResolverFn = async (
 
   await query(sqlClientPool, Sql.deleteEnvironmentServiceById(service.id));
 
-  const project = await query(
-    sqlClientPool,
-    projectSql.selectProjectById(environment.project)
-  );
+  const project = await projectHelpers(sqlClientPool).getProjectById(environment.id)
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },

--- a/services/api/src/resources/fact/resolvers.ts
+++ b/services/api/src/resources/fact/resolvers.ts
@@ -282,20 +282,23 @@ export const addFact: ResolverFn = async (
     Sql.selectFactByDatabaseId(insertId)
   );
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User added a fact to environment '${environment.name}'`, {
     project: '',
     event: 'api:addFact',
@@ -325,20 +328,23 @@ export const addFacts: ResolverFn = async (
   // log an event for each unique environment only
   const uniqueEnvs = [...new Set(returnFacts.map(item => item.environment))];
   for (const env of uniqueEnvs) {
-    const project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(env);
     const environment = await environmentHelpers(sqlClientPool).getEnvironmentById(env);
+    const project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
     const auditLog: AuditLog = {
       resource: {
-        id: project.id,
+        id: project.id.toString(),
         type: AuditType.PROJECT,
         details: project.name,
       },
       linkedResource: {
-        id: environment.id,
+        id: environment.id.toString(),
         type: AuditType.ENVIRONMENT,
         details: environment.name,
       },
     };
+    if (project.organization) {
+      auditLog.organizationId = project.organization;
+    }
     userActivityLogger(`User added facts to environment'`, {
       project: '',
       event: 'api:addFacts',
@@ -391,16 +397,19 @@ export const addFactsByName: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User added facts to '${project}:${environment}'`, {
     project: project,
     environment: environment,
@@ -429,22 +438,25 @@ export const deleteFact: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   await query(sqlClientPool, Sql.deleteFact(environmentId, name));
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted a fact`, {
     project: '',
     event: 'api:deleteFact',
@@ -477,22 +489,25 @@ export const deleteFactsFromSource: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   await query(sqlClientPool, Sql.deleteFactsFromSource(environmentId, source, service));
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted facts`, {
     project: '',
     event: 'api:deleteFactsFromSource',

--- a/services/api/src/resources/group/resolvers.ts
+++ b/services/api/src/resources/group/resolvers.ts
@@ -314,7 +314,7 @@ export const addGroup: ResolverFn = async (
       organization: input.organization
     });
     resource = {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION
     }
 
@@ -410,6 +410,9 @@ export const addGroup: ResolverFn = async (
   } else {
     auditLog.resource = groupResource
   }
+  if (input.organization) {
+    auditLog.organizationId = input.organization;
+  }
 
   userActivityLogger(`User added a group`, {
     project: '',
@@ -441,7 +444,7 @@ export const updateGroup: ResolverFn = async (
       organization: org
     });
     resource = {
-      id: org,
+      id: org.toString(),
       type: AuditType.ORGANIZATION
     }
   } else {
@@ -480,6 +483,9 @@ export const updateGroup: ResolverFn = async (
   } else {
     auditLog.resource = groupResource
   }
+  if (org) {
+    auditLog.organizationId = org;
+  }
 
   userActivityLogger(`User updated a group`, {
     project: '',
@@ -510,7 +516,7 @@ export const deleteGroup: ResolverFn = async (
       organization: org
     });
     resource = {
-      id: org,
+      id: org.toString(),
       type: AuditType.ORGANIZATION
     }
   } else {
@@ -537,6 +543,9 @@ export const deleteGroup: ResolverFn = async (
     auditLog.linkedResource = groupResource
   } else {
     auditLog.resource = groupResource
+  }
+  if (org) {
+    auditLog.organizationId = org;
   }
 
   userActivityLogger(`User deleted a group`, {
@@ -644,6 +653,9 @@ export const addUserToGroup: ResolverFn = async (
       details: `${user.email}, role: ${role}`,
     },
   };
+  if (org) {
+    auditLog.organizationId = org;
+  }
   var emailDetails = await getGroupEmailDetails('api:addUserToGroup', group.name, models, user, {"Role": role});
   userActivityLogger(`User added a user to a group`, {
     project: '',
@@ -707,6 +719,9 @@ export const removeUserFromGroup: ResolverFn = async (
       details: user.email,
     },
   };
+  if (org) {
+    auditLog.organizationId = org;
+  }
 
   var emailDetails = await getGroupEmailDetails('api:removeUserFromGroup', group.name, models, user);
 
@@ -798,7 +813,7 @@ export const addGroupsToProject: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
@@ -807,6 +822,9 @@ export const addGroupsToProject: ResolverFn = async (
       details: `multiple groups`,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User synced groups to a project`, {
     project: '',
     event: 'api:addGroupsToProject',
@@ -975,7 +993,7 @@ export const removeGroupsFromProject: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
@@ -984,6 +1002,9 @@ export const removeGroupsFromProject: ResolverFn = async (
       details: `multiple groups`,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User synced groups to a project`, {
     project: '',
     event: 'api:removeGroupsFromProject',

--- a/services/api/src/resources/insight/resolvers.ts
+++ b/services/api/src/resources/insight/resolvers.ts
@@ -75,6 +75,9 @@ export const getInsightsDownloadUrl: ResolverFn = async (
           type: AuditType.FILE,
         },
       };
+      if (projectData.organization) {
+        auditLog.organizationId = projectData.organization;
+      }
       userActivityLogger(`User requested a download link`, {
         event: 'api:getSignedInsightsUrl',
         payload: {

--- a/services/api/src/resources/notification/resolvers.ts
+++ b/services/api/src/resources/notification/resolvers.ts
@@ -46,10 +46,11 @@ const addNotificationGeneric = async (sqlClientPool, userActivityLogger, notific
   };
   if (input.organization) {
     auditLog.resource = {
-      id: input.organization,
+      id: input.organization.toString(),
       type: AuditType.ORGANIZATION,
     };
     auditLog.linkedResource = notificationResource;
+    auditLog.organizationId = input.organization;
   }
   userActivityLogger(`User added a ${type} notification`, {
     project: '',
@@ -187,15 +188,18 @@ export const addNotificationToProject: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: projectData.id,
+      id: projectData.id.toString(),
       type: AuditType.PROJECT,
       details: projectData.name,
     },
     linkedResource: {
-      id: projectNotification.id,
+      id: projectNotification.nid.toString(),
       type: AuditType.NOTIFICATION,
     },
   };
+  if (projectData.organization) {
+    auditLog.organizationId = projectData.organization;
+  }
   userActivityLogger(`User added a notification to project '${pid}'`, {
     project: '',
     event: 'api:addNotificationToProject',

--- a/services/api/src/resources/openshift/resolvers.ts
+++ b/services/api/src/resources/openshift/resolvers.ts
@@ -16,7 +16,7 @@ export const getToken: ResolverFn = async (
 
     const auditLog: AuditLog = {
       resource: {
-        id: kubernetes.id,
+        id: kubernetes.id.toString(),
         type: AuditType.DEPLOYTARGET,
         details: kubernetes.name,
       },
@@ -80,7 +80,7 @@ export const addOpenshift: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, rows).id,
+      id: R.prop(0, rows).id.toString(),
       type: AuditType.DEPLOYTARGET,
       details: R.prop(0, rows).name,
     },
@@ -120,7 +120,7 @@ export const deleteOpenshift: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, rows).id,
+      id: R.prop(0, rows).id.toString(),
       type: AuditType.DEPLOYTARGET,
       details: R.prop(0, rows).name,
     },
@@ -236,7 +236,7 @@ export const updateOpenshift: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, rows).id,
+      id: R.prop(0, rows).id.toString(),
       type: AuditType.DEPLOYTARGET,
       details: R.prop(0, rows).name,
     },

--- a/services/api/src/resources/organization/helpers.ts
+++ b/services/api/src/resources/organization/helpers.ts
@@ -64,6 +64,21 @@ export const Helpers = (sqlClientPool: Pool) => {
     const rows = await query(sqlClientPool, Sql.selectOrganizationDeployTargets(id));
     return rows;
   };
+  const organizationIdByBackup = async (id: string) => {
+
+  }
+  const organizationIdByTask = async (id: string) => {
+
+  }
+  const organizationIdByDeployment = async (id: string) => {
+
+  }
+  const organizationIdByEnvironment = async (id: number) => {
+
+  }
+  const organizationIdByProject = async (id: number) => {
+
+  }
   return {
     getOrganizationById,
     getProjectsByOrganizationId,
@@ -124,5 +139,10 @@ export const Helpers = (sqlClientPool: Pool) => {
 
       return toNumber(id);
     },
+    organizationIdByBackup,
+    organizationIdByTask,
+    organizationIdByDeployment,
+    organizationIdByEnvironment,
+    organizationIdByProject,
   }
 };

--- a/services/api/src/resources/organization/helpers.ts
+++ b/services/api/src/resources/organization/helpers.ts
@@ -64,21 +64,6 @@ export const Helpers = (sqlClientPool: Pool) => {
     const rows = await query(sqlClientPool, Sql.selectOrganizationDeployTargets(id));
     return rows;
   };
-  const organizationIdByBackup = async (id: string) => {
-
-  }
-  const organizationIdByTask = async (id: string) => {
-
-  }
-  const organizationIdByDeployment = async (id: string) => {
-
-  }
-  const organizationIdByEnvironment = async (id: number) => {
-
-  }
-  const organizationIdByProject = async (id: number) => {
-
-  }
   return {
     getOrganizationById,
     getProjectsByOrganizationId,
@@ -139,10 +124,5 @@ export const Helpers = (sqlClientPool: Pool) => {
 
       return toNumber(id);
     },
-    organizationIdByBackup,
-    organizationIdByTask,
-    organizationIdByDeployment,
-    organizationIdByEnvironment,
-    organizationIdByProject,
   }
 };

--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -43,7 +43,7 @@ export const addOrganization: ResolverFn = async (
 
       const auditLog: AuditLog = {
         resource: {
-          id: insertId,
+          id: insertId.toString(),
           type: AuditType.ORGANIZATION,
           details: R.prop(0, rows).name,
         },
@@ -102,12 +102,12 @@ export const addDeployTargetToOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, org).id,
+      id: R.prop(0, org).id.toString(),
       type: AuditType.ORGANIZATION,
       details: R.prop(0, org).name,
     },
     linkedResource: {
-      id: input.deployTarget,
+      id: input.deployTarget.toString(),
       type: AuditType.DEPLOYTARGET,
     },
   };
@@ -148,12 +148,12 @@ export const removeDeployTargetFromOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, org).id,
+      id: R.prop(0, org).id.toString(),
       type: AuditType.ORGANIZATION,
       details: R.prop(0, org).name,
     },
     linkedResource: {
-      id: input.deployTarget,
+      id: input.deployTarget.toString(),
       type: AuditType.DEPLOYTARGET,
     },
   };
@@ -246,10 +246,11 @@ export const updateOrganization: ResolverFn = async (
 
     const auditLog: AuditLog = {
       resource: {
-        id: R.prop(0, rows).id,
+        id: R.prop(0, rows).id.toString(),
         type: AuditType.ORGANIZATION,
         details: R.prop(0, rows).name,
       },
+      organizationId: rows[0].id.toString(),
     };
     userActivityLogger(`User updated organization ${R.prop(0, rows).name}`, {
       project: '',
@@ -754,12 +755,12 @@ export const removeProjectFromOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: R.prop(0, org).id,
+      id: R.prop(0, org).id.toString(),
       type: AuditType.ORGANIZATION,
       details: R.prop(0, org).name,
     },
     linkedResource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
@@ -860,7 +861,7 @@ export const addExistingProjectToOrganization: ResolverFn = async (
 
     const auditLog: AuditLog = {
       resource: {
-        id: orgResult.id,
+        id: orgResult.id.toString(),
         type: AuditType.ORGANIZATION,
         details: orgResult.name,
       },
@@ -900,12 +901,12 @@ export const addExistingProjectToOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: orgResult.id,
+      id: orgResult.id.toString(),
       type: AuditType.ORGANIZATION,
       details: orgResult.name,
     },
     linkedResource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
@@ -1026,7 +1027,7 @@ export const addExistingGroupToOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name,
     },
@@ -1097,7 +1098,7 @@ export const removeUserFromOrganizationGroups: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name,
     },
@@ -1185,7 +1186,7 @@ export const deleteOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: orgResult.id,
+      id: orgResult.id.toString(),
       type: AuditType.ORGANIZATION,
       details: orgResult.name,
     },
@@ -1380,7 +1381,7 @@ export const bulkImportProjectsAndGroupsToOrganization: ResolverFn = async (
 
         const auditLog: AuditLog = {
           resource: {
-            id: orgResult.id,
+            id: orgResult.id.toString(),
             type: AuditType.ORGANIZATION,
             details: orgResult.name,
           },
@@ -1414,7 +1415,7 @@ export const bulkImportProjectsAndGroupsToOrganization: ResolverFn = async (
             await notificationHelpers(sqlClientPool).removeAllNotificationsFromProject({project: project.id})
             const auditLog: AuditLog = {
               resource: {
-                id: orgResult.id,
+                id: orgResult.id.toString(),
                 type: AuditType.ORGANIZATION,
                 details: orgResult.name,
               },
@@ -1459,12 +1460,12 @@ export const bulkImportProjectsAndGroupsToOrganization: ResolverFn = async (
         // log this activity
         const auditLog: AuditLog = {
           resource: {
-            id: orgResult.id,
+            id: orgResult.id.toString(),
             type: AuditType.ORGANIZATION,
             details: orgResult.name,
           },
           linkedResource: {
-            id: project.id,
+            id: project.id.toString(),
             type: AuditType.PROJECT,
             details: project.name,
           },

--- a/services/api/src/resources/problem/resolvers.ts
+++ b/services/api/src/resources/problem/resolvers.ts
@@ -200,20 +200,23 @@ export const addProblem: ResolverFn = async (
     Sql.selectProblemByDatabaseId(insertId)
   );
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User added a problem to environment '${environment.name}' for '${environment.project}'`, {
     project: '',
     event: 'api:addProblem',
@@ -256,22 +259,25 @@ export const deleteProblem: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
 
   await query(sqlClientPool, Sql.deleteProblem(environmentId, identifier, service));
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted a problem on environment '${environment.name}' for '${environment.project}'`, {
     project: '',
     event: 'api:deleteProblem',
@@ -297,7 +303,7 @@ export const deleteProblemsFromSource: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
 
   await query(
     sqlClientPool,
@@ -306,16 +312,19 @@ export const deleteProblemsFromSource: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
     linkedResource: {
-      id: environment.id,
+      id: environment.id.toString(),
       type: AuditType.ENVIRONMENT,
       details: environment.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted problems on environment '${environment.id}' for source '${source}'`, {
     project: '',
     event: 'api:deleteProblemsFromSource',

--- a/services/api/src/resources/problem/resolvers.ts
+++ b/services/api/src/resources/problem/resolvers.ts
@@ -200,7 +200,7 @@ export const addProblem: ResolverFn = async (
     Sql.selectProblemByDatabaseId(insertId)
   );
 
-  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   const auditLog: AuditLog = {
     resource: {
@@ -259,7 +259,7 @@ export const deleteProblem: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   await query(sqlClientPool, Sql.deleteProblem(environmentId, identifier, service));
 
@@ -303,7 +303,7 @@ export const deleteProblemsFromSource: ResolverFn = async (
     project: environment.project
   });
 
-  let project = await projectHelpers(sqlClientPool).getProjectById(environment.id);
+  let project = await projectHelpers(sqlClientPool).getProjectById(environment.project);
 
   await query(
     sqlClientPool,

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -489,11 +489,14 @@ export const addProject = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User added a project '${project.name}'`, {
     project: '',
     event: 'api:addProject',
@@ -605,11 +608,14 @@ export const deleteProject: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User deleted a project '${project.name}'`, {
     project: '',
     event: 'api:deleteProject',
@@ -919,11 +925,14 @@ export const updateProject: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: oldProject.id,
+      id: oldProject.id.toString(),
       type: AuditType.PROJECT,
       details: oldProject.name,
     },
   };
+  if (oldProject.organization) {
+    auditLog.organizationId = oldProject.organization;
+  }
   userActivityLogger(`User updated project '${oldProject.name}'`, {
     project: '',
     event: 'api:updateProject',
@@ -996,11 +1005,14 @@ export const removeProjectMetadataByKey: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User removed project metadata key '${key}'`, {
     project: '',
     event: 'api:removeProjectMetadataByKey',
@@ -1063,11 +1075,14 @@ export const updateProjectMetadata: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: project.id,
+      id: project.id.toString(),
       type: AuditType.PROJECT,
       details: project.name,
     },
   };
+  if (project.organization) {
+    auditLog.organizationId = project.organization;
+  }
   userActivityLogger(`User updated project metadata`, {
     project: '',
     event: 'api:updateProjectMetadata',

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -342,7 +342,7 @@ export const addUserToOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name,
     },
@@ -351,6 +351,7 @@ export const addUserToOrganization: ResolverFn = async (
       type: AuditType.USER,
       details: `${user.email} role ${(admin ? `admin: ${admin}` : owner ? `owner: ${owner}` : `viewer`)}`,
     },
+    organizationId: organizationData.id,
   };
 
   var emailDetails = await getUserOrgEmailDetails('api:addUserToOrganization', models, user, {
@@ -409,7 +410,7 @@ export const removeUserFromOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name
     },
@@ -418,6 +419,7 @@ export const removeUserFromOrganization: ResolverFn = async (
       type: AuditType.USER,
       details: user.email
     },
+    organizationId: organizationData.id,
   };
 
     var emailDetails = await getUserOrgEmailDetails('api:removeUserFromOrganization', models, user, {
@@ -497,7 +499,7 @@ export const addAdminToOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name,
     },
@@ -506,6 +508,7 @@ export const addAdminToOrganization: ResolverFn = async (
       type: AuditType.USER,
       details: `${user.email} role ${role}`,
     },
+    organizationId: organizationData.id,
   };
 
 
@@ -569,7 +572,7 @@ export const removeAdminFromOrganization: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: organizationData.id,
+      id: organizationData.id.toString(),
       type: AuditType.ORGANIZATION,
       details: organizationData.name
     },
@@ -578,6 +581,7 @@ export const removeAdminFromOrganization: ResolverFn = async (
       type: AuditType.USER,
       details: user.email
     },
+    organizationId: organizationData.id,
   };
 
   var emailDetails = await getUserOrgEmailDetails('api:removeAdminFromOrganization', models, user, {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1203,6 +1203,7 @@ const typeDefs = gql`
     ipAddress: String
     source: AuditSource
     created: String
+    organizationId: Int
   }
 
   enum AuditSource {
@@ -1249,6 +1250,7 @@ const typeDefs = gql`
     Limit number of events returned. Defaults to 100 unless start and end date are defined
     """
     limit: Int
+    organizationId: Int
   }
 
   input AddDeployTargetConfigInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Extends audit logs to add an organization id, if known, to allow certain audit events to be show to organization administrators. This could eventually be show in the organizations UI for org management to query.

Also fixed a bunch of fields to use the correct information, as some helper calls didn't supply all of the required fields or were using the wrong fields in the audit log resulting in a failure to log the event properly.

The existing `getAuditLogs` query can be used with providing the input `organizationId: 1` with the organiztion id. If the user has permission to `view` on that organization, they will be able to see the logs.

This would be usable in the UI eventually, and any org viewer/admin/owner will be able to query these.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
