### PR TITLE
fix: increase env limit for default org in local-stack

### DIFF
--- a/local-dev/k3d-seed-data/00-populate-kubernetes.gql
+++ b/local-dev/k3d-seed-data/00-populate-kubernetes.gql
@@ -206,7 +206,7 @@ mutation PopulateApi {
     friendlyName: "Lagoon Demo Organization"
     description: "An organization for testing"
     quotaProject: 5
-    quotaEnvironment: 4
+    quotaEnvironment: 10
     quotaGroup: 10
     quotaNotification: 10
   }) {


### PR DESCRIPTION
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

The local-stack is currently preconfigured with a default organisation with an environment limit of 4, but unfortunately it comes preexhausted, as `lagoon-demo-org` already has 4 environments. 

This causes friction when a user is using the local-stack to test a project, since they then need to increase this limit or delete environments. Having had to do this myself many times, I find it very annoying and believe the limit should just be increased out of the box.
