### PR TITLE
chore: seed user ssh-keys for local-stack usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local-dev/jwt
 local-dev/stern
 local-dev/go
 local-dev/certificates
+local-dev/user-keys
 **/v8-*
 node_modules/
 build/*

--- a/Makefile
+++ b/Makefile
@@ -701,7 +701,7 @@ helm/repos: local-dev/helm
 
 # stand up a k3d cluster configured appropriately for lagoon testing
 .PHONY: k3d/cluster
-k3d/cluster: local-dev/k3d local-dev/jq local-dev/helm local-dev/kubectl local-dev/stern
+k3d/cluster: local-dev-tools
 	$(K3D) cluster list | grep -q "$(CI_BUILD_TAG)" && exit; \
 		docker network create $(DOCKER_NETWORK) || true \
 		&& export KUBECONFIG=$$(mktemp) \
@@ -1186,7 +1186,7 @@ docs/serve:
 		-c 'mkdocs serve -s --dev-addr=0.0.0.0:$(MKDOCS_SERVE_PORT) -f mkdocs.yml'
 
 # k3d/generate-user-keys will generate seed user ssh keys that can be used for local testing
-SEED_USERS = guest reporter developer maintainer owner orgviewer orgadmin orgowner platformorgowner platformviewer platformowner
+SEED_USERS = guest reporter developer maintainer owner orguser orgviewer orgadmin orgowner platformorgowner platformviewer platformowner
 .PHONY: k3d/generate-user-keys
 k3d/generate-user-keys:
 	@mkdir -p ./local-dev/user-keys

--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -350,6 +350,10 @@ It is also possible to get the command snippet to add the configuration for the 
 make k3d/get-lagoon-cli-details
 ```
 
+If the local-stack was installed with seed-data (default if `make k3d/local-stack` is used), then SSH keys for seed users will be generated in `local-dev/user-keys`. Otherwise you'll need to add ` SEED_DATA_INSTALLED=false` when running this command
+
+When retrieving the cli details output, you can change the `--ssh-key` flag to the key of a different user if you're wanting to test CLI access as a different user. You may need to `lagoon -l local-k3d login` after changing the key to refresh token.
+
 #### Rebuild Lagoon core and push images
 
 This will checkout `CHARTS_REPOSITORY` and `CHARTS_TREEISH` again, then build and re-push the images listed in `KIND_SERVICES` with the correct tag, and redeploy the lagoon charts. This is useful for testing small changes to Lagoon services, but does not support "live" development. You will need to rebuild these images locally first, e.g `rm build/api && make build/api`.

--- a/local-dev/k3d-seed-data/seed-user-keys.sh
+++ b/local-dev/k3d-seed-data/seed-user-keys.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+send_graphql_query() {
+  data=$(echo "mutation addKeyToUser {
+    addUserSSHPublicKey(input: {
+      name: \"${1}\"
+      publicKey: \"${2}\"
+      user: {
+        email: \"${1}@example.com\"
+      }
+    }) {
+      id
+      name
+    }
+  }" | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $$0} else {printf "\\n"$$0}}')
+  json="{\"query\": \"$data\"}"
+  curl -ksS -XPOST -H 'Content-Type: application/json' -H "Authorization: bearer ${LAGOON_LEGACY_ADMIN}" "${LAGOON_API_HOST}" -d "$json"
+}
+
+LAGOON_SEED_USERS=("guest" "reporter" "developer" "maintainer" "owner" "orguser" "orgviewer" "orgadmin" "orgowner" "platformorgowner" "platformviewer" "platformowner")
+
+for i in ${LAGOON_SEED_USERS[@]}
+do
+  echo "Configuring ssh-key for $i@example.com"
+  key=$(cat local-dev/user-keys/$i.pub | awk '{print $1" "$2}')
+  send_graphql_query $i "$key"
+done

--- a/local-dev/k3d-seed-data/seed-user-keys.sh
+++ b/local-dev/k3d-seed-data/seed-user-keys.sh
@@ -12,7 +12,7 @@ send_graphql_query() {
       id
       name
     }
-  }" | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $$0} else {printf "\\n"$$0}}')
+  }" | sed 's/"/\\"/g' | sed 's/\\n/\\\\n/g' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
   json="{\"query\": \"$data\"}"
   curl -ksS -XPOST -H 'Content-Type: application/json' -H "Authorization: bearer ${LAGOON_LEGACY_ADMIN}" "${LAGOON_API_HOST}" -d "$json"
 }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

This adds support to the local-stack to generate ssh keys for each seed user to make it easier to use the lagoon-cli locally when interacting with the local-stack without having to add keys to specific users.
