### PR TITLE
Configure AppSec in CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: docker
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    docker:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: gomod
+  commit-message:
+    prefix: chore
+    include: scope
+  directories:
+  - /services/actions-handler
+  - /services/api-sidecar-handler
+  - /services/backup-handler
+  - /services/logs2notifications
+  - /taskimages/activestandby
+  schedule:
+    interval: monthly
+  groups:
+    gomod:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: npm
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    gomod:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"

--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -1,0 +1,24 @@
+# https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md
+allow-licenses:
+# default allowed
+- 'Apache-2.0'
+# explicit CNCF allowlist
+- '0BSD'
+- 'BSD-2-Clause'
+- 'BSD-2-Clause-FreeBSD'
+- 'BSD-3-Clause'
+- 'ISC'
+- 'MIT'
+- 'MIT-0'
+- 'OpenSSL'
+- 'OpenSSL-standalone'
+- 'PSF-2.0'
+- 'PostgreSQL'
+- 'Python-2.0'
+- 'Python-2.0.1'
+- 'SSLeay-standalone'
+- 'UPL-1.0'
+- 'X11'
+- 'Zlib'
+# Google's patent licence for Go
+- 'LicenseRef-scancode-google-patent-license-golang'

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,19 @@
+name: dependency review
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    types:
+    - checks_requested
+permissions: {}
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+      with:
+        config-file: .github/dependency-review-config.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,45 @@
+name: lint
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    types:
+    - checks_requested
+permissions: {}
+jobs:
+  find-go-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.find-modules.outputs.dirs }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - id: find-modules
+      run: |
+        echo "dirs=$(find . -mindepth 2 -name go.mod -printf '%h\n' | jq -cRn '[inputs]')" >> "$GITHUB_OUTPUT"
+  lint-go:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: find-go-modules
+    strategy:
+      matrix:
+        dir: ${{ fromJson(needs.find-go-modules.outputs.dirs) }}
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      with:
+        go-version: stable
+    - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      with:
+        working-directory: ${{ matrix.dir }}
+  lint-actions:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: docker://rhysd/actionlint:1.7.0@sha256:601d6faeefa07683a4a79f756f430a1850b34d575d734b1d1324692202bf312e # v1.7.0
+      with:
+        args: -color

--- a/.github/workflows/ossf-analysis.yaml
+++ b/.github/workflows/ossf-analysis.yaml
@@ -1,0 +1,31 @@
+name: OSSF scorecard
+on:
+  push:
+    branches:
+    - main
+permissions: {}
+jobs:
+  ossf-scorecard-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed if using Code scanning alerts
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Run analysis
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        # Publish the results for public repositories to enable scorecard badges. For more details, see
+        # https://github.com/ossf/scorecard-action#publishing-results.
+        # For private repositories, `publish_results` will automatically be set to `false`, regardless
+        # of the value entered here.
+        publish_results: true
+    - name: Upload SARIF results to code scanning
+      uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v3.29.5
+      with:
+        sarif_file: results.sarif

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,9 @@
+version: "2"
+run:
+  timeout: 180s
+linters:
+  enable:
+  - gocritic
+  exclusions:
+    presets:
+    - std-error-handling

--- a/Makefile
+++ b/Makefile
@@ -342,14 +342,14 @@ webhooks-test-services-up: main-test-services-up $(foreach image,$(webhooks-test
 
 .PHONY: publish-testlagoon-images
 publish-testlagoon-images:
-	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/testlagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
+	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/testlagoon TAG=$(BRANCH_NAME) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push --sbom=true
 
 # tag and push all images
 
 .PHONY: publish-uselagoon-images
 publish-uselagoon-images:
-	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/uselagoon TAG=$(LAGOON_VERSION) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
-	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/uselagoon TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push
+	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/uselagoon TAG=$(LAGOON_VERSION) LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push --sbom=true
+	PLATFORMS=$(PUBLISH_PLATFORM_ARCH) DATABASE_VENDOR=$(DATABASE_VENDOR) DATABASE_DOCKERFILE=$(DATABASE_DOCKERFILE) IMAGE_REPO=docker.io/uselagoon TAG=latest LAGOON_VERSION=$(LAGOON_VERSION) docker buildx bake -f docker-bake.hcl --builder $(CI_BUILD_TAG) --push --sbom=true
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1209,3 +1209,7 @@ k3d/generate-user-keys:
 			ssh-keygen -q -t ed25519 -N '' -f ./local-dev/user-keys/$$user; \
 		fi; \
 	done
+
+.PHONY: lint
+lint:
+	find . -mindepth 2 -name "go.mod" -execdir golangci-lint run \;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 # Lagoon - the developer-focused application delivery platform for Kubernetes
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11874/badge)](https://www.bestpractices.dev/projects/11874)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uselagoon/lagoon/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uselagoon/lagoon)
+
 ## Table of Contents
 1. Project Description
 2. Usage


### PR DESCRIPTION
Partially addresses #3771 by enabling various GitHub features and workflows — see that issue for details.

To inspect SBOMs attached to images you can use:

```bash
$ docker buildx imagetools inspect testlagoon/api:pr-4054 --format "{{ json .SBOM }}" | head
{
  "linux/amd64": {
    "SPDX": {
      "SPDXID": "SPDXRef-DOCUMENT",
      "creationInfo": {
        "created": "2026-02-03T07:23:50Z",
        "creators": [
          "Organization: Anchore, Inc",
          "Tool: syft-v1.40.0",
          "Tool: buildkit-v0.27.1"
```

SBOM scanning during image build also doesn't seem to add much to image build time. Here's this PR jenkins build time (top) vs the most recent successful run on `main` (bottom):
<img width="820" height="64" alt="screenshot_2026-02-03-163610" src="https://github.com/user-attachments/assets/0e92a017-9f59-4c8b-aab3-b3a008c77de3" />
<img width="810" height="58" alt="screenshot_2026-02-03-163624" src="https://github.com/user-attachments/assets/cec184d9-acb5-4fb4-834e-7aa1336d3012" />

The rest of #3771 can be addressed once this is merged.
