### PR TITLE
fix: environment services containers update

### DIFF
--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -941,7 +941,12 @@ export const addOrUpdateEnvironmentService: ResolverFn = async (
     createOrUpdateSql);
 
   // reset this services containers (delete all and add the current ones)
-  await Helpers(sqlClientPool).resetServiceContainers(insertId, input.containers)
+  let containers = [];
+  if (input.containers){
+    containers = input.containers;
+  }
+  await Helpers(sqlClientPool).resetServiceContainers(insertId, containers)
+
 
   const rows = await query(sqlClientPool, Sql.selectEnvironmentServiceById(insertId));
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Fixes a small issue where if when submitting a service to the API with no containers, the API responds with an error saying `containers is not iterable`. This changes it so that containers has a default empty array if undefined.