### PR TITLE
Adds scan.txt and build.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ lagoon-charts.*
 calico.yaml
 .devcontainer
 docker-compose.override.yml
+scan.txt
+build.txt


### PR DESCRIPTION
Followup to #4053 - when making locally,  `scan.txt` and `build.txt` files are created.
This teensy PR prevents someone from adding by accident (as yours truly did, half a decade ago) by explicitly adding them to the `.gitignore` file

